### PR TITLE
LogFile comparator must handle log file names without write token for backwards compatibility

### DIFF
--- a/hoodie-common/src/main/java/com/uber/hoodie/common/model/HoodieLogFile.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/model/HoodieLogFile.java
@@ -129,12 +129,12 @@ public class HoodieLogFile implements Serializable {
    */
   public static class LogFileComparator implements Comparator<HoodieLogFile>, Serializable {
 
-    private transient Comparator<HoodieLogFile> writeTokenComparator;
+    private transient Comparator<String> writeTokenComparator;
 
-    private Comparator<HoodieLogFile> getWriteTokenComparator() {
+    private Comparator<String> getWriteTokenComparator() {
       if (null == writeTokenComparator) {
         // writeTokenComparator is not serializable. Hence, lazy loading
-        writeTokenComparator = Comparator.nullsFirst(Comparator.comparing(HoodieLogFile::getLogWriteToken));
+        writeTokenComparator = Comparator.nullsFirst(Comparator.naturalOrder());
       }
       return writeTokenComparator;
     }
@@ -148,7 +148,7 @@ public class HoodieLogFile implements Serializable {
 
         if (o1.getLogVersion() == o2.getLogVersion()) {
           // Compare by write token when base-commit and log-version is same
-          return getWriteTokenComparator().compare(o1, o2);
+          return getWriteTokenComparator().compare(o1.getLogWriteToken(), o2.getLogWriteToken());
         }
 
         // compare by log-version when base-commit is same


### PR DESCRIPTION
Found this during testing in staging.

Fixes:


java.lang.NullPointerException
	at java.util.Comparator.lambda$comparing$77a9974f$1(Comparator.java:469)
	at java.util.Comparators$NullComparator.compare(Comparators.java:83)
	at com.uber.hoodie.common.model.HoodieLogFile$LogFileComparator.compare(HoodieLogFile.java:151)
	at com.uber.hoodie.common.model.HoodieLogFile$LogFileComparator.compare(HoodieLogFile.java:130)
	at java.util.Collections$ReverseComparator2.compare(Collections.java:5178)
	at java.util.TreeMap.compare(TreeMap.java:1295)
	at java.util.TreeMap.put(TreeMap.java:538)
	at java.util.TreeSet.add(TreeSet.java:255)
	at com.uber.hoodie.common.model.FileSlice.addLogFile(FileSlice.java:70)
	at com.uber.hoodie.common.model.HoodieFileGroup.addLogFile(HoodieFileGroup.java:95)
	at java.util.ArrayList.forEach(ArrayList.java:1257)
	at com.uber.hoodie.common.table.view.AbstractTableFileSystemView.lambda$buildFileGroups$4(AbstractTableFileSystemView.java:160)
	at java.lang.Iterable.forEach(Iterable.java:75)
	at com.uber.hoodie.common.table.view.AbstractTableFileSystemView.buildFileGroups(AbstractTableFileSystemView.java:153)
	at com.uber.hoodie.common.table.view.AbstractTableFileSystemView.buildFileGroups(AbstractTableFileSystemView.java:128)
	at com.uber.hoodie.common.table.view.AbstractTableFileSystemView.addFilesToView(AbstractTableFileSystemView.java:106)
	at com.uber.hoodie.common.table.view.AbstractTableFileSystemView.lambda$ensurePartitionLoadedCorrectly$5(AbstractTableFileSystemView.java:224)
	at java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1660)
	at com.uber.hoodie.common.table.view.AbstractTableFileSystemView.ensurePartitionLoadedCorrectly(AbstractTableFileSystemView.java:209)
	at com.uber.hoodie.common.table.view.AbstractTableFileSystemView.getAllFileGroups(AbstractTableFileSystemView.java:548)
	at com.uber.hoodie.io.HoodieCleanHelper.getFilesToCleanKeepingLatestCommits(HoodieCleanHelper.java:150)
	at com.uber.hoodie.io.HoodieCleanHelper.getDeletePaths(HoodieCleanHelper.java:227)
	at com.uber.hoodie.table.HoodieCopyOnWriteTable.lambda$getFilesToDeleteFunc$a939e470$1(HoodieCopyOnWriteTable.java:127)
	at org.apache.spark.api.java.JavaRDDLike$$anonfun$fn$3$1.apply(JavaRDDLike.scala:143)
	at org.apache.spark.api.java.JavaRDDLike$$anonfun$fn$3$1.apply(JavaRDDLike.scala:143)
	at scala.collection.Iterator$$anon$12.nextCur(Iterator.scala:434)
	at scala.collection.Iterator$$anon$12.hasNext(Iterator.scala:440)
	at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:408)
	at org.apache.spark.shuffle.sort.BypassMergeSortShuffleWriter.write(BypassMergeSortShuffleWriter.java:126)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:96)
	at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:53)
	at org.apache.spark.scheduler.Task.run(Task.scala:99)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:288)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
