### PR TITLE
update codehaus.jackson modules to the same version 1.9.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,7 @@
     <scala.libversion>2.11</scala.libversion>
     <surefire-log4j.file>file://${project.basedir}/src/test/resources/log4j-surefire.properties</surefire-log4j.file>
     <thrift.version>0.12.0</thrift.version>
+    <codehaus-jackson.version>1.9.13</codehaus-jackson.version>
   </properties>
 
   <scm>
@@ -663,14 +664,27 @@
       <dependency>
         <groupId>org.codehaus.jackson</groupId>
         <artifactId>jackson-core-asl</artifactId>
-        <version>1.9.13</version>
+        <version>${codehaus-jackson.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.codehaus.jackson</groupId>
         <artifactId>jackson-mapper-asl</artifactId>
-        <version>1.9.13</version>
+        <version>${codehaus-jackson.version}</version>
       </dependency>
+
+      <dependency>
+        <groupId>org.codehaus.jackson</groupId>
+        <artifactId>jackson-jaxrs</artifactId>
+        <version>${codehaus-jackson.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.codehaus.jackson</groupId>
+        <artifactId>jackson-xc</artifactId>
+        <version>${codehaus-jackson.version}</version>
+      </dependency>
+
       <dependency>
         <groupId>${hive.groupid}</groupId>
         <artifactId>hive-service</artifactId>


### PR DESCRIPTION
The version of jackson-jaxrs/jackson-xc  is  different from jackson-core-asl.
When running hive on tez. Run some simple `count, max` query, the server throw excpetion.

```
Caused by: java.lang.Exception: java.lang.AbstractMethodError: org.codehaus.jackson.map.AnnotationIntrospector.findSerializer(Lorg/codehaus/jackson/map/introspect/Annotated;)Ljava/lang/Object;
        at org.apache.hadoop.hive.ql.exec.tez.TezSessionState$1.call(TezSessionState.java:333) ~[hive-exec-2.3.3-amzn-2.jar:2.3.3-amzn-2]
        at org.apache.hadoop.hive.ql.exec.tez.TezSessionState$1.call(TezSessionState.java:326) ~[hive-exec-2.3.3-amzn-2.jar:2.3.3-amzn-2]
        at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[?:1.8.0_201]
        at java.lang.Thread.run(Thread.java:748) ~[?:1.8.0_201]
Caused by: java.lang.AbstractMethodError: org.codehaus.jackson.map.AnnotationIntrospector.findSerializer(Lorg/codehaus/jackson/map/introspect/Annotated;)Ljava/lang/Object;
        at org.codehaus.jackson.map.ser.BasicSerializerFactory.findSerializerFromAnnotation(BasicSerializerFactory.java:366) ~[hive-exec-2.3.3-amzn-2.jar:2.3.3-amzn-2]
        at org.codehaus.jackson.map.ser.BeanSerializerFactory.createSerializer(BeanSerializerFactory.java:252) ~[hive-exec-2.3.3-amzn-2.jar:2.3.3-amzn-2]
        at org.codehaus.jackson.map.ser.StdSerializerProvider._createUntypedSerializer(StdSerializerProvider.java:782) ~[hive-exec-2.3.3-amzn-2.jar:2.3.3-amzn-2]
        at org.codehaus.jackson.map.ser.StdSerializerProvider._createAndCacheUntypedSerializer(StdSerializerProvider.java:735) ~[hive-exec-2.3.3-amzn-2.jar:2.3.3-amzn-2]
        at org.codehaus.jackson.map.ser.StdSerializerProvider.findValueSerializer(StdSerializerProvider.java:344) ~[hive-exec-2.3.3-amzn-2.jar:2.3.3-amzn-2]
```