### PR TITLE
HUDI-131 Zero File Listing in Compactor run

### DIFF
--- a/hoodie-client/src/main/java/com/uber/hoodie/io/compact/HoodieRealtimeTableCompactor.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/io/compact/HoodieRealtimeTableCompactor.java
@@ -126,14 +126,13 @@ public class HoodieRealtimeTableCompactor implements HoodieCompactor {
       return Lists.<WriteStatus>newArrayList();
     }
 
-    Option<HoodieDataFile> oldDataFileOpt = hoodieCopyOnWriteTable.getROFileSystemView()
-        .getDataFileOn(operation.getPartitionPath(), operation.getBaseInstantTime(), operation.getFileId());
+    Option<HoodieDataFile> oldDataFileOpt = operation.getBaseFile();
 
     // Compacting is very similar to applying updates to existing file
     Iterator<List<WriteStatus>> result;
     // If the dataFile is present, there is a base parquet file present, perform updates else perform inserts into a
     // new base parquet file.
-    if (operation.getDataFilePath().isPresent()) {
+    if (oldDataFileOpt.isPresent()) {
       result = hoodieCopyOnWriteTable
           .handleUpdate(commitTime, operation.getFileId(), scanner.getRecords(), oldDataFileOpt.get());
     } else {

--- a/hoodie-common/src/main/java/com/uber/hoodie/common/model/CompactionOperation.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/model/CompactionOperation.java
@@ -110,6 +110,11 @@ public class CompactionOperation implements Serializable {
     return id;
   }
 
+  public Option<HoodieDataFile> getBaseFile() {
+    //TODO: HUDI-130 - Paths return in compaction plan needs to be relative to base-path
+    return dataFilePath.map(df -> new HoodieDataFile(df));
+  }
+
   /**
    * Convert Avro generated Compaction operation to POJO for Spark RDD operation
    * @param operation Hoodie Compaction Operation


### PR DESCRIPTION
HUDI-131 Zero File Listing in Compactor run

@n3nash @vinothchandar : 

Compaction has all the information regarding file-slices in its metadata. Instead of querying Timeline-server or list file-status directly, it can simply use the metadata to complete the operations. 

This optimization is already employed internally and needs to be available for oss. 

