### PR TITLE
SparkUtil#initLauncher shoudn't raise when spark-defaults.conf doesn't exist

### DIFF
--- a/hoodie-cli/src/main/java/com/uber/hoodie/cli/utils/SparkUtil.java
+++ b/hoodie-cli/src/main/java/com/uber/hoodie/cli/utils/SparkUtil.java
@@ -21,6 +21,8 @@ import com.uber.hoodie.cli.commands.SparkMain;
 import com.uber.hoodie.common.util.FSUtils;
 import java.io.File;
 import java.net.URISyntaxException;
+
+import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -37,8 +39,13 @@ public class SparkUtil {
   public static SparkLauncher initLauncher(String propertiesFile) throws URISyntaxException {
     String currentJar = new File(SparkUtil.class.getProtectionDomain().getCodeSource().getLocation().toURI().getPath())
         .getAbsolutePath();
-    SparkLauncher sparkLauncher = new SparkLauncher().setAppResource(currentJar).setMainClass(SparkMain.class.getName())
-        .setPropertiesFile(propertiesFile);
+    SparkLauncher sparkLauncher = new SparkLauncher().setAppResource(currentJar)
+        .setMainClass(SparkMain.class.getName());
+
+    if (StringUtils.isNotEmpty(propertiesFile)) {
+      sparkLauncher.setPropertiesFile(propertiesFile);
+    }
+
     File libDirectory = new File(new File(currentJar).getParent(), "lib");
     for (String library : libDirectory.list()) {
       sparkLauncher.addJar(new File(libDirectory, library).getAbsolutePath());


### PR DESCRIPTION
@vinothchandar @n3nash 

# The Problem

When attempting to run the `hdfsparquetimport` command from the hoode-cli I ran into an issue where it raises when the file _spark-defaults.conf_ is not present.

The `SparkLauncher` has a [check](https://github.com/apache/spark/blob/5e79ae3b40b76e3473288830ab958fc4834dcb33/launcher/src/main/java/org/apache/spark/launcher/AbstractLauncher.java#L45) that raises when this value is `null` which is the case when using a default spark download for example.

# The Solution

Since I couldn't find any reason to require this to be present, I simply added a `isEmpty` check to only set the properties file when the value isn't `null` or `""`.