### PR TITLE
HUDI-134 - Disable inline compaction for Hoodie Demo

### DIFF
--- a/docker/demo/config/base.properties
+++ b/docker/demo/config/base.properties
@@ -21,3 +21,4 @@ hoodie.insert.shuffle.parallelism=2
 hoodie.bulkinsert.shuffle.parallelism=2
 hoodie.embed.timeline.server=true
 hoodie.filesystem.view.type=EMBEDDED_KV_STORE
+hoodie.compact.inline=false


### PR DESCRIPTION
The demo steps do not expect inline compaction to happen for MOR table. Disabling it.