### PR TITLE
Add support for dynamic bloom filter to increase efficiency of bloom filter for static sizing

### DIFF
--- a/hoodie-client/src/main/java/com/uber/hoodie/config/HoodieIndexConfig.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/config/HoodieIndexConfig.java
@@ -50,6 +50,9 @@ public class HoodieIndexConfig extends DefaultHoodieConfig {
   public static final String BLOOM_INDEX_INPUT_STORAGE_LEVEL =
       "hoodie.bloom.index.input.storage" + ".level";
   public static final String DEFAULT_BLOOM_INDEX_INPUT_STORAGE_LEVEL = "MEMORY_AND_DISK_SER";
+  public static final String BLOOM_INDEX_ENABLE_DYNAMIC_PROP =
+      "hoodie.bloom.index.dynamic";
+  public static final String DEFAULT_BLOOM_INDEX_ENABLE_DYNAMIC = "false";
 
   private HoodieIndexConfig(Properties props) {
     super(props);

--- a/hoodie-client/src/main/java/com/uber/hoodie/config/HoodieWriteConfig.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/config/HoodieWriteConfig.java
@@ -333,6 +333,10 @@ public class HoodieWriteConfig extends DefaultHoodieConfig {
         .fromString(props.getProperty(HoodieIndexConfig.BLOOM_INDEX_INPUT_STORAGE_LEVEL));
   }
 
+  public boolean getEnableDynamicBloomIndex() {
+    return Boolean.parseBoolean(props.getProperty(HoodieIndexConfig.BLOOM_INDEX_ENABLE_DYNAMIC_PROP));
+  }
+
   /**
    * storage properties
    **/

--- a/hoodie-client/src/main/java/com/uber/hoodie/index/bloom/HoodieBloomIndex.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/index/bloom/HoodieBloomIndex.java
@@ -342,7 +342,7 @@ public class HoodieBloomIndex<T extends HoodieRecordPayload> extends HoodieIndex
             .sortByKey(true, joinParallelism);
 
     return fileSortedTripletRDD.mapPartitionsWithIndex(
-        new HoodieBloomIndexCheckFunction(metaClient, config.getBasePath()), true)
+        new HoodieBloomIndexCheckFunction(metaClient, config), true)
         .flatMap(List::iterator)
         .filter(lookupResult -> lookupResult.getMatchingRecordKeys().size() > 0)
         .flatMapToPair(lookupResult -> {

--- a/hoodie-client/src/main/java/com/uber/hoodie/io/storage/HoodieStorageWriterFactory.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/io/storage/HoodieStorageWriterFactory.java
@@ -41,7 +41,7 @@ public class HoodieStorageWriterFactory {
       R extends IndexedRecord> HoodieStorageWriter<R> newParquetStorageWriter(String commitTime, Path path,
       HoodieWriteConfig config, Schema schema, HoodieTable hoodieTable) throws IOException {
     BloomFilter filter = new BloomFilter(config.getBloomFilterNumEntries(),
-        config.getBloomFilterFPP());
+        config.getBloomFilterFPP(), false);
     HoodieAvroWriteSupport writeSupport = new HoodieAvroWriteSupport(
         new AvroSchemaConverter().convert(schema), schema, filter);
 

--- a/hoodie-client/src/test/java/com/uber/hoodie/common/HoodieClientTestUtils.java
+++ b/hoodie-client/src/test/java/com/uber/hoodie/common/HoodieClientTestUtils.java
@@ -196,7 +196,7 @@ public class HoodieClientTestUtils {
                                         boolean createCommitTime) throws IOException {
 
     if (filter == null) {
-      filter = new BloomFilter(10000, 0.0000001);
+      filter = new BloomFilter(10000, 0.0000001, false);
     }
     HoodieAvroWriteSupport writeSupport = new HoodieAvroWriteSupport(new AvroSchemaConverter().convert(schema), schema,
         filter);

--- a/hoodie-client/src/test/java/com/uber/hoodie/index/bloom/TestHoodieBloomIndex.java
+++ b/hoodie-client/src/test/java/com/uber/hoodie/index/bloom/TestHoodieBloomIndex.java
@@ -265,7 +265,7 @@ public class TestHoodieBloomIndex {
 
     // We write record1, record2 to a parquet file, but the bloom filter contains (record1,
     // record2, record3).
-    BloomFilter filter = new BloomFilter(10000, 0.0000001);
+    BloomFilter filter = new BloomFilter(10000, 0.0000001, false);
     filter.add(record3.getRecordKey());
     String filename = HoodieClientTestUtils
         .writeParquetFile(basePath, "2016/01/31",
@@ -479,7 +479,7 @@ public class TestHoodieBloomIndex {
     HoodieRecord record2 = new HoodieRecord(new HoodieKey(rowChange2.getRowKey(), rowChange2.getPartitionPath()),
         rowChange2);
 
-    BloomFilter filter = new BloomFilter(10000, 0.0000001);
+    BloomFilter filter = new BloomFilter(10000, 0.0000001, false);
     filter.add(record2.getRecordKey());
     String filename = HoodieClientTestUtils
         .writeParquetFile(basePath, "2016/01/31",

--- a/hoodie-client/src/test/java/com/uber/hoodie/table/TestCopyOnWriteTable.java
+++ b/hoodie-client/src/test/java/com/uber/hoodie/table/TestCopyOnWriteTable.java
@@ -155,7 +155,8 @@ public class TestCopyOnWriteTable {
 
     // Read out the bloom filter and make sure filter can answer record exist or not
     Path parquetFilePath = new Path(parquetFile.getAbsolutePath());
-    BloomFilter filter = ParquetUtils.readBloomFilterFromParquetMetadata(jsc.hadoopConfiguration(), parquetFilePath);
+    BloomFilter filter = ParquetUtils.readBloomFilterFromParquetMetadata(jsc.hadoopConfiguration(), parquetFilePath,
+        false);
     for (HoodieRecord record : records) {
       assertTrue(filter.mightContain(record.getRecordKey()));
     }
@@ -211,7 +212,7 @@ public class TestCopyOnWriteTable {
     // Check whether the record has been updated
     Path updatedParquetFilePath = new Path(updatedParquetFile.getAbsolutePath());
     BloomFilter updatedFilter = ParquetUtils.readBloomFilterFromParquetMetadata(jsc.hadoopConfiguration(),
-        updatedParquetFilePath);
+        updatedParquetFilePath, false);
     for (HoodieRecord record : records) {
       // No change to the _row_key
       assertTrue(updatedFilter.mightContain(record.getRecordKey()));

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/util/ParquetUtils.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/util/ParquetUtils.java
@@ -146,10 +146,10 @@ public class ParquetUtils {
    * Read out the bloom filter from the parquet file meta data.
    */
   public static BloomFilter readBloomFilterFromParquetMetadata(Configuration configuration,
-      Path parquetFilePath) {
+      Path parquetFilePath, boolean enableDynamicBloomFilter) {
     String footerVal = readParquetFooter(configuration, parquetFilePath,
         HoodieAvroWriteSupport.HOODIE_AVRO_BLOOM_FILTER_METADATA_KEY).get(0);
-    return new BloomFilter(footerVal);
+    return new BloomFilter(footerVal, enableDynamicBloomFilter);
   }
 
   public static String[] readMinMaxRecordKeys(Configuration configuration, Path parquetFilePath) {

--- a/hoodie-common/src/test/java/com/uber/hoodie/common/AbstractBloomFilter.java
+++ b/hoodie-common/src/test/java/com/uber/hoodie/common/AbstractBloomFilter.java
@@ -1,0 +1,53 @@
+package com.uber.hoodie.common;/*
+ *  Copyright (c) 2019 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+import java.io.IOException;
+import java.util.UUID;
+
+public abstract class AbstractBloomFilter {
+
+  protected void testAddKey(boolean isDynamic) {
+    BloomFilter filter = new BloomFilter(100, 0.0000001, isDynamic);
+    filter.add("key1");
+    assert (filter.mightContain("key1"));
+  }
+
+  protected int testOverloadBloom(boolean isDynamic) {
+    BloomFilter filter = new BloomFilter(10, 0.0000001, isDynamic);
+    for (int i = 0; i < 100; i++) {
+      filter.add(UUID.randomUUID().toString());
+    }
+    int falsePositives = 0;
+    for (int i = 0; i < 100; i++) {
+      if (filter.mightContain(UUID.randomUUID().toString())) {
+        falsePositives++;
+      }
+    }
+    return falsePositives;
+  }
+
+  protected void testSerialize(boolean isDynamic) throws IOException, ClassNotFoundException {
+    BloomFilter filter = new BloomFilter(1000, 0.0000001, isDynamic);
+    filter.add("key1");
+    filter.add("key2");
+    String filterStr = filter.serializeToString();
+
+    // Rebuild
+    BloomFilter newFilter = new BloomFilter(filterStr, isDynamic);
+    assert (newFilter.mightContain("key1"));
+    assert (newFilter.mightContain("key2"));
+  }
+}

--- a/hoodie-common/src/test/java/com/uber/hoodie/common/TestDynamicBloomFilter.java
+++ b/hoodie-common/src/test/java/com/uber/hoodie/common/TestDynamicBloomFilter.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2016 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
+ *  Copyright (c) 2019 Uber Technologies, Inc. (hoodie-dev-group@uber.com)
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
@@ -19,21 +19,22 @@ package com.uber.hoodie.common;
 import java.io.IOException;
 import org.junit.Test;
 
-public class TestBloomFilter extends AbstractBloomFilter {
+public class TestDynamicBloomFilter extends AbstractBloomFilter {
 
   @Test
   public void testAddKey() {
-    testAddKey(false);
+    testAddKey(true);
   }
 
   @Test
   public void testOverloadBloom() {
-    int falsePositives = testOverloadBloom(false);
-    assert (falsePositives > 0);
+    int falsePositives = testOverloadBloom(true);
+    assert (falsePositives == 0);
   }
 
   @Test
   public void testSerialize() throws IOException, ClassNotFoundException {
-    testSerialize(false);
+    testSerialize(true);
   }
+
 }

--- a/hoodie-common/src/test/java/com/uber/hoodie/common/util/TestParquetUtils.java
+++ b/hoodie-common/src/test/java/com/uber/hoodie/common/util/TestParquetUtils.java
@@ -72,7 +72,7 @@ public class TestParquetUtils {
 
     assertEquals("Did not read back the expected list of keys", rowKeys, rowKeysInFile);
     BloomFilter filterInFile = ParquetUtils.readBloomFilterFromParquetMetadata(HoodieTestUtils.getDefaultHadoopConf(),
-        new Path(filePath));
+        new Path(filePath), false);
     for (String rowKey : rowKeys) {
       assertTrue("key should be found in bloom filter", filterInFile.mightContain(rowKey));
     }
@@ -109,7 +109,7 @@ public class TestParquetUtils {
       List<String> rowKeys) throws Exception {
     // Write out a parquet file
     Schema schema = HoodieAvroUtils.getRecordKeySchema();
-    BloomFilter filter = new BloomFilter(1000, 0.0001);
+    BloomFilter filter = new BloomFilter(1000, 0.0001, false);
     HoodieAvroWriteSupport writeSupport = new HoodieAvroWriteSupport(new AvroSchemaConverter().convert(schema), schema,
         filter);
     ParquetWriter writer = new ParquetWriter(new Path(filePath), writeSupport, CompressionCodecName.GZIP,

--- a/hoodie-hive/src/test/java/com/uber/hoodie/hive/TestUtil.java
+++ b/hoodie-hive/src/test/java/com/uber/hoodie/hive/TestUtil.java
@@ -276,7 +276,7 @@ public class TestUtil {
     Schema schema = (isParquetSchemaSimple ? SchemaTestUtil.getSimpleSchema()
         : SchemaTestUtil.getEvolvedSchema());
     org.apache.parquet.schema.MessageType parquetSchema = new AvroSchemaConverter().convert(schema);
-    BloomFilter filter = new BloomFilter(1000, 0.0001);
+    BloomFilter filter = new BloomFilter(1000, 0.0001, false);
     HoodieAvroWriteSupport writeSupport = new HoodieAvroWriteSupport(parquetSchema, schema, filter);
     ParquetWriter writer = new ParquetWriter(filePath, writeSupport, CompressionCodecName.GZIP,
         120 * 1024 * 1024, ParquetWriter.DEFAULT_PAGE_SIZE, ParquetWriter.DEFAULT_PAGE_SIZE,


### PR DESCRIPTION
Performed the following tests to check for correctness & performance:

|Correctness|
|------|
|numEntries: 1000|
|ErrorRate: 0.0000001|
|NumKeysAdded : 10000 & 100000 (10X and 100X)|
|Num Iterations : 100|

|BloomIndex| DynamicBloomIndex|
|------|----|
| 10+ false positives average, best case = 10, worst case = 1000 | 0 false positives best, average & worst case |

|Speed|
|------|
|numEntries: 500000|
|ErrorRate: 0.0000001|
|NumKeysAdded : 500000|
|Iterations : 100|

|BloomIndex| DynamicBloomIndex|
|------|----|
| 0.3 secs average, best & worst case | best case = 0.3 secs & worst case = 0.7 secs| 

|Size|
|------|
|numEntries: 500000|
|ErrorRate: 0.0000001|
|NumKeysAdded : 500000|
|Iterations : 100|

|BloomIndex| DynamicBloomIndex|
|------|----|
| 2 MB average, best & worst case | 2 MB average, best & worst case |
