### PR TITLE
[WIP] Cache FilesystemView early and reuse to reduce listStatus calls on namenode

### DIFF
--- a/hoodie-client/src/main/java/com/uber/hoodie/HoodieWriteClient.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/HoodieWriteClient.java
@@ -53,6 +53,7 @@ import com.uber.hoodie.exception.HoodieRollbackException;
 import com.uber.hoodie.exception.HoodieSavepointException;
 import com.uber.hoodie.exception.HoodieUpsertException;
 import com.uber.hoodie.func.BulkInsertMapFunction;
+import com.uber.hoodie.func.ViewCacheUtils;
 import com.uber.hoodie.index.HoodieIndex;
 import com.uber.hoodie.io.HoodieCommitArchiveLog;
 import com.uber.hoodie.metrics.HoodieMetrics;
@@ -421,6 +422,12 @@ public class HoodieWriteClient<T extends HoodieRecordPayload> implements Seriali
       preppedRecords.persist(StorageLevel.MEMORY_AND_DISK_SER());
     } else {
       logger.info("RDD PreppedRecords was persisted at: " + preppedRecords.getStorageLevel());
+    }
+
+    if (config.isWriterFSViewCacheEnabled()) {
+      // Cache Latest File-System View & Seal
+      ViewCacheUtils.cachePartitionsViewAndSeal(hoodieTable,
+          preppedRecords.map(rec -> rec.getPartitionPath()).distinct().collect().stream());
     }
 
     WorkloadProfile profile = null;

--- a/hoodie-client/src/main/java/com/uber/hoodie/config/HoodieWriteConfig.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/config/HoodieWriteConfig.java
@@ -62,6 +62,9 @@ public class HoodieWriteConfig extends DefaultHoodieConfig {
   private static final String DEFAULT_HOODIE_WRITE_STATUS_CLASS = WriteStatus.class.getName();
   private static final String HOODIE_COPYONWRITE_USE_TEMP_FOLDER_CREATE =
       "hoodie.copyonwrite.use" + ".temp.folder.for.create";
+  private static final String HOODIE_CACHE_WRITER_FS_VIEW = "hoodie.writer.fsview.cache.enabled";
+  //TODO: Will be set to default true after testing
+  private static final String DEFAULT_HOODIE_CACHE_WRITER_FS_VIEW = "false";
   private static final String DEFAULT_HOODIE_COPYONWRITE_USE_TEMP_FOLDER_CREATE = "false";
   private static final String HOODIE_COPYONWRITE_USE_TEMP_FOLDER_MERGE =
       "hoodie.copyonwrite.use" + ".temp.folder.for.merge";
@@ -154,6 +157,10 @@ public class HoodieWriteConfig extends DefaultHoodieConfig {
 
   public boolean isConsistencyCheckEnabled() {
     return Boolean.parseBoolean(props.getProperty(CONSISTENCY_CHECK_ENABLED));
+  }
+
+  public boolean isWriterFSViewCacheEnabled() {
+    return Boolean.parseBoolean(props.getProperty(HOODIE_CACHE_WRITER_FS_VIEW));
   }
 
   /**
@@ -562,6 +569,11 @@ public class HoodieWriteConfig extends DefaultHoodieConfig {
       return this;
     }
 
+    public Builder withWriterFSViewCacheEnabled(boolean enabled) {
+      props.setProperty(HOODIE_CACHE_WRITER_FS_VIEW, String.valueOf(enabled));
+      return this;
+    }
+
     public HoodieWriteConfig build() {
       HoodieWriteConfig config = new HoodieWriteConfig(props);
       // Check for mandatory properties
@@ -594,6 +606,8 @@ public class HoodieWriteConfig extends DefaultHoodieConfig {
           FINALIZE_WRITE_PARALLELISM, DEFAULT_FINALIZE_WRITE_PARALLELISM);
       setDefaultOnCondition(props, !props.containsKey(CONSISTENCY_CHECK_ENABLED),
           CONSISTENCY_CHECK_ENABLED, DEFAULT_CONSISTENCY_CHECK_ENABLED);
+      setDefaultOnCondition(props, !props.containsKey(HOODIE_CACHE_WRITER_FS_VIEW),
+          HOODIE_CACHE_WRITER_FS_VIEW, DEFAULT_HOODIE_CACHE_WRITER_FS_VIEW);
 
       // Make sure the props is propagated
       setDefaultOnCondition(props, !isIndexConfigSet,

--- a/hoodie-client/src/main/java/com/uber/hoodie/func/ViewCacheUtils.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/func/ViewCacheUtils.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2017 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.uber.hoodie.func;
+
+import com.uber.hoodie.table.HoodieTable;
+import java.util.stream.Stream;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+
+public class ViewCacheUtils {
+
+  private static Logger logger = LogManager.getLogger(ViewCacheUtils.class);
+
+  /**
+   * Cache Latest file-system view for the partitions passed
+   * @param hoodieTable Table where view needs to be cached
+   * @param partitions Stream of partitions
+   */
+  public static void cachePartitionsView(HoodieTable hoodieTable, Stream<String> partitions) {
+    partitions.forEach(partitionPath -> {
+      // Populate latest version file-slice cache. No-op if already populated
+      long numFileSlices = hoodieTable.getLatestFileSliceOnlyFSView().getLatestFileSlices(partitionPath).count();
+      logger.info("Pre-populated view for partition=(" + partitionPath + "). numFileSlices=" + numFileSlices);
+    });
+  }
+
+  public static void cachePartitionsViewAndSeal(HoodieTable hoodieTable, Stream<String> partitions) {
+    cachePartitionsView(hoodieTable, partitions);
+    hoodieTable.getLatestFileSliceOnlyFSView().seal();
+  }
+}

--- a/hoodie-client/src/main/java/com/uber/hoodie/io/HoodieAppendHandle.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/io/HoodieAppendHandle.java
@@ -25,7 +25,7 @@ import com.uber.hoodie.common.model.HoodieRecord;
 import com.uber.hoodie.common.model.HoodieRecordLocation;
 import com.uber.hoodie.common.model.HoodieRecordPayload;
 import com.uber.hoodie.common.model.HoodieWriteStat.RuntimeStats;
-import com.uber.hoodie.common.table.TableFileSystemView;
+import com.uber.hoodie.common.table.TableFileSystemView.RealtimeViewWithLatestSlice;
 import com.uber.hoodie.common.table.log.HoodieLogFormat;
 import com.uber.hoodie.common.table.log.HoodieLogFormat.Writer;
 import com.uber.hoodie.common.table.log.block.HoodieAvroDataBlock;
@@ -68,7 +68,7 @@ public class HoodieAppendHandle<T extends HoodieRecordPayload> extends HoodieIOH
   List<IndexedRecord> recordList = new ArrayList<>();
   // Buffer for holding records (to be deleted) in memory before they are flushed to disk
   List<String> keysToDelete = new ArrayList<>();
-  private TableFileSystemView.RealtimeView fileSystemView;
+  private RealtimeViewWithLatestSlice fileSystemView;
   private String partitionPath;
   private Iterator<HoodieRecord<T>> recordItr;
   // Total number of records written during an append
@@ -101,7 +101,7 @@ public class HoodieAppendHandle<T extends HoodieRecordPayload> extends HoodieIOH
     writeStatus.setStat(new HoodieDeltaWriteStat());
     this.writeStatus = writeStatus;
     this.fileId = fileId;
-    this.fileSystemView = hoodieTable.getRTFileSystemView();
+    this.fileSystemView = hoodieTable.getLatestFileSliceOnlyFSView();
     this.recordItr = recordItr;
   }
 

--- a/hoodie-client/src/main/java/com/uber/hoodie/io/HoodieCleanHelper.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/io/HoodieCleanHelper.java
@@ -102,7 +102,7 @@ public class HoodieCleanHelper<T extends HoodieRecordPayload<T>> {
         if (!isFileSliceNeededForPendingCompaction(nextSlice)) {
           if (nextSlice.getDataFile().isPresent()) {
             HoodieDataFile dataFile = nextSlice.getDataFile().get();
-            deletePaths.add(dataFile.getFileStatus().getPath().toString());
+            deletePaths.add(dataFile.getPath());
           }
           if (hoodieTable.getMetaClient().getTableType() == HoodieTableType.MERGE_ON_READ) {
             // If merge on read, then clean the log files for the commits as well
@@ -181,7 +181,7 @@ public class HoodieCleanHelper<T extends HoodieRecordPayload<T>> {
                   HoodieTimeline.GREATER)) {
             // this is a commit, that should be cleaned.
             if (aFile.isPresent()) {
-              deletePaths.add(aFile.get().getFileStatus().getPath().toString());
+              deletePaths.add(aFile.get().getPath());
             }
             if (hoodieTable.getMetaClient().getTableType() == HoodieTableType.MERGE_ON_READ) {
               // If merge on read, then clean the log files for the commits as well

--- a/hoodie-client/src/main/java/com/uber/hoodie/io/HoodieMergeHandle.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/io/HoodieMergeHandle.java
@@ -24,7 +24,7 @@ import com.uber.hoodie.common.model.HoodieRecordLocation;
 import com.uber.hoodie.common.model.HoodieRecordPayload;
 import com.uber.hoodie.common.model.HoodieWriteStat;
 import com.uber.hoodie.common.model.HoodieWriteStat.RuntimeStats;
-import com.uber.hoodie.common.table.TableFileSystemView;
+import com.uber.hoodie.common.table.TableFileSystemView.ReadOptimizedViewWithLatestSlice;
 import com.uber.hoodie.common.util.DefaultSizeEstimator;
 import com.uber.hoodie.common.util.FSUtils;
 import com.uber.hoodie.common.util.HoodieRecordSizeEstimator;
@@ -60,7 +60,7 @@ public class HoodieMergeHandle<T extends HoodieRecordPayload> extends HoodieIOHa
   private Map<String, HoodieRecord<T>> keyToNewRecords;
   private Set<String> writtenRecordKeys;
   private HoodieStorageWriter<IndexedRecord> storageWriter;
-  private TableFileSystemView.ReadOptimizedView fileSystemView;
+  private ReadOptimizedViewWithLatestSlice fileSystemView;
   private Path newFilePath;
   private Path oldFilePath;
   private Path tempPath = null;
@@ -72,7 +72,7 @@ public class HoodieMergeHandle<T extends HoodieRecordPayload> extends HoodieIOHa
   public HoodieMergeHandle(HoodieWriteConfig config, String commitTime, HoodieTable<T> hoodieTable,
       Iterator<HoodieRecord<T>> recordItr, String fileId) {
     super(config, commitTime, hoodieTable);
-    this.fileSystemView = hoodieTable.getROFileSystemView();
+    this.fileSystemView = hoodieTable.getLatestFileSliceOnlyFSView();
     String partitionPath = init(fileId, recordItr);
     init(fileId, partitionPath,
         fileSystemView.getLatestDataFiles(partitionPath)
@@ -82,7 +82,7 @@ public class HoodieMergeHandle<T extends HoodieRecordPayload> extends HoodieIOHa
   public HoodieMergeHandle(HoodieWriteConfig config, String commitTime, HoodieTable<T> hoodieTable,
       Map<String, HoodieRecord<T>> keyToNewRecords, String fileId, Optional<HoodieDataFile> dataFileToBeMerged) {
     super(config, commitTime, hoodieTable);
-    this.fileSystemView = hoodieTable.getROFileSystemView();
+    this.fileSystemView = hoodieTable.getLatestFileSliceOnlyFSView();
     this.keyToNewRecords = keyToNewRecords;
     init(fileId, keyToNewRecords.get(keyToNewRecords.keySet().stream().findFirst().get())
         .getPartitionPath(), dataFileToBeMerged);

--- a/hoodie-client/src/main/java/com/uber/hoodie/table/HoodieCopyOnWriteTable.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/table/HoodieCopyOnWriteTable.java
@@ -769,7 +769,7 @@ public class HoodieCopyOnWriteTable<T extends HoodieRecordPayload> extends Hoodi
 
       if (!commitTimeline.empty()) { // if we have some commits
         HoodieInstant latestCommitTime = commitTimeline.lastInstant().get();
-        List<HoodieDataFile> allFiles = getROFileSystemView()
+        List<HoodieDataFile> allFiles = getLatestFileSliceOnlyFSView()
             .getLatestDataFilesBeforeOrOn(partitionPath, latestCommitTime.getTimestamp())
             .collect(Collectors.toList());
 

--- a/hoodie-client/src/main/java/com/uber/hoodie/table/HoodieMergeOnReadTable.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/table/HoodieMergeOnReadTable.java
@@ -351,7 +351,7 @@ public class HoodieMergeOnReadTable<T extends HoodieRecordPayload> extends
         if (!index.canIndexLogFiles()) {
           // TODO : choose last N small files since there can be multiple small files written to a single partition
           // by different spark partitions in a single batch
-          Optional<FileSlice> smallFileSlice = getRTFileSystemView()
+          Optional<FileSlice> smallFileSlice = getLatestFileSliceOnlyFSView()
               .getLatestFileSlicesBeforeOrOn(partitionPath, latestCommitTime.getTimestamp()).filter(
                   fileSlice -> fileSlice.getLogFiles().count() < 1
                       && fileSlice.getDataFile().get().getFileSize() < config

--- a/hoodie-client/src/test/java/com/uber/hoodie/TestHoodieClientBase.java
+++ b/hoodie-client/src/test/java/com/uber/hoodie/TestHoodieClientBase.java
@@ -145,6 +145,7 @@ public class TestHoodieClientBase implements Serializable {
         .withParallelism(2, 2)
         .withBulkInsertParallelism(2).withFinalizeWriteParallelism(2)
         .withConsistencyCheckEnabled(true)
+        .withWriterFSViewCacheEnabled(true)
         .withCompactionConfig(HoodieCompactionConfig.newBuilder().compactionSmallFileSize(1024 * 1024).build())
         .withStorageConfig(HoodieStorageConfig.newBuilder().limitFileSize(1024 * 1024).build())
         .forTable("test-trip-table")

--- a/hoodie-client/src/test/java/com/uber/hoodie/TestMultiFS.java
+++ b/hoodie-client/src/test/java/com/uber/hoodie/TestMultiFS.java
@@ -108,7 +108,7 @@ public class TestMultiFS implements Serializable {
             HoodieAvroPayload.class.getName());
 
     //Create write client to write some records in
-    HoodieWriteConfig cfg = HoodieWriteConfig.newBuilder().withPath(dfsBasePath)
+    HoodieWriteConfig cfg = HoodieWriteConfig.newBuilder().withPath(dfsBasePath).withWriterFSViewCacheEnabled(true)
         .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA).withParallelism(2, 2)
         .forTable(tableName).withIndexConfig(
             HoodieIndexConfig.newBuilder().withIndexType(HoodieIndex.IndexType.BLOOM).build()).build();
@@ -132,7 +132,8 @@ public class TestMultiFS implements Serializable {
     HoodieTableMetaClient
         .initTableType(jsc.hadoopConfiguration(), tablePath, HoodieTableType.valueOf(tableType), tableName,
             HoodieAvroPayload.class.getName());
-    HoodieWriteConfig localConfig = HoodieWriteConfig.newBuilder().withPath(tablePath)
+    HoodieWriteConfig localConfig =
+        HoodieWriteConfig.newBuilder().withPath(tablePath).withWriterFSViewCacheEnabled(true)
         .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA).withParallelism(2, 2)
         .forTable(tableName).withIndexConfig(
             HoodieIndexConfig.newBuilder().withIndexType(HoodieIndex.IndexType.BLOOM).build()).build();

--- a/hoodie-client/src/test/java/com/uber/hoodie/table/TestMergeOnReadTable.java
+++ b/hoodie-client/src/test/java/com/uber/hoodie/table/TestMergeOnReadTable.java
@@ -1125,7 +1125,8 @@ public class TestMergeOnReadTable {
 
   private HoodieWriteConfig.Builder getConfigBuilder(Boolean autoCommit, HoodieIndex.IndexType indexType) {
     return HoodieWriteConfig.newBuilder().withPath(basePath).withSchema(TRIP_EXAMPLE_SCHEMA).withParallelism(2, 2)
-        .withAutoCommit(autoCommit).withAssumeDatePartitioning(true).withCompactionConfig(
+        .withAutoCommit(autoCommit).withWriterFSViewCacheEnabled(true).withAssumeDatePartitioning(true)
+        .withCompactionConfig(
             HoodieCompactionConfig.newBuilder().compactionSmallFileSize(1024 * 1024 * 1024).withInlineCompaction(false)
                 .withMaxNumDeltaCommitsBeforeCompaction(1).build())
         .withStorageConfig(HoodieStorageConfig.newBuilder().limitFileSize(1024 * 1024 * 1024).build())

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/model/FileSlice.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/model/FileSlice.java
@@ -84,7 +84,8 @@ public class FileSlice implements Serializable {
   @Override
   public String toString() {
     final StringBuilder sb = new StringBuilder("FileSlice {");
-    sb.append("baseCommitTime=").append(baseInstantTime);
+    sb.append("fileId=").append(fileId);
+    sb.append(", baseCommitTime=").append(baseInstantTime);
     sb.append(", dataFile='").append(dataFile).append('\'');
     sb.append(", logFiles='").append(logFiles).append('\'');
     sb.append('}');

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/model/HoodieFileGroup.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/model/HoodieFileGroup.java
@@ -20,6 +20,7 @@ package com.uber.hoodie.common.model;
 
 import com.uber.hoodie.common.table.HoodieTimeline;
 import com.uber.hoodie.common.table.timeline.HoodieInstant;
+import com.uber.hoodie.common.util.Option;
 import java.io.Serializable;
 import java.util.Comparator;
 import java.util.List;
@@ -33,10 +34,7 @@ import java.util.stream.Stream;
 public class HoodieFileGroup implements Serializable {
 
   public static Comparator<String> getReverseCommitTimeComparator() {
-    return (o1, o2) -> {
-      // reverse the order
-      return o2.compareTo(o1);
-    };
+    return Comparator.reverseOrder();
   }
 
   /**
@@ -62,14 +60,16 @@ public class HoodieFileGroup implements Serializable {
   /**
    * The last completed instant, that acts as a high watermark for all getters
    */
-  private final Optional<HoodieInstant> lastInstant;
+  private final Option<HoodieInstant> lastInstant;
 
   public HoodieFileGroup(String partitionPath, String id, HoodieTimeline timeline) {
     this.partitionPath = partitionPath;
     this.id = id;
     this.fileSlices = new TreeMap<>(HoodieFileGroup.getReverseCommitTimeComparator());
     this.timeline = timeline;
-    this.lastInstant = timeline.lastInstant();
+    // Guava Optional is serializable.
+    // TODO : varadarb -> Open another PR to replace java.util.Optional with Guava'a everywhere internally
+    this.lastInstant = Option.fromJavaOptional(timeline.lastInstant());
   }
 
   /**
@@ -207,5 +207,9 @@ public class HoodieFileGroup implements Serializable {
     sb.append(", fileSlices='").append(fileSlices).append('\'');
     sb.append('}');
     return sb.toString();
+  }
+
+  public HoodieTimeline getTimeline() {
+    return timeline;
   }
 }

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/table/TableFileSystemView.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/table/TableFileSystemView.java
@@ -30,9 +30,9 @@ import java.util.stream.Stream;
 public interface TableFileSystemView {
 
   /**
-   * ReadOptimizedView - methods to provide a view of columnar data files only.
+   * ReadOptimizedView with methods to only access latest version of file for the instant(s) passed.
    */
-  interface ReadOptimizedView {
+  interface ReadOptimizedViewWithLatestSlice {
 
     /**
      * Stream all the latest data files in the given partition
@@ -45,15 +45,15 @@ public interface TableFileSystemView {
     Stream<HoodieDataFile> getLatestDataFiles();
 
     /**
-     * Stream all the latest version data files in the given partition with precondition that
-     * commitTime(file) before maxCommitTime
+     * Stream all the latest version data files in the given partition with precondition that commitTime(file) before
+     * maxCommitTime
      */
     Stream<HoodieDataFile> getLatestDataFilesBeforeOrOn(String partitionPath,
         String maxCommitTime);
 
     /**
-     * Stream all the latest version data files in the given partition with precondition that
-     * instant time of file matches passed in instant time.
+     * Stream all the latest version data files in the given partition with precondition that instant time of file
+     * matches passed in instant time.
      */
     Stream<HoodieDataFile> getLatestDataFilesOn(String partitionPath, String instantTime);
 
@@ -61,7 +61,12 @@ public interface TableFileSystemView {
      * Stream all the latest data files pass
      */
     Stream<HoodieDataFile> getLatestDataFilesInRange(List<String> commitsToReturn);
+  }
 
+  /**
+   * ReadOptimizedView - methods to provide a view of columnar data files only.
+   */
+  interface ReadOptimizedView extends ReadOptimizedViewWithLatestSlice {
     /**
      * Stream all the data file versions grouped by FileId for a given partition
      */
@@ -69,10 +74,9 @@ public interface TableFileSystemView {
   }
 
   /**
-   * RealtimeView - methods to access a combination of columnar data files + log files with real
-   * time data.
+   * RealtimeView with methods to only access latest version of file-slice for the instant(s) passed.
    */
-  interface RealtimeView {
+  interface RealtimeViewWithLatestSlice {
 
     /**
      * Stream all the latest file slices in the given partition
@@ -106,6 +110,12 @@ public interface TableFileSystemView {
      * Stream all the latest file slices, in the given range
      */
     Stream<FileSlice> getLatestFileSliceInRange(List<String> commitsToReturn);
+  }
+
+  /**
+   * RealtimeView - methods to access a combination of columnar data files + log files with real time data.
+   */
+  interface RealtimeView extends RealtimeViewWithLatestSlice {
 
     /**
      * Stream all the file slices for a given partition, latest or not.

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/table/view/LatestFileSliceOnlyFSViewImpl.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/table/view/LatestFileSliceOnlyFSViewImpl.java
@@ -1,0 +1,75 @@
+/*
+ *  Copyright (c) 2016 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.uber.hoodie.common.table.view;
+
+import com.uber.hoodie.common.model.HoodieFileGroup;
+import com.uber.hoodie.common.table.HoodieTableMetaClient;
+import com.uber.hoodie.common.table.HoodieTimeline;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.hadoop.fs.FileStatus;
+
+/**
+ * A file-system view implementataion containing only the latest file-slice for each file-group
+ */
+public class LatestFileSliceOnlyFSViewImpl extends HoodieTableFileSystemView implements
+    SealedLatestVersionOnlyFSView {
+
+  // State to track when the cache is fully populated.
+  private boolean sealed = false;
+  private final boolean errorIfSealBroken;
+
+  public LatestFileSliceOnlyFSViewImpl(HoodieTableMetaClient metaClient,
+      HoodieTimeline visibleActiveTimeline, boolean errorIfSealBroken) {
+    super(metaClient, visibleActiveTimeline);
+    this.errorIfSealBroken = errorIfSealBroken;
+  }
+
+  public LatestFileSliceOnlyFSViewImpl(HoodieTableMetaClient metaClient,
+      HoodieTimeline visibleActiveTimeline, FileStatus[] fileStatuses, boolean errorIfSealBroken) {
+    super(metaClient, visibleActiveTimeline, fileStatuses);
+    this.errorIfSealBroken = errorIfSealBroken;
+  }
+
+  protected HoodieFileGroup preProcessFileGroup(HoodieFileGroup group, boolean isCompactionPending) {
+    HoodieFileGroup newGroup = new HoodieFileGroup(group.getPartitionPath(), group.getId(), group.getTimeline());
+    // We allow latest 2 file-slices to be added to create a complete file-version here
+    int maxNumberOfFileSlicesAdded = isCompactionPending ? 2 : 1;
+    group.getAllFileSlices().limit(maxNumberOfFileSlicesAdded).forEach(fs -> {
+      newGroup.addNewFileSliceAtInstant(fs.getBaseInstantTime());
+      if (fs.getDataFile().isPresent()) {
+        newGroup.addDataFile(fs.getDataFile().get());
+      }
+      fs.getLogFiles().forEach(lf -> {
+        newGroup.addLogFile(lf);
+      });
+    });
+    return newGroup;
+  }
+
+  protected List<HoodieFileGroup> addFilesToView(FileStatus[] statuses) {
+    if (!sealed || !errorIfSealBroken) {
+      return super.addFilesToView(statuses);
+    }
+    throw new IllegalStateException("Internal Exception : Files can not be added after this view is sealed."
+        + "Trying to add statuses :" + Arrays.toString(statuses));
+  }
+
+  public void seal() {
+    sealed = true;
+  }
+}

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/table/view/SealedLatestVersionOnlyFSView.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/table/view/SealedLatestVersionOnlyFSView.java
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (c) 2016 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.uber.hoodie.common.table.view;
+
+import com.uber.hoodie.common.table.TableFileSystemView.ReadOptimizedViewWithLatestSlice;
+import com.uber.hoodie.common.table.TableFileSystemView.RealtimeViewWithLatestSlice;
+
+/**
+ * A latest file-slice only FS view with method to seal the view to track the state when the cache is fully populated.
+ * Useful to add pre-conditions to check if the cache is indeed effective
+ */
+public interface SealedLatestVersionOnlyFSView extends RealtimeViewWithLatestSlice,
+    ReadOptimizedViewWithLatestSlice {
+
+  /**
+   * Seal the file-system view. New files will no longer be added to the file-system view after sealed.
+   * Allows for 2 phases ->
+   *  (a) Growing phase where the view is getting constructed. once this phase is done, seal the view
+   *  (b) Immutable View where the view represents a consistent snapshot
+   */
+  public void seal();
+}

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/util/Option.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/util/Option.java
@@ -1,0 +1,312 @@
+/*
+ *  Copyright (c) 2016 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.uber.hoodie.common.util;
+
+import java.io.Serializable;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+/**
+ * Copied from java.util.Optional and made Serializable along with methods to convert to/from standard Option
+ */
+public final class Option<T> implements Serializable {
+
+  private static final long serialVersionUID = 0L;
+
+  /**
+   * Common instance for {@code empty()}.
+   */
+  private static final Option<?> EMPTY = new Option<>();
+
+  /**
+   * If non-null, the value; if null, indicates no value is present
+   */
+  private final T value;
+
+  /**
+   * Constructs an empty instance.
+   *
+   * @implNote Generally only one empty instance, {@link Option#EMPTY}, should exist per VM.
+   */
+  private Option() {
+    this.value = null;
+  }
+
+  /**
+   * Returns an empty {@code Option} instance.  No value is present for this Option.
+   *
+   * @param <T> Type of the non-existent value
+   * @return an empty {@code Option}
+   * @apiNote Though it may be tempting to do so, avoid testing if an object is empty by comparing with {@code ==}
+   * against instances returned by {@code Option.empty()}. There is no guarantee that it is a singleton. Instead, use
+   * {@link #isPresent()}.
+   */
+  public static <T> Option<T> empty() {
+    @SuppressWarnings("unchecked")
+    Option<T> t = (Option<T>) EMPTY;
+    return t;
+  }
+
+  /**
+   * Constructs an instance with the value present.
+   *
+   * @param value the non-null value to be present
+   * @throws NullPointerException if value is null
+   */
+  private Option(T value) {
+    this.value = Objects.requireNonNull(value);
+  }
+
+  /**
+   * Returns an {@code Option} with the specified present non-null value.
+   *
+   * @param <T> the class of the value
+   * @param value the value to be present, which must be non-null
+   * @return an {@code Option} with the value present
+   * @throws NullPointerException if value is null
+   */
+  public static <T> Option<T> of(T value) {
+    return new Option<>(value);
+  }
+
+  /**
+   * Returns an {@code Option} describing the specified value, if non-null, otherwise returns an empty {@code Option}.
+   *
+   * @param <T> the class of the value
+   * @param value the possibly-null value to describe
+   * @return an {@code Option} with a present value if the specified value is non-null, otherwise an empty {@code
+   * Option}
+   */
+  public static <T> Option<T> ofNullable(T value) {
+    return value == null ? empty() : of(value);
+  }
+
+  /**
+   * If a value is present in this {@code Option}, returns the value, otherwise throws {@code NoSuchElementException}.
+   *
+   * @return the non-null value held by this {@code Option}
+   * @throws NoSuchElementException if there is no value present
+   * @see Option#isPresent()
+   */
+  public T get() {
+    if (value == null) {
+      throw new NoSuchElementException("No value present");
+    }
+    return value;
+  }
+
+  /**
+   * Return {@code true} if there is a value present, otherwise {@code false}.
+   *
+   * @return {@code true} if there is a value present, otherwise {@code false}
+   */
+  public boolean isPresent() {
+    return value != null;
+  }
+
+  /**
+   * If a value is present, invoke the specified consumer with the value, otherwise do nothing.
+   *
+   * @param consumer block to be executed if a value is present
+   * @throws NullPointerException if value is present and {@code consumer} is null
+   */
+  public void ifPresent(Consumer<? super T> consumer) {
+    if (value != null) {
+      consumer.accept(value);
+    }
+  }
+
+  /**
+   * If a value is present, and the value matches the given predicate, return an {@code Option} describing the value,
+   * otherwise return an empty {@code Option}.
+   *
+   * @param predicate a predicate to apply to the value, if present
+   * @return an {@code Option} describing the value of this {@code Option} if a value is present and the value matches
+   * the given predicate, otherwise an empty {@code Option}
+   * @throws NullPointerException if the predicate is null
+   */
+  public Option<T> filter(Predicate<? super T> predicate) {
+    Objects.requireNonNull(predicate);
+    if (!isPresent()) {
+      return this;
+    } else {
+      return predicate.test(value) ? this : empty();
+    }
+  }
+
+  /**
+   * If a value is present, apply the provided mapping function to it, and if the result is non-null, return an {@code
+   * Option} describing the result.  Otherwise return an empty {@code Option}.
+   *
+   * @param <U> The type of the result of the mapping function
+   * @param mapper a mapping function to apply to the value, if present
+   * @return an {@code Option} describing the result of applying a mapping function to the value of this {@code Option},
+   * if a value is present, otherwise an empty {@code Option}
+   * @throws NullPointerException if the mapping function is null
+   * @apiNote This method supports post-processing on optional values, without the need to explicitly check for a return
+   * status.  For example, the following code traverses a stream of file names, selects one that has not yet been
+   * processed, and then opens that file, returning an {@code Option<FileInputStream>}:
+   *
+   * <pre>{@code
+   *     Option<FileInputStream> fis =
+   *         names.stream().filter(name -> !isProcessedYet(name))
+   *                       .findFirst()
+   *                       .map(name -> new FileInputStream(name));
+   * }</pre>
+   *
+   * Here, {@code findFirst} returns an {@code Option<String>}, and then {@code map} returns an {@code
+   * Option<FileInputStream>} for the desired file if one exists.
+   */
+  public <U> Option<U> map(Function<? super T, ? extends U> mapper) {
+    Objects.requireNonNull(mapper);
+    if (!isPresent()) {
+      return empty();
+    } else {
+      return Option.ofNullable(mapper.apply(value));
+    }
+  }
+
+  /**
+   * If a value is present, apply the provided {@code Option}-bearing mapping function to it, return that result,
+   * otherwise return an empty {@code Option}.  This method is similar to {@link #map(Function)}, but the provided
+   * mapper is one whose result is already an {@code Option}, and if invoked, {@code flatMap} does not wrap it with an
+   * additional {@code Option}.
+   *
+   * @param <U> The type parameter to the {@code Option} returned by
+   * @param mapper a mapping function to apply to the value, if present the mapping function
+   * @return the result of applying an {@code Option}-bearing mapping function to the value of this {@code Option}, if a
+   * value is present, otherwise an empty {@code Option}
+   * @throws NullPointerException if the mapping function is null or returns a null result
+   */
+  public <U> Option<U> flatMap(Function<? super T, Option<U>> mapper) {
+    Objects.requireNonNull(mapper);
+    if (!isPresent()) {
+      return empty();
+    } else {
+      return Objects.requireNonNull(mapper.apply(value));
+    }
+  }
+
+  /**
+   * Return the value if present, otherwise return {@code other}.
+   *
+   * @param other the value to be returned if there is no value present, may be null
+   * @return the value, if present, otherwise {@code other}
+   */
+  public T orElse(T other) {
+    return value != null ? value : other;
+  }
+
+  /**
+   * Return the value if present, otherwise invoke {@code other} and return the result of that invocation.
+   *
+   * @param other a {@code Supplier} whose result is returned if no value is present
+   * @return the value if present otherwise the result of {@code other.get()}
+   * @throws NullPointerException if value is not present and {@code other} is null
+   */
+  public T orElseGet(Supplier<? extends T> other) {
+    return value != null ? value : other.get();
+  }
+
+  /**
+   * Return the contained value, if present, otherwise throw an exception to be created by the provided supplier.
+   *
+   * @param <X> Type of the exception to be thrown
+   * @param exceptionSupplier The supplier which will return the exception to be thrown
+   * @return the present value
+   * @throws X if there is no value present
+   * @throws NullPointerException if no value is present and {@code exceptionSupplier} is null
+   * @apiNote A method reference to the exception constructor with an empty argument list can be used as the supplier.
+   * For example, {@code IllegalStateException::new}
+   */
+  public <X extends Throwable> T orElseThrow(Supplier<? extends X> exceptionSupplier) throws X {
+    if (value != null) {
+      return value;
+    } else {
+      throw exceptionSupplier.get();
+    }
+  }
+
+  /**
+   * Indicates whether some other object is "equal to" this Option. The other object is considered equal if:
+   * <ul>
+   * <li>it is also an {@code Option} and;
+   * <li>both instances have no value present or;
+   * <li>the present values are "equal to" each other via {@code equals()}.
+   * </ul>
+   *
+   * @param obj an object to be tested for equality
+   * @return {code true} if the other object is "equal to" this object otherwise {@code false}
+   */
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+
+    if (!(obj instanceof Option)) {
+      return false;
+    }
+
+    Option<?> other = (Option<?>) obj;
+    return Objects.equals(value, other.value);
+  }
+
+  /**
+   * Returns the hash code value of the present value, if any, or 0 (zero) if no value is present.
+   *
+   * @return hash code value of the present value or 0 if no value is present
+   */
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(value);
+  }
+
+  /**
+   * Returns a non-empty string representation of this Option suitable for debugging. The exact presentation format is
+   * unspecified and may vary between implementations and versions.
+   *
+   * @return the string representation of this instance
+   * @implSpec If a value is present the result must include its string representation in the result. Empty and present
+   * Optionals must be unambiguously differentiable.
+   */
+  @Override
+  public String toString() {
+    return value != null
+        ? String.format("Option[%s]", value)
+        : "Option.empty";
+  }
+
+  /**
+   * Convert to java Optional
+   */
+  public Optional<T> toJavaOptional() {
+    return Optional.ofNullable(value);
+  }
+
+  /**
+   * Convert from java.util.Optional
+   */
+  public static <T> Option<T> fromJavaOptional(Optional<T> v) {
+    return Option.ofNullable(v.orElse(null));
+  }
+}

--- a/hoodie-common/src/test/java/com/uber/hoodie/common/table/view/LatestFileSliceOnlyFSViewImplTest.java
+++ b/hoodie-common/src/test/java/com/uber/hoodie/common/table/view/LatestFileSliceOnlyFSViewImplTest.java
@@ -1,0 +1,142 @@
+/*
+ *  Copyright (c) 2016 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.uber.hoodie.common.table.view;
+
+import static org.junit.Assert.assertEquals;
+
+import com.uber.hoodie.common.model.HoodieDataFile;
+import com.uber.hoodie.common.table.HoodieTimeline;
+import com.uber.hoodie.common.util.FSUtils;
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+import org.junit.Test;
+
+
+public class LatestFileSliceOnlyFSViewImplTest extends HoodieTableFileSystemViewTest {
+
+  protected HoodieTableFileSystemView getFileSystemView(HoodieTimeline timeline) {
+    return new LatestFileSliceOnlyFSViewImpl(metaClient, timeline, true);
+  }
+
+  protected HoodieTableFileSystemView getFileSystemView(HoodieTimeline timeline, FileStatus[] statuses) {
+    return new LatestFileSliceOnlyFSViewImpl(metaClient, timeline, statuses, true);
+  }
+
+  /**
+   * Test case for view generation on a file group where the only file-slice does not have data-file. This is the case
+   * where upserts directly go to log-files
+   */
+  @Test
+  public void testViewForFileSlicesWithNoBaseFile() throws Exception {
+    testViewForFileSlicesWithNoBaseFile(1, 0);
+  }
+
+  @Test
+  public void testViewForFileSlicesWithNoBaseFileAndRequestedCompaction() throws Exception {
+    testViewForFileSlicesWithAsyncCompaction(true, false, 1, 1, false);
+  }
+
+  @Test
+  public void testViewForFileSlicesWithBaseFileAndRequestedCompaction() throws Exception {
+    testViewForFileSlicesWithAsyncCompaction(false, false, 1, 1, false);
+  }
+
+  @Test
+  public void testViewForFileSlicesWithNoBaseFileAndInflightCompaction() throws Exception {
+    testViewForFileSlicesWithAsyncCompaction(true, true, 1, 1, false);
+  }
+
+  @Test
+  public void testViewForFileSlicesWithBaseFileAndInflightCompaction() throws Exception {
+    testViewForFileSlicesWithAsyncCompaction(false, true, 1, 1, false);
+  }
+
+  @Test
+  public void testStreamEveryVersionInPartition() throws IOException {
+    testStreamEveryVersionInPartition(true);
+  }
+
+  @Test
+  public void testStreamLatestVersionsBefore() throws IOException {
+    testStreamLatestVersionsBefore(true);
+  }
+
+  @Test
+  public void testStreamLatestVersionInRange() throws IOException {
+    testStreamLatestVersionInRange(true);
+  }
+
+  @Test
+  public void testStreamLatestVersionInPartition() throws IOException {
+    testStreamLatestVersionInPartition(true);
+  }
+
+  @Test
+  public void testStreamLatestVersions() throws IOException {
+    testStreamLatestVersions(true);
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testBrokenSeal() throws IOException {
+    // Put some files in the partition
+    String partitionPath = "2016/05/01/";
+    String fullPartitionPath = basePath + "/" + partitionPath;
+    new File(fullPartitionPath).mkdirs();
+    String commitTime1 = "1";
+    String commitTime2 = "2";
+    String commitTime3 = "3";
+    String commitTime4 = "4";
+    String fileId1 = UUID.randomUUID().toString();
+    String fileId2 = UUID.randomUUID().toString();
+    String fileId3 = UUID.randomUUID().toString();
+
+    new File(fullPartitionPath + FSUtils.makeDataFileName(commitTime1, 1, fileId1)).createNewFile();
+    new File(fullPartitionPath + FSUtils.makeDataFileName(commitTime1, 1, fileId2)).createNewFile();
+    new File(fullPartitionPath + FSUtils.makeDataFileName(commitTime2, 1, fileId2)).createNewFile();
+    new File(fullPartitionPath + FSUtils.makeDataFileName(commitTime3, 1, fileId2)).createNewFile();
+    new File(fullPartitionPath + FSUtils.makeDataFileName(commitTime3, 1, fileId3)).createNewFile();
+
+    new File(basePath + "/.hoodie/" + commitTime1 + ".commit").createNewFile();
+    new File(basePath + "/.hoodie/" + commitTime2 + ".commit").createNewFile();
+    new File(basePath + "/.hoodie/" + commitTime3 + ".commit").createNewFile();
+
+    // Now we list the entire partition
+    FileStatus[] statuses = metaClient.getFs().listStatus(new Path(fullPartitionPath));
+    assertEquals(5, statuses.length);
+    refreshFsView(null);
+    List<HoodieDataFile> dataFiles = roView.getLatestDataFilesBeforeOrOn(partitionPath, commitTime3)
+        .collect(Collectors.toList());
+    assertEquals(3, dataFiles.size());
+
+    // Seal the view
+    ((LatestFileSliceOnlyFSViewImpl) fsView).seal();
+
+    String newPartitionPath = "2016/05/02/";
+    String fullNewPartitionPath = basePath + "/" + newPartitionPath;
+    new File(fullNewPartitionPath).mkdirs();
+    new File(fullNewPartitionPath + FSUtils.makeDataFileName(commitTime4, 1, fileId1)).createNewFile();
+    new File(fullNewPartitionPath + FSUtils.makeDataFileName(commitTime4, 1, fileId3)).createNewFile();
+    new File(basePath + "/.hoodie/" + commitTime4 + ".commit").createNewFile();
+
+    roView.getLatestDataFilesBeforeOrOn(newPartitionPath, commitTime4).collect(Collectors.toList());
+  }
+}


### PR DESCRIPTION

Issue : https://github.com/uber/hudi/issues/433

    Hudi writing and Compaction step to use cached file-system view containing only needed file-slices to reduce name-node list-status calls
    Write Path :
         When using Bloom Filter index, listStatus is performed once and cached in BloomIndex for all interesting partition-paths. For other cases, listStatus is performed after records are prepped (indexed)
         and before starting the IOHandle write stage. This helps avoid listStatus calls for each IOHandle (MergeHandle and AppendHandle) tasks. Depending on the partition-to-file distribution, the gains vary.
         In case where all the fileIds to be merged/appended are in the same partition-path, we save n-1 listStatus calls where n is the number of fileIds changed. In case where only new parquet-files are generated
         or the corner-case where there is exactly one fileId per partition getting appended/merged, #listStatus calls are break-even for bloom index.
    Compaction Path:
         Hoodie Compactor caches all the partitions which has atleast one fileId in the scheduled compaction plan. The benefits are similar to above except that only MergeHandle is used here which always does one listStatus
         at partition-level. For cases where there are more than one fileId per partition getting compacted, we only do listStatus once per partition and save others.