### PR TITLE
 [HUDI-61] Remove payload class dependency in SpillableMap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,8 @@ local.properties
 # Maven
 #######################################
 dependency-reduced-pom.xml
+
+#######################################
+#     Integ Testing specific files    #
+#######################################
+hoodie-integ-test/compose_env

--- a/hoodie-client/src/test/java/com/uber/hoodie/common/TestRawTripPayload.java
+++ b/hoodie-client/src/test/java/com/uber/hoodie/common/TestRawTripPayload.java
@@ -43,13 +43,17 @@ import org.apache.commons.io.IOUtils;
  */
 public class TestRawTripPayload implements HoodieRecordPayload<TestRawTripPayload> {
 
+  private static final long serialVersionUID = 3741429564025630707L;
   private static final transient ObjectMapper mapper = new ObjectMapper();
   private String partitionPath;
   private String rowKey;
   private byte[] jsonDataCompressed;
   private int dataSize;
   private boolean isDeleted;
-
+  
+  // To be used only for serialization
+  public TestRawTripPayload() {}
+  
   public TestRawTripPayload(Optional<String> jsonData, String rowKey, String partitionPath, String schemaStr,
       Boolean isDeleted) throws IOException {
     if (jsonData.isPresent()) {
@@ -190,5 +194,15 @@ public class TestRawTripPayload implements HoodieRecordPayload<TestRawTripPayloa
     private Map<String, String> getMergedMetadataMap() {
       return mergedMetadataMap;
     }
+  }
+
+  @Override
+  public byte[] getBytes() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public TestRawTripPayload fromBytes(byte[] bytes) {
+    throw new UnsupportedOperationException();
   }
 }

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/HoodieJsonPayload.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/HoodieJsonPayload.java
@@ -35,9 +35,13 @@ import org.apache.commons.io.IOUtils;
 
 public class HoodieJsonPayload implements HoodieRecordPayload<HoodieJsonPayload> {
 
+  private static final long serialVersionUID = 4150623342458636396L;
   private byte[] jsonDataCompressed;
   private int dataSize;
 
+  // To be used only for serialization
+  public HoodieJsonPayload() {}
+  
   public HoodieJsonPayload(String json) throws IOException {
     this.jsonDataCompressed = compressData(json);
     this.dataSize = json.length();
@@ -107,5 +111,16 @@ public class HoodieJsonPayload implements HoodieRecordPayload<HoodieJsonPayload>
 
   public String getPartitionPath(String partitionPathField) throws IOException {
     return getFieldFromJsonOrFail(partitionPathField);
+  }
+
+  @Override
+  public byte[] getBytes() {
+    return jsonDataCompressed;
+  }
+
+  @Override
+  public HoodieJsonPayload fromBytes(byte[] bytes) {
+    this.jsonDataCompressed = bytes;
+    return this;
   }
 }

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/model/HoodieAvroPayload.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/model/HoodieAvroPayload.java
@@ -30,9 +30,18 @@ import org.apache.avro.generic.IndexedRecord;
  */
 public class HoodieAvroPayload implements HoodieRecordPayload<HoodieAvroPayload> {
 
-  // Store the GenericRecord converted to bytes - 1) Doesn't store schema hence memory efficient 2) Makes the payload
-  // java serializable
-  private final byte [] recordBytes;
+  private static final long serialVersionUID = -505257251712222212L;
+  /**
+   * Store the GenericRecord converted to bytes
+   * <ol>
+   * <li>Doesn't store schema hence memory efficient</li>
+   * <li>Makes the payload java serializable</li>
+   * </ol>
+   */
+  private byte[] recordBytes;
+
+  // To be used only for serialization
+  public HoodieAvroPayload() {}
 
   public HoodieAvroPayload(Optional<GenericRecord> record) {
     try {
@@ -63,5 +72,16 @@ public class HoodieAvroPayload implements HoodieRecordPayload<HoodieAvroPayload>
       return Optional.empty();
     }
     return Optional.of(HoodieAvroUtils.bytesToAvro(recordBytes, schema));
+  }
+
+  @Override
+  public HoodieAvroPayload fromBytes(byte[] bytes) {
+    this.recordBytes = bytes;
+    return this;
+  }
+
+  @Override
+  public byte[] getBytes() {
+    return this.recordBytes;
   }
 }

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/model/HoodieRecordPayload.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/model/HoodieRecordPayload.java
@@ -24,10 +24,12 @@ import org.apache.avro.Schema;
 import org.apache.avro.generic.IndexedRecord;
 
 /**
- * Every Hoodie dataset has an implementation of the <code>HoodieRecordPayload</code> This abstracts
- * out callbacks which depend on record specific logic
+ * Every Hoodie dataset has an implementation of the <code>HoodieRecordPayload</code>.
+ * <p>
+ * This abstracts out callbacks which depend on record specific logic
+ * </p>
  */
-public interface HoodieRecordPayload<T extends HoodieRecordPayload> extends Serializable {
+public interface HoodieRecordPayload<T extends HoodieRecordPayload<T>> extends Serializable {
 
   /**
    * When more than one HoodieRecord have the same HoodieKey, this function combines them before
@@ -67,4 +69,20 @@ public interface HoodieRecordPayload<T extends HoodieRecordPayload> extends Seri
   default Optional<Map<String, String>> getMetadata() {
     return Optional.empty();
   }
+  
+  /**
+   * This method is used to serialize the {@link HoodieRecordPayload} into byte array
+   * 
+   * @return The serialized data in the form of byte array
+   */
+  byte[] getBytes();
+  
+  /**
+   * This method is used to construct the {@link HoodieRecordPayload} back from the serialized byte
+   * array
+   * 
+   * @param bytes The serialized data in the form of byte array
+   * @return The instance of {@link HoodieRecordPayload} from the serialized data
+   */
+  T fromBytes(byte[] bytes);
 }

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/util/ReflectionUtils.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/util/ReflectionUtils.java
@@ -51,17 +51,22 @@ public class ReflectionUtils {
     }
   }
 
+
   /**
-   * Instantiate a given class with a generic record payload
+   * Method to instantiate the payload class
+   * 
+   * @param recordPayloadClass The class to be instantiated
+   * @param recordBytes The serialized byte array of the class
+   * @return The object of instance recordPayloadClass
    */
-  public static <T extends HoodieRecordPayload> T loadPayload(String recordPayloadClass,
-      Object[] payloadArgs,
-      Class<?>... constructorArgTypes) {
+  public static <T extends HoodieRecordPayload<T>> T loadPayload(String recordPayloadClass,
+      byte[] recordBytes) {
     try {
-      return (T) getClass(recordPayloadClass).getConstructor(constructorArgTypes)
-          .newInstance(payloadArgs);
-    } catch (InstantiationException | IllegalAccessException
-        | InvocationTargetException | NoSuchMethodException e) {
+      Class<?> clazz = getClass(recordPayloadClass);
+      T newInstance = (T) clazz.newInstance();
+      newInstance.fromBytes(recordBytes);
+      return newInstance;
+    } catch (InstantiationException | IllegalAccessException e) {
       throw new HoodieException("Unable to instantiate payload class ", e);
     }
   }

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/util/SpillableMapUtils.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/util/SpillableMapUtils.java
@@ -24,7 +24,6 @@ import com.uber.hoodie.common.util.collection.io.storage.SizeAwareDataOutputStre
 import com.uber.hoodie.exception.HoodieCorruptedDataException;
 import java.io.IOException;
 import java.io.RandomAccessFile;
-import java.util.Optional;
 import java.util.zip.CRC32;
 import org.apache.avro.generic.GenericRecord;
 
@@ -105,7 +104,7 @@ public class SpillableMapUtils {
   /**
    * Utility method to convert bytes to HoodieRecord using schema and payload class
    */
-  public static <R> R convertToHoodieRecordPayload(GenericRecord rec, String payloadClazz) {
+  public static <R> R convertToHoodieRecordPayload(GenericRecord rec, String payloadClazz) throws IOException {
     String recKey = rec.get(HoodieRecord.RECORD_KEY_METADATA_FIELD)
         .toString();
     String partitionPath =
@@ -114,7 +113,7 @@ public class SpillableMapUtils {
     HoodieRecord<? extends HoodieRecordPayload> hoodieRecord = new HoodieRecord<>(
         new HoodieKey(recKey, partitionPath),
         ReflectionUtils
-            .loadPayload(payloadClazz, new Object[]{Optional.of(rec)}, Optional.class));
+            .loadPayload(payloadClazz, HoodieAvroUtils.avroToBytes(rec)));
     return (R) hoodieRecord;
   }
 
@@ -125,7 +124,7 @@ public class SpillableMapUtils {
     HoodieRecord<? extends HoodieRecordPayload> hoodieRecord = new HoodieRecord<>(
         new HoodieKey(recKey, partitionPath),
         ReflectionUtils
-            .loadPayload(payloadClazz, new Object[]{Optional.empty()}, Optional.class));
+            .loadPayload(payloadClazz, new byte[0]));
     return (R) hoodieRecord;
   }
 }

--- a/hoodie-common/src/test/java/com/uber/hoodie/common/model/AvroBinaryTestPayload.java
+++ b/hoodie-common/src/test/java/com/uber/hoodie/common/model/AvroBinaryTestPayload.java
@@ -24,10 +24,14 @@ import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.IndexedRecord;
 
-public class AvroBinaryTestPayload implements HoodieRecordPayload {
+public class AvroBinaryTestPayload implements HoodieRecordPayload<AvroBinaryTestPayload> {
 
-  private final byte[] recordBytes;
+  private static final long serialVersionUID = -8165368650526698179L;
+  private byte[] recordBytes;
 
+  // To be used only for serialization
+  public AvroBinaryTestPayload() {}
+  
   public AvroBinaryTestPayload(Optional<GenericRecord> record) {
 
     try {
@@ -42,7 +46,7 @@ public class AvroBinaryTestPayload implements HoodieRecordPayload {
   }
 
   @Override
-  public HoodieRecordPayload preCombine(HoodieRecordPayload another) {
+  public AvroBinaryTestPayload preCombine(AvroBinaryTestPayload another) {
     return this;
   }
 
@@ -55,5 +59,16 @@ public class AvroBinaryTestPayload implements HoodieRecordPayload {
   @Override
   public Optional<IndexedRecord> getInsertValue(Schema schema) throws IOException {
     return Optional.of(HoodieAvroUtils.bytesToAvro(recordBytes, schema));
+  }
+
+  @Override
+  public AvroBinaryTestPayload fromBytes(byte[] bytes) {
+    this.recordBytes = bytes;
+    return this;
+  }
+
+  @Override
+  public byte[] getBytes() {
+    return this.recordBytes;
   }
 }

--- a/hoodie-spark/src/main/java/com/uber/hoodie/OverwriteWithLatestAvroPayload.java
+++ b/hoodie-spark/src/main/java/com/uber/hoodie/OverwriteWithLatestAvroPayload.java
@@ -35,6 +35,8 @@ import org.apache.avro.generic.IndexedRecord;
 public class OverwriteWithLatestAvroPayload extends BaseAvroPayload implements
     HoodieRecordPayload<OverwriteWithLatestAvroPayload> {
 
+  private static final long serialVersionUID = 1441789303785114865L;
+
   /**
    * @param record
    * @param orderingVal
@@ -67,5 +69,15 @@ public class OverwriteWithLatestAvroPayload extends BaseAvroPayload implements
   @Override
   public Optional<IndexedRecord> getInsertValue(Schema schema) throws IOException {
     return Optional.of(HoodieAvroUtils.bytesToAvro(recordBytes, schema));
+  }
+
+  @Override
+  public byte[] getBytes() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public OverwriteWithLatestAvroPayload fromBytes(byte[] bytes) {
+    throw new UnsupportedOperationException();
   }
 }


### PR DESCRIPTION
* Parameterized HoodieRecordPayload with recursive type T
* Added getBytes and fromBytes in HoodieRecordPayload Interface
* The payload class instantiation changed from GenericRecord to bytes
* Added generated serialization ID for the classes changed in this diff