### PR TITLE
FIXES HUDI-98: Fix multiple issues when using build_local_docker_images for demo setup

### DIFF
--- a/docker/hoodie/hadoop/base/Dockerfile
+++ b/docker/hoodie/hadoop/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM frolvlad/alpine-oraclejdk8
+FROM frolvlad/alpine-java
 MAINTAINER Hoodie
 USER root
 

--- a/docker/hoodie/hadoop/spark_base/Dockerfile
+++ b/docker/hoodie/hadoop/spark_base/Dockerfile
@@ -17,7 +17,7 @@ COPY execute-step.sh /
 COPY finish-step.sh /
 
 RUN echo "Installing Spark-version (${SPARK_VERSION})" \
-      &&  wget http://apache.mirror.iphh.net/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz \
+      &&  wget http://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz \
       && tar -xvzf spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz \
       && mv spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION} /opt/spark \
       && rm spark-${SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz \

--- a/hoodie-utilities/pom.xml
+++ b/hoodie-utilities/pom.xml
@@ -82,6 +82,7 @@
                   <include>org.apache.hive:hive-metastore</include>
                   <include>org.apache.hive:hive-jdbc</include>
                   <include>com.twitter:chill_2.11</include>
+                  <include>com.twitter:chill-java</include>
                 </includes>
               </artifactSet>
               <relocations>

--- a/packaging/hoodie-hadoop-mr-bundle/pom.xml
+++ b/packaging/hoodie-hadoop-mr-bundle/pom.xml
@@ -145,12 +145,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.esotericsoftware</groupId>
-      <artifactId>kryo</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>
@@ -216,6 +210,8 @@
                   <include>com.twitter.common:objectsize</include>
                   <include>commons-logging:commons-logging</include>
                   <include>com.twitter:chill_2.11</include>
+                  <include>com.twitter:chill-java</include>
+                  <include>com.esotericsoftware:kryo-shaded</include>
                 </includes>
               </artifactSet>
               <finalName>${project.artifactId}-${project.version}</finalName>


### PR DESCRIPTION
Issue - https://issues.apache.org/jira/browse/HUDI-98

The build local docker images is broken due to some issues like:

frolvlad/alpine-oraclejdk8 image does not exist
The url link for downloading spark fails
packing issues causing noclassdef error for - com.esotericsoftware.kryo.Kryo, com.uber.hoodie.com.twitter.chill.KryoInstantiator