### PR TITLE
set codehaus.jackson modules to the same version 1.9.13

### DIFF
--- a/packaging/hoodie-presto-bundle/pom.xml
+++ b/packaging/hoodie-presto-bundle/pom.xml
@@ -185,6 +185,10 @@
                   <exclude>org.apache.thrift:*</exclude>
                   <!--Provided by aws-java-sdk-core dependency in presto-hive connector-->
                   <exclude>org.apache.httpcomponents:*</exclude>
+                  <!--Provided by hive-hadoop2-->
+                  <excude>com.fasterxml.jackson.core:*</excude>
+                  <excude>com.fasterxml.jackson.datatype:jackson-datatype-guava</excude>
+                  <excude>org.apache.parquet:*</excude>
                 </excludes>
               </artifactSet>
               <filters>

--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,7 @@
     <surefire-log4j.file>file://${project.basedir}/src/test/resources/log4j-surefire.properties</surefire-log4j.file>
     <thrift.version>0.12.0</thrift.version>
     <hbase.version>1.2.3</hbase.version>
+    <codehaus-jackson.version>1.9.13</codehaus-jackson.version>
   </properties>
 
   <scm>
@@ -684,14 +685,27 @@
       <dependency>
         <groupId>org.codehaus.jackson</groupId>
         <artifactId>jackson-core-asl</artifactId>
-        <version>1.9.13</version>
+        <version>${codehaus-jackson.version}</version>
       </dependency>
 
       <dependency>
         <groupId>org.codehaus.jackson</groupId>
         <artifactId>jackson-mapper-asl</artifactId>
-        <version>1.9.13</version>
+        <version>${codehaus-jackson.version}</version>
       </dependency>
+
+      <dependency>
+        <groupId>org.codehaus.jackson</groupId>
+        <artifactId>jackson-jaxrs</artifactId>
+        <version>${codehaus-jackson.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.codehaus.jackson</groupId>
+        <artifactId>jackson-xc</artifactId>
+        <version>${codehaus-jackson.version}</version>
+      </dependency>
+
       <dependency>
         <groupId>${hive.groupid}</groupId>
         <artifactId>hive-service</artifactId>


### PR DESCRIPTION
The version of jackson-jaxrs/jackson-xc  is  different from jackson-core-asl.
When running hive on tez. Run some simple `count, max` query, the server throw excpetion.

```
Caused by: java.lang.Exception: java.lang.AbstractMethodError: org.codehaus.jackson.map.AnnotationIntrospector.findSerializer(Lorg/codehaus/jackson/map/introspect/Annotated;)Ljava/lang/Object;
        at org.apache.hadoop.hive.ql.exec.tez.TezSessionState$1.call(TezSessionState.java:333) ~[hive-exec-2.3.3-amzn-2.jar:2.3.3-amzn-2]
        at org.apache.hadoop.hive.ql.exec.tez.TezSessionState$1.call(TezSessionState.java:326) ~[hive-exec-2.3.3-amzn-2.jar:2.3.3-amzn-2]
        at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[?:1.8.0_201]
        at java.lang.Thread.run(Thread.java:748) ~[?:1.8.0_201]
Caused by: java.lang.AbstractMethodError: org.codehaus.jackson.map.AnnotationIntrospector.findSerializer(Lorg/codehaus/jackson/map/introspect/Annotated;)Ljava/lang/Object;
        at org.codehaus.jackson.map.ser.BasicSerializerFactory.findSerializerFromAnnotation(BasicSerializerFactory.java:366) ~[hive-exec-2.3.3-amzn-2.jar:2.3.3-amzn-2]
        at org.codehaus.jackson.map.ser.BeanSerializerFactory.createSerializer(BeanSerializerFactory.java:252) ~[hive-exec-2.3.3-amzn-2.jar:2.3.3-amzn-2]
        at org.codehaus.jackson.map.ser.StdSerializerProvider._createUntypedSerializer(StdSerializerProvider.java:782) ~[hive-exec-2.3.3-amzn-2.jar:2.3.3-amzn-2]
        at org.codehaus.jackson.map.ser.StdSerializerProvider._createAndCacheUntypedSerializer(StdSerializerProvider.java:735) ~[hive-exec-2.3.3-amzn-2.jar:2.3.3-amzn-2]
        at org.codehaus.jackson.map.ser.StdSerializerProvider.findValueSerializer(StdSerializerProvider.java:344) ~[hive-exec-2.3.3-amzn-2.jar:2.3.3-amzn-2]
```

I run the docker demo in https://hudi.incubator.apache.org/docker_demo.html, it works fine.
