### PR TITLE
Add scala and kryo dependencies to hadoop bundle to fix HUDI-99

### DIFF
--- a/packaging/hoodie-hadoop-mr-bundle/pom.xml
+++ b/packaging/hoodie-hadoop-mr-bundle/pom.xml
@@ -119,6 +119,11 @@
     </dependency>
 
     <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-avro</artifactId>
     </dependency>
@@ -148,6 +153,30 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <!-- Needs to be bundled as this is not available in sys classpath for HiveServer !-->
+      <groupId>com.esotericsoftware</groupId>
+      <artifactId>kryo-shaded</artifactId>
+      <version>${kryo.version}</version>
+    </dependency>
+
+    <dependency>
+      <!-- Needs to be bundled as this is not available in sys classpath for HiveServer !-->
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+      <version>${scala.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.esotericsoftware</groupId>
+      <artifactId>minlog</artifactId>
+      <version>1.3.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.objenesis</groupId>
+      <artifactId>objenesis</artifactId>
+      <version>2.5.1</version>
     </dependency>
   </dependencies>
 
@@ -208,10 +237,14 @@
                   <include>com.twitter:parquet-avro</include>
                   <include>com.twitter:parquet-hadoop-bundle</include>
                   <include>com.twitter.common:objectsize</include>
+                  <include>commons-io:commons-io</include>
                   <include>commons-logging:commons-logging</include>
                   <include>com.twitter:chill_2.11</include>
                   <include>com.twitter:chill-java</include>
+                  <include>org.scala-lang:scala-library</include>
+                  <include>com.esotericsoftware:minlog</include>
                   <include>com.esotericsoftware:kryo-shaded</include>
+                  <include>org.objenesis:objenesis</include>
                 </includes>
               </artifactSet>
               <finalName>${project.artifactId}-${project.version}</finalName>

--- a/packaging/hoodie-presto-bundle/pom.xml
+++ b/packaging/hoodie-presto-bundle/pom.xml
@@ -105,6 +105,13 @@
       <artifactId>hoodie-hadoop-mr-bundle</artifactId>
       <version>${project.version}</version>
     </dependency>
+
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+      <version>${scala.version}</version>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,7 @@
     <fasterxml.version>2.8.11</fasterxml.version>
     <parquet.version>1.8.1</parquet.version>
     <junit.version>4.11</junit.version>
+    <kryo.version>4.0.0</kryo.version>
     <mockito.version>1.9.5</mockito.version>
     <log4j.version>1.2.17</log4j.version>
     <joda.version>2.9.9</joda.version>
@@ -720,7 +721,7 @@
         <!--Used to test execution in task executor after de-serializing-->
         <groupId>com.esotericsoftware</groupId>
         <artifactId>kryo</artifactId>
-        <version>4.0.0</version>
+        <version>${kryo.version}</version>
         <scope>test</scope>
       </dependency>
     </dependencies>


### PR DESCRIPTION
Hoodie Hadoop bundle now requires scala and other related dependencies with new changes to include kryo-serializer.

Hoodie Hadoop bundle is used in a non-spark context (e.g : Hive Server). We need to include scala and kryo dependencies as they are not provided by default .