### PR TITLE
Read and apply schema for each log block from the metadata header instead of the latest schema

### DIFF
--- a/hoodie-common/src/main/java/com/uber/hoodie/common/table/log/HoodieLogFileReader.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/table/log/HoodieLogFileReader.java
@@ -197,12 +197,17 @@ class HoodieLogFileReader implements HoodieLogFormat.Reader {
     switch (blockType) {
       // based on type read the block
       case AVRO_DATA_BLOCK:
+        Schema readerSchemaForBlock = readerSchema;
+        if (header != null) {
+          String schema = header.get(HeaderMetadataType.SCHEMA);
+          readerSchemaForBlock = schema != null ? new Schema.Parser().parse(schema) : readerSchema;
+        }
         if (nextBlockVersion.getVersion() == HoodieLogFormatVersion.DEFAULT_VERSION) {
-          return HoodieAvroDataBlock.getBlock(content, readerSchema);
+          return HoodieAvroDataBlock.getBlock(content, readerSchemaForBlock);
         } else {
           return HoodieAvroDataBlock
               .getBlock(logFile, inputStream, Optional.ofNullable(content), readBlockLazily,
-                  contentPosition, contentLength, blockEndPos, readerSchema, header, footer);
+                  contentPosition, contentLength, blockEndPos, readerSchemaForBlock, header, footer);
         }
       case DELETE_BLOCK:
         return HoodieDeleteBlock


### PR DESCRIPTION
This is a bug fix. Ideally, during a schema evolution, fields should get added to the end of the schema and hence not requiring the exact same schema for decoding, but in certain cases, the new entry gets added to the middle of the schema which fails decoding if written with a previous version and decoded with the new version. 

Example exception : 

```
org.apache.avro.AvroTypeException: Found union, expecting union, missing required field NEW_FIELD_THAT_WAS_ADDED
	at org.apache.avro.io.ResolvingDecoder.doAction(ResolvingDecoder.java:292)
	at org.apache.avro.io.parsing.Parser.advance(Parser.java:88)
	at org.apache.avro.io.ResolvingDecoder.readFieldOrder(ResolvingDecoder.java:130)
	at org.apache.avro.generic.GenericDatumReader.readRecord(GenericDatumReader.java:176)
	at org.apache.avro.generic.GenericDatumReader.read(GenericDatumReader.java:151)
	at org.apache.avro.generic.GenericDatumReader.read(GenericDatumReader.java:142)
	at com.uber.hoodie.common.table.log.block.HoodieAvroDataBlock.createRecordsFromContentBytes(HoodieAvroDataBlock.java:206)
	at com.uber.hoodie.common.table.log.block.HoodieAvroDataBlock.getRecords(HoodieAvroDataBlock.java:151)
	at com.uber.hoodie.common.table.log.AbstractHoodieLogRecordScanner.processAvroDataBlock(AbstractHoodieLogRecordScanner.java:261)
	at com.uber.hoodie.common.table.log.AbstractHoodieLogRecordScanner.processQueuedBlocksForInstant(AbstractHoodieLogRecordScanner.java:296)
	at com.uber.hoodie.common.table.log.AbstractHoodieLogRecordScanner.scan(AbstractHoodieLogRecordScanner.java:235)
	at com.uber.hoodie.common.table.log.HoodieMergedLogRecordScanner.<init>(HoodieMergedLogRecordScanner.java:78)
	at com.uber.hoodie.io.compact.HoodieRealtimeTableCompactor.compact(HoodieRealtimeTableCompactor.java:136)
	at com.uber.hoodie.io.compact.HoodieRealtimeTableCompactor.lambda$null$ec1b96ba$1(HoodieRealtimeTableCompactor.java:100)
	at org.apache.spark.api.java.JavaPairRDD$$anonfun$toScalaFunction$1.apply(JavaPairRDD.scala:1040)
	at scala.collection.Iterator$$anon$11.next(Iterator.scala:409)
	at scala.collection.Iterator$$anon$12.nextCur(Iterator.scala:434)
	at scala.collection.Iterator$$anon$12.hasNext(Iterator.scala:440)
	at scala.collection.Iterator$$anon$12.hasNext(Iterator.scala:438)
	at org.apache.spark.storage.memory.MemoryStore.putIteratorAsBytes(MemoryStore.scala:363)
	at org.apache.spark.storage.BlockManager$$anonfun$doPutIterator$1.apply(BlockManager.scala:973)
	at org.apache.spark.storage.BlockManager$$anonfun$doPutIterator$1.apply(BlockManager.scala:948)
	at org.apache.spark.storage.BlockManager.doPut(BlockManager.scala:888)
	at org.apache.spark.storage.BlockManager.doPutIterator(BlockManager.scala:948)
	at org.apache.spark.storage.BlockManager.getOrElseUpdate(BlockManager.scala:694)
	at org.apache.spark.rdd.RDD.getOrCompute(RDD.scala:334)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:285)
	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:38)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:323)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:287)
	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:87)
	at org.apache.spark.scheduler.Task.run(Task.scala:99)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:282)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
```