### PR TITLE
HUDI-147 Compaction Inflight Rollback not deleting Marker directory

### DIFF
--- a/hoodie-client/src/main/java/com/uber/hoodie/table/HoodieTable.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/table/HoodieTable.java
@@ -293,6 +293,24 @@ public abstract class HoodieTable<T extends HoodieRecordPayload> implements Seri
   }
 
   /**
+   * Delete Marker directory corresponding to an instant
+   * @param instantTs Instant Time
+   */
+  protected void deleteMarkerDir(String instantTs) {
+    try {
+      FileSystem fs = getMetaClient().getFs();
+      Path markerDir = new Path(metaClient.getMarkerFolderPath(instantTs));
+      if (fs.exists(markerDir)) {
+        // For append only case, we do not write to marker dir. Hence, the above check
+        logger.info("Removing marker directory=" + markerDir);
+        fs.delete(markerDir, true);
+      }
+    } catch (IOException ioe) {
+      throw new HoodieIOException(ioe.getMessage(), ioe);
+    }
+  }
+
+  /**
    * Reconciles WriteStats and marker files to detect and safely delete duplicate data files created because of Spark
    * retries.
    *
@@ -362,11 +380,7 @@ public abstract class HoodieTable<T extends HoodieRecordPayload> implements Seri
         }
       }
       // Now delete the marker directory
-      if (fs.exists(markerDir)) {
-        // For append only case, we do not write to marker dir. Hence, the above check
-        logger.info("Removing marker directory=" + markerDir);
-        fs.delete(markerDir, true);
-      }
+      deleteMarkerDir(instantTs);
     } catch (IOException ioe) {
       throw new HoodieIOException(ioe.getMessage(), ioe);
     }


### PR DESCRIPTION
When a compaction run for an instant fails, subsequent run rollbacks inflight and retries compaction. As part of this step, marker directory of failed run must be deleted but that was not happening.

Found this when running in staging