### PR TITLE
Move to apachehudi dockerhub repository & use openjdk docker containers

### DIFF
--- a/docker/compose/docker-compose_hadoop284_hive233_spark231.yml
+++ b/docker/compose/docker-compose_hadoop284_hive233_spark231.yml
@@ -3,7 +3,7 @@ version: "3.3"
 services:
 
   namenode:
-    image: varadarb/hudi-hadoop_2.8.4-namenode:latest
+    image: apachehudi/hudi-hadoop_2.8.4-namenode:latest
     hostname: namenode
     container_name: namenode
     volumes:
@@ -22,7 +22,7 @@ services:
       retries: 3
  
   datanode1:
-    image: varadarb/hudi-hadoop_2.8.4-datanode:latest
+    image: apachehudi/hudi-hadoop_2.8.4-datanode:latest
     container_name: datanode1
     hostname: datanode1
     environment:
@@ -46,7 +46,7 @@ services:
       - /tmp/hadoop_data:/hadoop/dfs/data
 
   historyserver:
-    image: varadarb/hudi-hadoop_2.8.4-history:latest
+    image: apachehudi/hudi-hadoop_2.8.4-history:latest
     hostname: historyserver
     container_name: historyserver
     environment:
@@ -75,7 +75,7 @@ services:
     container_name: hive-metastore-postgresql
  
   hivemetastore:
-    image: varadarb/hudi-hadoop_2.8.4-hive_2.3.3:latest
+    image: apachehudi/hudi-hadoop_2.8.4-hive_2.3.3:latest
     hostname: hivemetastore
     container_name: hivemetastore
     links:
@@ -98,7 +98,7 @@ services:
       - "namenode"
 
   hiveserver:
-    image: varadarb/hudi-hadoop_2.8.4-hive_2.3.3:latest
+    image: apachehudi/hudi-hadoop_2.8.4-hive_2.3.3:latest
     hostname: hiveserver
     container_name: hiveserver
     env_file:
@@ -117,7 +117,7 @@ services:
       - ${HUDI_WS}:/var/hoodie/ws
 
   sparkmaster:
-    image: varadarb/hudi-hadoop_2.8.4-hive_2.3.3-sparkmaster_2.3.1:latest
+    image: apachehudi/hudi-hadoop_2.8.4-hive_2.3.3-sparkmaster_2.3.1:latest
     hostname: sparkmaster
     container_name: sparkmaster
     env_file:
@@ -134,7 +134,7 @@ services:
       - "namenode"
 
   spark-worker-1:
-    image: varadarb/hudi-hadoop_2.8.4-hive_2.3.3-sparkworker_2.3.1:latest
+    image: apachehudi/hudi-hadoop_2.8.4-hive_2.3.3-sparkworker_2.3.1:latest
     hostname: spark-worker-1
     container_name: spark-worker-1
     env_file:
@@ -171,7 +171,7 @@ services:
       - ALLOW_PLAINTEXT_LISTENER=yes
 
   adhoc-1:
-    image: varadarb/hudi-hadoop_2.8.4-hive_2.3.3-sparkadhoc_2.3.1:latest
+    image: apachehudi/hudi-hadoop_2.8.4-hive_2.3.3-sparkadhoc_2.3.1:latest
     hostname: adhoc-1
     container_name: adhoc-1
     env_file:
@@ -191,7 +191,7 @@ services:
       - ${HUDI_WS}:/var/hoodie/ws
 
   adhoc-2:
-    image: varadarb/hudi-hadoop_2.8.4-hive_2.3.3-sparkadhoc_2.3.1:latest
+    image: apachehudi/hudi-hadoop_2.8.4-hive_2.3.3-sparkadhoc_2.3.1:latest
     hostname: adhoc-2
     container_name: adhoc-2
     env_file:

--- a/docker/hoodie/hadoop/base/Dockerfile
+++ b/docker/hoodie/hadoop/base/Dockerfile
@@ -1,12 +1,9 @@
-FROM frolvlad/alpine-java
+FROM openjdk:8u212-jdk-slim-stretch
 MAINTAINER Hoodie
 USER root
 
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
-
-# Updating & Installing packages
-RUN apk add net-tools curl bash perl procps
 
 ARG HADOOP_VERSION=2.8.4 
 ARG HADOOP_URL=https://www.apache.org/dist/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz
@@ -14,6 +11,7 @@ ENV HADOOP_VERSION ${HADOOP_VERSION}
 ENV HADOOP_URL ${HADOOP_URL}
 
 RUN set -x \
+    && DEBIAN_FRONTEND=noninteractive apt-get -yq update && apt-get -yq install curl wget netcat procps \
     && echo "Fetch URL2 is : ${HADOOP_URL}" \
     && curl -fSL "${HADOOP_URL}" -o /tmp/hadoop.tar.gz \
     && curl -fSL "${HADOOP_URL}.asc" -o /tmp/hadoop.tar.gz.asc \

--- a/docker/hoodie/hadoop/base/pom.xml
+++ b/docker/hoodie/hadoop/base/pom.xml
@@ -62,7 +62,7 @@
             <configuration>
               <skip>${docker.build.skip}</skip>
               <pullNewerImage>false</pullNewerImage>
-              <repository>varadarb/hudi-hadoop_${docker.hadoop.version}-base</repository>
+              <repository>apachehudi/hudi-hadoop_${docker.hadoop.version}-base</repository>
               <forceTags>true</forceTags>
               <tag>latest</tag>
             </configuration>
@@ -78,7 +78,7 @@
             <configuration>
               <skip>${docker.build.skip}</skip>
               <pullNewerImage>false</pullNewerImage>
-              <repository>varadarb/hudi-hadoop_${docker.hadoop.version}-base</repository>
+              <repository>apachehudi/hudi-hadoop_${docker.hadoop.version}-base</repository>
               <forceTags>true</forceTags>
               <tag>${project.version}</tag>
             </configuration>

--- a/docker/hoodie/hadoop/datanode/Dockerfile
+++ b/docker/hoodie/hadoop/datanode/Dockerfile
@@ -1,6 +1,6 @@
 ARG HADOOP_VERSION=2.8.4 
 ARG HADOOP_DN_PORT=50075
-FROM varadarb/hudi-hadoop_${HADOOP_VERSION}-base:latest
+FROM apachehudi/hudi-hadoop_${HADOOP_VERSION}-base:latest
 
 ENV HADOOP_DN_PORT ${HADOOP_DN_PORT}
 

--- a/docker/hoodie/hadoop/datanode/pom.xml
+++ b/docker/hoodie/hadoop/datanode/pom.xml
@@ -61,7 +61,7 @@
             <configuration>
               <skip>${docker.build.skip}</skip>
               <pullNewerImage>false</pullNewerImage>
-              <repository>varadarb/hudi-hadoop_${docker.hadoop.version}-datanode</repository>
+              <repository>apachehudi/hudi-hadoop_${docker.hadoop.version}-datanode</repository>
               <forceTags>true</forceTags>
               <tag>latest</tag>
             </configuration>
@@ -77,7 +77,7 @@
             <configuration>
               <skip>${docker.build.skip}</skip>
               <pullNewerImage>false</pullNewerImage>
-              <repository>varadarb/hudi-hadoop_${docker.hadoop.version}-datanode</repository>
+              <repository>apachehudi/hudi-hadoop_${docker.hadoop.version}-datanode</repository>
               <forceTags>true</forceTags>
               <tag>${project.version}</tag>
             </configuration>

--- a/docker/hoodie/hadoop/historyserver/Dockerfile
+++ b/docker/hoodie/hadoop/historyserver/Dockerfile
@@ -1,6 +1,6 @@
 ARG HADOOP_VERSION=2.8.4 
 ARG HADOOP_HISTORY_PORT=8188
-FROM varadarb/hudi-hadoop_${HADOOP_VERSION}-base:latest
+FROM apachehudi/hudi-hadoop_${HADOOP_VERSION}-base:latest
 
 ENV HADOOP_HISTORY_PORT ${HADOOP_HISTORY_PORT}
 

--- a/docker/hoodie/hadoop/historyserver/pom.xml
+++ b/docker/hoodie/hadoop/historyserver/pom.xml
@@ -61,7 +61,7 @@
             <configuration>
               <skip>${docker.build.skip}</skip>
               <pullNewerImage>false</pullNewerImage>
-              <repository>varadarb/hudi-hadoop_${docker.hadoop.version}-history</repository>
+              <repository>apachehudi/hudi-hadoop_${docker.hadoop.version}-history</repository>
               <forceTags>true</forceTags>
               <tag>latest</tag>
             </configuration>
@@ -77,7 +77,7 @@
             <configuration>
               <skip>${docker.build.skip}</skip>
               <pullNewerImage>false</pullNewerImage>
-              <repository>varadarb/hudi-hadoop_${docker.hadoop.version}-history</repository>
+              <repository>apachehudi/hudi-hadoop_${docker.hadoop.version}-history</repository>
               <forceTags>true</forceTags>
               <tag>${project.version}</tag>
             </configuration>

--- a/docker/hoodie/hadoop/hive_base/Dockerfile
+++ b/docker/hoodie/hadoop/hive_base/Dockerfile
@@ -1,5 +1,5 @@
 ARG HADOOP_VERSION=2.8.4 
-FROM varadarb/hudi-hadoop_${HADOOP_VERSION}-base:latest
+FROM apachehudi/hudi-hadoop_${HADOOP_VERSION}-base:latest
 
 ENV HIVE_HOME /opt/hive
 ENV PATH $HIVE_HOME/bin:$PATH

--- a/docker/hoodie/hadoop/hive_base/pom.xml
+++ b/docker/hoodie/hadoop/hive_base/pom.xml
@@ -81,7 +81,7 @@
             <configuration>
               <skip>${docker.build.skip}</skip>
               <pullNewerImage>false</pullNewerImage>
-              <repository>varadarb/hudi-hadoop_${docker.hadoop.version}-hive_${docker.hive.version}</repository>
+              <repository>apachehudi/hudi-hadoop_${docker.hadoop.version}-hive_${docker.hive.version}</repository>
               <forceTags>true</forceTags>
               <tag>latest</tag>
             </configuration>
@@ -97,7 +97,7 @@
             <configuration>
               <skip>${docker.build.skip}</skip>
               <pullNewerImage>false</pullNewerImage>
-              <repository>varadarb/hudi-hadoop_${docker.hadoop.version}-hive_${docker.hive.version}</repository>
+              <repository>apachehudi/hudi-hadoop_${docker.hadoop.version}-hive_${docker.hive.version}</repository>
               <forceTags>true</forceTags>
               <tag>${project.version}</tag>
             </configuration>

--- a/docker/hoodie/hadoop/namenode/Dockerfile
+++ b/docker/hoodie/hadoop/namenode/Dockerfile
@@ -1,6 +1,6 @@
 ARG HADOOP_VERSION=2.8.4 
 ARG HADOOP_WEBHDFS_PORT=50070
-FROM varadarb/hudi-hadoop_${HADOOP_VERSION}-base:latest
+FROM apachehudi/hudi-hadoop_${HADOOP_VERSION}-base:latest
 
 ENV HADOOP_WEBHDFS_PORT ${HADOOP_WEBHDFS_PORT}
 

--- a/docker/hoodie/hadoop/namenode/pom.xml
+++ b/docker/hoodie/hadoop/namenode/pom.xml
@@ -61,7 +61,7 @@
             <configuration>
               <skip>${docker.build.skip}</skip>
               <pullNewerImage>false</pullNewerImage>
-              <repository>varadarb/hudi-hadoop_${docker.hadoop.version}-namenode</repository>
+              <repository>apachehudi/hudi-hadoop_${docker.hadoop.version}-namenode</repository>
               <forceTags>true</forceTags>
               <tag>latest</tag>
             </configuration>
@@ -77,7 +77,7 @@
             <configuration>
               <skip>${docker.build.skip}</skip>
               <pullNewerImage>false</pullNewerImage>
-              <repository>varadarb/hudi-hadoop_${docker.hadoop.version}-namenode</repository>
+              <repository>apachehudi/hudi-hadoop_${docker.hadoop.version}-namenode</repository>
               <forceTags>true</forceTags>
               <tag>${project.version}</tag>
             </configuration>

--- a/docker/hoodie/hadoop/spark_base/Dockerfile
+++ b/docker/hoodie/hadoop/spark_base/Dockerfile
@@ -1,6 +1,6 @@
 ARG HADOOP_VERSION=2.8.4 
 ARG HIVE_VERSION=2.3.3
-FROM varadarb/hudi-hadoop_${HADOOP_VERSION}-hive_${HIVE_VERSION}
+FROM apachehudi/hudi-hadoop_${HADOOP_VERSION}-hive_${HIVE_VERSION}
 
 ENV ENABLE_INIT_DAEMON true
 ENV INIT_DAEMON_BASE_URI http://identifier/init-daemon

--- a/docker/hoodie/hadoop/spark_base/pom.xml
+++ b/docker/hoodie/hadoop/spark_base/pom.xml
@@ -61,7 +61,7 @@
             <configuration>
               <skip>${docker.build.skip}</skip>
               <pullNewerImage>false</pullNewerImage>
-              <repository>varadarb/hudi-hadoop_${docker.hadoop.version}-hive_${docker.hive.version}-sparkbase_${docker.spark.version}</repository>
+              <repository>apachehudi/hudi-hadoop_${docker.hadoop.version}-hive_${docker.hive.version}-sparkbase_${docker.spark.version}</repository>
               <forceTags>true</forceTags>
               <tag>latest</tag>
             </configuration>
@@ -77,7 +77,7 @@
             <configuration>
               <skip>${docker.build.skip}</skip>
               <pullNewerImage>false</pullNewerImage>
-              <repository>varadarb/hudi-hadoop_${docker.hadoop.version}-hive_${docker.hive.version}-sparkbase_${docker.spark.version}</repository>
+              <repository>apachehudi/hudi-hadoop_${docker.hadoop.version}-hive_${docker.hive.version}-sparkbase_${docker.spark.version}</repository>
               <forceTags>true</forceTags>
               <tag>${project.version}</tag>
             </configuration>

--- a/docker/hoodie/hadoop/sparkadhoc/Dockerfile
+++ b/docker/hoodie/hadoop/sparkadhoc/Dockerfile
@@ -1,7 +1,7 @@
 ARG HADOOP_VERSION=2.8.4 
 ARG HIVE_VERSION=2.3.3
 ARG SPARK_VERSION=2.3.1
-FROM varadarb/hudi-hadoop_${HADOOP_VERSION}-hive_${HIVE_VERSION}-sparkbase_${SPARK_VERSION}
+FROM apachehudi/hudi-hadoop_${HADOOP_VERSION}-hive_${HIVE_VERSION}-sparkbase_${SPARK_VERSION}
 
 COPY adhoc.sh /opt/spark
 

--- a/docker/hoodie/hadoop/sparkadhoc/pom.xml
+++ b/docker/hoodie/hadoop/sparkadhoc/pom.xml
@@ -61,7 +61,7 @@
             <configuration>
               <skip>${docker.build.skip}</skip>
               <pullNewerImage>false</pullNewerImage>
-              <repository>varadarb/hudi-hadoop_${docker.hadoop.version}-hive_${docker.hive.version}-sparkadhoc_${docker.spark.version}</repository>
+              <repository>apachehudi/hudi-hadoop_${docker.hadoop.version}-hive_${docker.hive.version}-sparkadhoc_${docker.spark.version}</repository>
               <forceTags>true</forceTags>
               <tag>latest</tag>
             </configuration>
@@ -77,7 +77,7 @@
             <configuration>
               <skip>${docker.build.skip}</skip>
               <pullNewerImage>false</pullNewerImage>
-              <repository>varadarb/hudi-hadoop_${docker.hadoop.version}-hive_${docker.hive.version}-sparkadhoc_${docker.spark.version}</repository>
+              <repository>apachehudi/hudi-hadoop_${docker.hadoop.version}-hive_${docker.hive.version}-sparkadhoc_${docker.spark.version}</repository>
               <forceTags>true</forceTags>
               <tag>${project.version}</tag>
             </configuration>

--- a/docker/hoodie/hadoop/sparkmaster/Dockerfile
+++ b/docker/hoodie/hadoop/sparkmaster/Dockerfile
@@ -1,7 +1,7 @@
 ARG HADOOP_VERSION=2.8.4 
 ARG HIVE_VERSION=2.3.3
 ARG SPARK_VERSION=2.3.1
-FROM varadarb/hudi-hadoop_${HADOOP_VERSION}-hive_${HIVE_VERSION}-sparkbase_${SPARK_VERSION}
+FROM apachehudi/hudi-hadoop_${HADOOP_VERSION}-hive_${HIVE_VERSION}-sparkbase_${SPARK_VERSION}
 
 COPY master.sh /opt/spark
 

--- a/docker/hoodie/hadoop/sparkmaster/pom.xml
+++ b/docker/hoodie/hadoop/sparkmaster/pom.xml
@@ -61,7 +61,7 @@
             <configuration>
               <skip>${docker.build.skip}</skip>
               <pullNewerImage>false</pullNewerImage>
-              <repository>varadarb/hudi-hadoop_${docker.hadoop.version}-hive_${docker.hive.version}-sparkmaster_${docker.spark.version}</repository>
+              <repository>apachehudi/hudi-hadoop_${docker.hadoop.version}-hive_${docker.hive.version}-sparkmaster_${docker.spark.version}</repository>
               <forceTags>true</forceTags>
               <tag>latest</tag>
             </configuration>
@@ -77,7 +77,7 @@
             <configuration>
               <skip>${docker.build.skip}</skip>
               <pullNewerImage>false</pullNewerImage>
-              <repository>varadarb/hudi-hadoop_${docker.hadoop.version}-hive_${docker.hive.version}-sparkmaster_${docker.spark.version}</repository>
+              <repository>apachehudi/hudi-hadoop_${docker.hadoop.version}-hive_${docker.hive.version}-sparkmaster_${docker.spark.version}</repository>
               <forceTags>true</forceTags>
               <tag>${project.version}</tag>
             </configuration>

--- a/docker/hoodie/hadoop/sparkworker/Dockerfile
+++ b/docker/hoodie/hadoop/sparkworker/Dockerfile
@@ -1,7 +1,7 @@
 ARG HADOOP_VERSION=2.8.4 
 ARG HIVE_VERSION=2.3.3
 ARG SPARK_VERSION=2.3.1
-FROM varadarb/hudi-hadoop_${HADOOP_VERSION}-hive_${HIVE_VERSION}-sparkbase_${SPARK_VERSION}
+FROM apachehudi/hudi-hadoop_${HADOOP_VERSION}-hive_${HIVE_VERSION}-sparkbase_${SPARK_VERSION}
 
 COPY worker.sh /opt/spark
 

--- a/docker/hoodie/hadoop/sparkworker/pom.xml
+++ b/docker/hoodie/hadoop/sparkworker/pom.xml
@@ -61,7 +61,7 @@
             <configuration>
               <skip>${docker.build.skip}</skip>
               <pullNewerImage>false</pullNewerImage>
-              <repository>varadarb/hudi-hadoop_${docker.hadoop.version}-hive_${docker.hive.version}-sparkworker_${docker.spark.version}</repository>
+              <repository>apachehudi/hudi-hadoop_${docker.hadoop.version}-hive_${docker.hive.version}-sparkworker_${docker.spark.version}</repository>
               <forceTags>true</forceTags>
               <tag>latest</tag>
             </configuration>
@@ -77,7 +77,7 @@
             <configuration>
               <skip>${docker.build.skip}</skip>
               <pullNewerImage>false</pullNewerImage>
-              <repository>varadarb/hudi-hadoop_${docker.hadoop.version}-hive_${docker.hive.version}-sparkworker_${docker.spark.version}</repository>
+              <repository>apachehudi/hudi-hadoop_${docker.hadoop.version}-hive_${docker.hive.version}-sparkworker_${docker.spark.version}</repository>
               <forceTags>true</forceTags>
               <tag>${project.version}</tag>
             </configuration>


### PR DESCRIPTION
1. Created new docker containers based off of openjdk. Required moving to debian distribution. Alpine and openjdk does not mix well because of glibc compatibility issues in alpine linux
2. Pushed docker containers to apachehudi

Ran and tested demo. A minor change is required for running RT queries. This will be added in upcoming PR.