### PR TITLE
Enable multi rollbacks for MOR table type

### DIFF
--- a/hoodie-client/src/main/java/com/uber/hoodie/table/HoodieTable.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/table/HoodieTable.java
@@ -253,7 +253,7 @@ public abstract class HoodieTable<T extends HoodieRecordPayload> implements Seri
    * Atomically unpublish this commit (2) clean indexing data (3) clean new generated parquet files
    * / log blocks (4) Finally, delete .<action>.commit or .<action>.inflight file if deleteInstants = true
    */
-  public abstract List<HoodieRollbackStat> rollback(JavaSparkContext jsc, List<String> commits, boolean deleteInstants)
+  public abstract List<HoodieRollbackStat> rollback(JavaSparkContext jsc, String commit, boolean deleteInstants)
       throws IOException;
 
   /**

--- a/hoodie-client/src/test/java/com/uber/hoodie/TestAsyncCompaction.java
+++ b/hoodie-client/src/test/java/com/uber/hoodie/TestAsyncCompaction.java
@@ -114,7 +114,7 @@ public class TestAsyncCompaction extends TestHoodieClientBase {
     // Reload and rollback inflight compaction
     metaClient = new HoodieTableMetaClient(jsc.hadoopConfiguration(), cfg.getBasePath());
     HoodieTable hoodieTable = HoodieTable.getHoodieTable(metaClient, cfg, jsc);
-    hoodieTable.rollback(jsc, Arrays.asList(compactionInstantTime), false);
+    hoodieTable.rollback(jsc, compactionInstantTime, false);
 
     client.rollbackInflightCompaction(
         new HoodieInstant(State.INFLIGHT, HoodieTimeline.COMPACTION_ACTION, compactionInstantTime), hoodieTable);

--- a/hoodie-client/src/test/java/com/uber/hoodie/TestCleaner.java
+++ b/hoodie-client/src/test/java/com/uber/hoodie/TestCleaner.java
@@ -55,7 +55,6 @@ import com.uber.hoodie.table.HoodieTable;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -628,19 +627,12 @@ public class TestCleaner extends TestHoodieClientBase {
     assertEquals("Some temp files are created.", tempFiles.size(), getTotalTempFiles());
 
     HoodieWriteConfig config = HoodieWriteConfig.newBuilder().withPath(basePath)
-        .withUseTempFolderCopyOnWriteForCreate(false)
+        .withUseTempFolderCopyOnWriteForCreate(true)
         .withUseTempFolderCopyOnWriteForMerge(false).build();
-    HoodieTable table = HoodieTable.getHoodieTable(
-        new HoodieTableMetaClient(jsc.hadoopConfiguration(), config.getBasePath(), true), config,
-        jsc);
-    table.rollback(jsc, Collections.emptyList(), true);
-    assertEquals("Some temp files are created.", tempFiles.size(), getTotalTempFiles());
-
-    config = HoodieWriteConfig.newBuilder().withPath(basePath).withUseTempFolderCopyOnWriteForCreate(true)
-        .withUseTempFolderCopyOnWriteForMerge(false).build();
-    table = HoodieTable.getHoodieTable(new HoodieTableMetaClient(jsc.hadoopConfiguration(), config.getBasePath(), true),
+    HoodieTable table = HoodieTable.getHoodieTable(new HoodieTableMetaClient(jsc.hadoopConfiguration(), config
+            .getBasePath(), true),
         config, jsc);
-    table.rollback(jsc, Collections.emptyList(), true);
+    table.rollback(jsc, "000", true);
     assertEquals("All temp files are deleted.", 0, getTotalTempFiles());
   }
 

--- a/hoodie-client/src/test/java/com/uber/hoodie/table/TestMergeOnReadTable.java
+++ b/hoodie-client/src/test/java/com/uber/hoodie/table/TestMergeOnReadTable.java
@@ -721,7 +721,7 @@ public class TestMergeOnReadTable {
     copyOfRecords.clear();
 
     // Rollback latest commit first
-    client.restoreToCommit("000");
+    client.restoreToInstant("000");
 
     metaClient = new HoodieTableMetaClient(jsc.hadoopConfiguration(), cfg.getBasePath());
     allFiles = HoodieTestUtils.listAllDataFilesInPath(metaClient.getFs(), cfg.getBasePath());

--- a/hoodie-client/src/test/java/com/uber/hoodie/table/TestMergeOnReadTable.java
+++ b/hoodie-client/src/test/java/com/uber/hoodie/table/TestMergeOnReadTable.java
@@ -33,6 +33,7 @@ import com.uber.hoodie.common.minicluster.HdfsTestService;
 import com.uber.hoodie.common.model.FileSlice;
 import com.uber.hoodie.common.model.HoodieCommitMetadata;
 import com.uber.hoodie.common.model.HoodieDataFile;
+import com.uber.hoodie.common.model.HoodieFileGroup;
 import com.uber.hoodie.common.model.HoodieKey;
 import com.uber.hoodie.common.model.HoodieRecord;
 import com.uber.hoodie.common.model.HoodieRollingStat;
@@ -563,6 +564,178 @@ public class TestMergeOnReadTable {
       }
     }).findAny().isPresent());
   }
+
+  @Test
+  public void testMultiRollbackWithDeltaAndCompactionCommit() throws Exception {
+
+    HoodieWriteConfig cfg = getConfig(false);
+    final HoodieWriteClient client = new HoodieWriteClient(jsc, cfg);
+    List<String> allCommits = new ArrayList<>();
+    /**
+     * Write 1 (only inserts)
+     */
+    String newCommitTime = "001";
+    allCommits.add(newCommitTime);
+    client.startCommitWithTime(newCommitTime);
+
+    HoodieTestDataGenerator dataGen = new HoodieTestDataGenerator();
+    List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 200);
+    JavaRDD<HoodieRecord> writeRecords = jsc.parallelize(records, 1);
+
+    JavaRDD<WriteStatus> writeStatusJavaRDD = client.upsert(writeRecords, newCommitTime);
+    client.commit(newCommitTime, writeStatusJavaRDD);
+    List<WriteStatus> statuses = writeStatusJavaRDD.collect();
+    assertNoWriteErrors(statuses);
+
+    HoodieTableMetaClient metaClient = new HoodieTableMetaClient(jsc.hadoopConfiguration(), cfg.getBasePath());
+    HoodieTable hoodieTable = HoodieTable.getHoodieTable(metaClient, cfg, jsc);
+
+    Optional<HoodieInstant> deltaCommit = metaClient.getActiveTimeline().getDeltaCommitTimeline().firstInstant();
+    assertTrue(deltaCommit.isPresent());
+    assertEquals("Delta commit should be 001", "001", deltaCommit.get().getTimestamp());
+
+    Optional<HoodieInstant> commit = metaClient.getActiveTimeline().getCommitTimeline().firstInstant();
+    assertFalse(commit.isPresent());
+
+    FileStatus[] allFiles = HoodieTestUtils.listAllDataFilesInPath(metaClient.getFs(), cfg.getBasePath());
+    TableFileSystemView.ReadOptimizedView roView = new HoodieTableFileSystemView(metaClient,
+        metaClient.getCommitTimeline().filterCompletedInstants(), allFiles);
+    Stream<HoodieDataFile> dataFilesToRead = roView.getLatestDataFiles();
+    assertTrue(!dataFilesToRead.findAny().isPresent());
+
+    roView = new HoodieTableFileSystemView(metaClient, hoodieTable.getCompletedCommitsTimeline(), allFiles);
+    dataFilesToRead = roView.getLatestDataFiles();
+    assertTrue("ReadOptimizedTableView should list the parquet files we wrote in the delta commit",
+        dataFilesToRead.findAny().isPresent());
+
+    /**
+     * Write 2 (inserts + updates)
+     */
+    newCommitTime = "002";
+    allCommits.add(newCommitTime);
+    // WriteClient with custom config (disable small file handling)
+    HoodieWriteClient nClient = new HoodieWriteClient(jsc, HoodieWriteConfig.newBuilder().withPath(basePath)
+        .withSchema(TRIP_EXAMPLE_SCHEMA)
+        .withParallelism(2, 2)
+        .withAutoCommit(false).withAssumeDatePartitioning(true).withCompactionConfig(HoodieCompactionConfig.newBuilder()
+            .compactionSmallFileSize(1 * 1024).withInlineCompaction(false)
+            .withMaxNumDeltaCommitsBeforeCompaction(1).build())
+        .withStorageConfig(HoodieStorageConfig.newBuilder().limitFileSize(1 * 1024).build())
+        .forTable("test-trip-table").build());
+    nClient.startCommitWithTime(newCommitTime);
+
+    List<HoodieRecord> copyOfRecords = new ArrayList<>(records);
+    copyOfRecords = dataGen.generateUpdates(newCommitTime, copyOfRecords);
+    copyOfRecords.addAll(dataGen.generateInserts(newCommitTime, 200));
+
+    List<String> dataFiles = roView.getLatestDataFiles().map(hf -> hf.getPath()).collect(Collectors.toList());
+    List<GenericRecord> recordsRead = HoodieMergeOnReadTestUtils.getRecordsUsingInputFormat(dataFiles, basePath);
+    assertEquals(recordsRead.size(), 200);
+
+    statuses = nClient.upsert(jsc.parallelize(copyOfRecords, 1), newCommitTime).collect();
+    // Verify there are no errors
+    assertNoWriteErrors(statuses);
+    nClient.commit(newCommitTime, writeStatusJavaRDD);
+    copyOfRecords.clear();
+
+
+    // Schedule a compaction
+    /**
+     * Write 3 (inserts + updates)
+     */
+    newCommitTime = "003";
+    allCommits.add(newCommitTime);
+    client.startCommitWithTime(newCommitTime);
+
+    List<HoodieRecord> newInserts = dataGen.generateInserts(newCommitTime, 100);
+    records = dataGen.generateUpdates(newCommitTime, records);
+    records.addAll(newInserts);
+    writeRecords = jsc.parallelize(records, 1);
+
+    writeStatusJavaRDD = client.upsert(writeRecords, newCommitTime);
+    client.commit(newCommitTime, writeStatusJavaRDD);
+    statuses = writeStatusJavaRDD.collect();
+    // Verify there are no errors
+    assertNoWriteErrors(statuses);
+
+    metaClient = new HoodieTableMetaClient(jsc.hadoopConfiguration(), cfg.getBasePath());
+
+    String compactionInstantTime = "004";
+    allCommits.add(compactionInstantTime);
+    client.scheduleCompactionAtInstant(compactionInstantTime, Optional.empty());
+
+    // Compaction commit
+    /**
+     * Write 4 (updates)
+     */
+    newCommitTime = "005";
+    allCommits.add(newCommitTime);
+    client.startCommitWithTime(newCommitTime);
+
+    records = dataGen.generateUpdates(newCommitTime, records);
+    writeRecords = jsc.parallelize(records, 1);
+
+    writeStatusJavaRDD = client.upsert(writeRecords, newCommitTime);
+    client.commit(newCommitTime, writeStatusJavaRDD);
+    statuses = writeStatusJavaRDD.collect();
+    // Verify there are no errors
+    assertNoWriteErrors(statuses);
+
+    metaClient = new HoodieTableMetaClient(jsc.hadoopConfiguration(), cfg.getBasePath());
+
+    compactionInstantTime = "006";
+    allCommits.add(compactionInstantTime);
+    client.scheduleCompactionAtInstant(compactionInstantTime, Optional.empty());
+    JavaRDD<WriteStatus> ws = client.compact(compactionInstantTime);
+    client.commitCompaction(compactionInstantTime, ws, Optional.empty());
+
+    allFiles = HoodieTestUtils.listAllDataFilesInPath(metaClient.getFs(), cfg.getBasePath());
+    metaClient = new HoodieTableMetaClient(jsc.hadoopConfiguration(), cfg.getBasePath());
+    roView = new HoodieTableFileSystemView(metaClient, metaClient.getCommitsTimeline(), allFiles);
+
+    final String compactedCommitTime = metaClient.getActiveTimeline().reload().getCommitsTimeline().lastInstant().get()
+        .getTimestamp();
+
+    assertTrue(roView.getLatestDataFiles().filter(file -> {
+      if (compactedCommitTime.equals(file.getCommitTime())) {
+        return true;
+      } else {
+        return false;
+      }
+    }).findAny().isPresent());
+
+    /**
+     * Write 5 (updates)
+     */
+    newCommitTime = "007";
+    allCommits.add(newCommitTime);
+    client.startCommitWithTime(newCommitTime);
+    copyOfRecords = new ArrayList<>(records);
+    copyOfRecords = dataGen.generateUpdates(newCommitTime, copyOfRecords);
+    copyOfRecords.addAll(dataGen.generateInserts(newCommitTime, 200));
+
+    statuses = client.upsert(jsc.parallelize(copyOfRecords, 1), newCommitTime).collect();
+    // Verify there are no errors
+    assertNoWriteErrors(statuses);
+    client.commit(newCommitTime, writeStatusJavaRDD);
+    copyOfRecords.clear();
+
+    // Rollback latest commit first
+    client.restoreToCommit("000");
+
+    metaClient = new HoodieTableMetaClient(jsc.hadoopConfiguration(), cfg.getBasePath());
+    allFiles = HoodieTestUtils.listAllDataFilesInPath(metaClient.getFs(), cfg.getBasePath());
+    roView = new HoodieTableFileSystemView(metaClient,
+        metaClient.getCommitTimeline().filterCompletedInstants(), allFiles);
+    dataFilesToRead = roView.getLatestDataFiles();
+    assertTrue(!dataFilesToRead.findAny().isPresent());
+    HoodieTableFileSystemView.RealtimeView rtView = new HoodieTableFileSystemView(metaClient,
+        metaClient.getCommitTimeline().filterCompletedInstants(), allFiles);
+    List<HoodieFileGroup> fileGroups = ((HoodieTableFileSystemView) rtView).getAllFileGroups().collect(Collectors
+        .toList());
+    assertTrue(fileGroups.isEmpty());
+  }
+
 
   @Test
   public void testUpsertPartitioner() throws Exception {

--- a/hoodie-common/pom.xml
+++ b/hoodie-common/pom.xml
@@ -62,6 +62,7 @@
             <import>${basedir}/src/main/avro/HoodieCompactionMetadata.avsc</import>
             <import>${basedir}/src/main/avro/HoodieCleanMetadata.avsc</import>
             <import>${basedir}/src/main/avro/HoodieRollbackMetadata.avsc</import>
+            <import>${basedir}/src/main/avro/HoodieRestoreMetadata.avsc</import>
           </imports>
         </configuration>
       </plugin>

--- a/hoodie-common/src/main/avro/HoodieRestoreMetadata.avsc
+++ b/hoodie-common/src/main/avro/HoodieRestoreMetadata.avsc
@@ -1,0 +1,17 @@
+{"namespace": "com.uber.hoodie.avro.model",
+ "type": "record",
+ "name": "HoodieRestoreMetadata",
+ "fields": [
+     {"name": "startRestoreTime", "type": "string"},
+     {"name": "timeTakenInMillis", "type": "long"},
+     {"name": "instantsToRollback", "type": {"type": "array", "items": "string"}},
+     {"name": "hoodieRestoreMetadata", "type": {
+     "type" : "map", "values" : {
+        "type": "array",
+        "default": "null",
+        "items": "HoodieRollbackMetadata",
+        "name": "hoodieRollbackMetadata"
+     }
+   }}
+ ]
+}

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/table/HoodieTimeline.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/table/HoodieTimeline.java
@@ -48,6 +48,7 @@ public interface HoodieTimeline extends Serializable {
   // (compaction-requested), (compaction-inflight), (completed)
   String COMPACTION_ACTION = "compaction";
   String REQUESTED_EXTENSION = ".requested";
+  String RESTORE_ACTION = "restore";
 
   String COMMIT_EXTENSION = "." + COMMIT_ACTION;
   String DELTA_COMMIT_EXTENSION = "." + DELTA_COMMIT_ACTION;
@@ -66,6 +67,8 @@ public interface HoodieTimeline extends Serializable {
       StringUtils.join(".", REQUESTED_COMPACTION_SUFFIX);
   String INFLIGHT_COMPACTION_EXTENSION =
       StringUtils.join(".", COMPACTION_ACTION, INFLIGHT_EXTENSION);
+  String INFLIGHT_RESTORE_EXTENSION = "." + RESTORE_ACTION + INFLIGHT_EXTENSION;
+  String RESTORE_EXTENSION = "." + RESTORE_ACTION;
 
   /**
    * Filter this timeline to just include the in-flights
@@ -246,6 +249,14 @@ public interface HoodieTimeline extends Serializable {
 
   static String makeRequestedCompactionFileName(String commitTime) {
     return StringUtils.join(commitTime, HoodieTimeline.REQUESTED_COMPACTION_EXTENSION);
+  }
+
+  static String makeRestoreFileName(String instant) {
+    return StringUtils.join(instant, HoodieTimeline.RESTORE_EXTENSION);
+  }
+
+  static String makeInflightRestoreFileName(String instant) {
+    return StringUtils.join(instant, HoodieTimeline.INFLIGHT_RESTORE_EXTENSION);
   }
 
   static String makeDeltaFileName(String commitTime) {

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/table/HoodieTimeline.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/table/HoodieTimeline.java
@@ -98,7 +98,7 @@ public interface HoodieTimeline extends Serializable {
   HoodieTimeline filterCompletedAndCompactionInstants();
 
   /**
-   * Filter this timeline to just include inflight and requested compaction instants
+   * Filter this timeline to just include requested and inflight compaction instants
    * @return
    */
   HoodieTimeline filterPendingCompactionTimeline();

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/table/timeline/HoodieActiveTimeline.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/table/timeline/HoodieActiveTimeline.java
@@ -262,6 +262,7 @@ public class HoodieActiveTimeline extends HoodieDefaultTimeline {
     Preconditions.checkArgument(inflightInstant.isInflight());
     HoodieInstant requestedInstant =
         new HoodieInstant(State.REQUESTED, COMPACTION_ACTION, inflightInstant.getTimestamp());
+    // Pass empty data since it is read from the corresponding .aux/.compaction instant file
     transitionState(inflightInstant, requestedInstant, Optional.empty());
     return requestedInstant;
   }
@@ -310,7 +311,7 @@ public class HoodieActiveTimeline extends HoodieDefaultTimeline {
     Preconditions.checkArgument(fromInstant.getTimestamp().equals(toInstant.getTimestamp()));
     Path commitFilePath = new Path(metaClient.getMetaPath(), toInstant.getFileName());
     try {
-      // open a new file and write the commit metadata in
+      // Re-create the .inflight file by opening a new file and write the commit metadata in
       Path inflightCommitFile = new Path(metaClient.getMetaPath(), fromInstant.getFileName());
       createFileInMetaPath(fromInstant.getFileName(), data);
       boolean success = metaClient.getFs().rename(inflightCommitFile, commitFilePath);

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/table/timeline/HoodieActiveTimeline.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/table/timeline/HoodieActiveTimeline.java
@@ -54,7 +54,8 @@ public class HoodieActiveTimeline extends HoodieDefaultTimeline {
   public static final Set<String> VALID_EXTENSIONS_IN_ACTIVE_TIMELINE = new HashSet<>(Arrays.asList(
       new String[]{COMMIT_EXTENSION, INFLIGHT_COMMIT_EXTENSION, DELTA_COMMIT_EXTENSION,
           INFLIGHT_DELTA_COMMIT_EXTENSION, SAVEPOINT_EXTENSION, INFLIGHT_SAVEPOINT_EXTENSION,
-          CLEAN_EXTENSION, INFLIGHT_CLEAN_EXTENSION, INFLIGHT_COMPACTION_EXTENSION, REQUESTED_COMPACTION_EXTENSION}));
+          CLEAN_EXTENSION, INFLIGHT_CLEAN_EXTENSION, INFLIGHT_COMPACTION_EXTENSION, REQUESTED_COMPACTION_EXTENSION,
+          INFLIGHT_RESTORE_EXTENSION, RESTORE_EXTENSION}));
 
   private static final transient Logger log = LogManager.getLogger(HoodieActiveTimeline.class);
   private HoodieTableMetaClient metaClient;
@@ -183,6 +184,14 @@ public class HoodieActiveTimeline extends HoodieDefaultTimeline {
    */
   public HoodieTimeline getSavePointTimeline() {
     return new HoodieDefaultTimeline(filterInstantsByAction(SAVEPOINT_ACTION),
+        (Function<HoodieInstant, Optional<byte[]>> & Serializable) this::getInstantDetails);
+  }
+
+  /**
+   * Get only the restore action (inflight and completed) in the active timeline
+   */
+  public HoodieTimeline getRestoreTimeline() {
+    return new HoodieDefaultTimeline(filterInstantsByAction(RESTORE_ACTION),
         (Function<HoodieInstant, Optional<byte[]>> & Serializable) this::getInstantDetails);
   }
 

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/table/timeline/HoodieInstant.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/table/timeline/HoodieInstant.java
@@ -131,6 +131,9 @@ public class HoodieInstant implements Serializable {
       } else {
         return HoodieTimeline.makeCommitFileName(timestamp);
       }
+    } else if (HoodieTimeline.RESTORE_ACTION.equals(action)) {
+      return isInflight() ? HoodieTimeline.makeInflightRestoreFileName(timestamp)
+          : HoodieTimeline.makeRestoreFileName(timestamp);
     }
     throw new IllegalArgumentException("Cannot get file name for unknown action " + action);
   }

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/util/FSUtils.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/util/FSUtils.java
@@ -398,6 +398,20 @@ public class FSUtils {
     });
   }
 
+  public static void deleteOlderRestoreMetaFiles(FileSystem fs, String metaPath,
+      Stream<HoodieInstant> instants) {
+    //TODO - this should be archived when archival is made general for all meta-data
+    // skip MIN_ROLLBACK_TO_KEEP and delete rest
+    instants.skip(MIN_ROLLBACK_TO_KEEP).map(s -> {
+      try {
+        return fs.delete(new Path(metaPath, s.getFileName()), false);
+      } catch (IOException e) {
+        throw new HoodieIOException(
+            "Could not delete restore meta files " + s.getFileName(), e);
+      }
+    });
+  }
+
   public static void createPathIfNotExists(FileSystem fs, Path partitionPath) throws IOException {
     if (!fs.exists(partitionPath)) {
       fs.mkdirs(partitionPath);


### PR DESCRIPTION
This PR allows for clients to perform nested/multiple rollbacks on MOR dataset. As a part of this PR, I would like for us to start a conversation around either keeping the client.rollback() API and supporting it going forward or deprecating the same. Let's share our thoughts on this. Personally, I feel that HUDI is used for storing large datasets. For a client to be able to implement recovery techniques, for example snapshot copy the entire dataset once in a while and then back it up might be very expensive. Either we support rollback (this is needed basically in case data corruption happens) or we as clients to incrementally read the dataset and keep backing up the incremental parts. This way, the snapshot copy is now a incremental copy and is fast at the same time if they ended up backing a corrupted file, they can just drop the last incremental backup and reingest all that data. The big con I see with this approach is that if you want to do this process for all your datasets, this would double the storage costs of any org which seems very inefficient.