### PR TITLE
Fix to enable hoodie.datasource.read.incr.filters

### DIFF
--- a/hoodie-spark/src/main/scala/com/uber/hoodie/IncrementalRelation.scala
+++ b/hoodie-spark/src/main/scala/com/uber/hoodie/IncrementalRelation.scala
@@ -87,8 +87,9 @@ class IncrementalRelation(val sqlContext: SQLContext,
     if (optParams.contains(DataSourceReadOptions.PUSH_DOWN_INCR_FILTERS_OPT_KEY)) {
       val filterStr = optParams.get(DataSourceReadOptions.PUSH_DOWN_INCR_FILTERS_OPT_KEY).getOrElse("")
       filterStr.split(",").filter(!_.isEmpty)
+    } else {
+      Array[String]()
     }
-    Array[String]()
   }
 
   override def schema: StructType = latestSchema


### PR DESCRIPTION
`hoodie.datasource.read.incr.filters` option doesn't work in the current hoodie-spark implementation.