### PR TITLE
adding support for complex keys

### DIFF
--- a/hoodie-spark/src/main/java/com/uber/hoodie/ComplexKeyGenerator.java
+++ b/hoodie-spark/src/main/java/com/uber/hoodie/ComplexKeyGenerator.java
@@ -18,16 +18,12 @@
 
 package com.uber.hoodie;
 
-import com.uber.hoodie.common.model.HoodieKey;
-import com.uber.hoodie.common.util.TypedProperties;
-import com.uber.hoodie.exception.HoodieException;
-import org.apache.avro.generic.GenericRecord;
 
 /**
  * Complex key generator, which takes names of fields to be used for recordKey and partitionPath as
  * configs.
  */
-mport com.uber.hoodie.DataSourceUtils;
+import com.uber.hoodie.DataSourceUtils;
 import com.uber.hoodie.DataSourceWriteOptions;
 import com.uber.hoodie.KeyGenerator;
 import com.uber.hoodie.common.model.HoodieKey;

--- a/hoodie-spark/src/main/java/com/uber/hoodie/ComplexKeyGenerator.java
+++ b/hoodie-spark/src/main/java/com/uber/hoodie/ComplexKeyGenerator.java
@@ -18,8 +18,6 @@
 
 package com.uber.hoodie;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonObject;
 import com.uber.hoodie.common.model.HoodieKey;
 import com.uber.hoodie.common.util.TypedProperties;
 import com.uber.hoodie.exception.HoodieException;
@@ -54,25 +52,19 @@ public class ComplexKeyGenerator extends KeyGenerator {
       throw new HoodieException(
               "Unable to find field names for record key or partition path in cfg");
     }
-
-    JsonObject recordKeyJson = new JsonObject();
-
-
+    StringBuilder recordKey = new StringBuilder();
     for (String recordKeyField : recordKeyFields) {
-      recordKeyJson.addProperty(recordKeyField,DataSourceUtils.getNestedFieldValAsString(record, recordKeyField));
+      recordKey.append(recordKeyField+":"+DataSourceUtils.getNestedFieldValAsString(record, recordKeyField)+",");
     }
-    Gson gson = new Gson();
-    String recordKey = gson.toJson(recordKeyJson);
+    recordKey.deleteCharAt(recordKey.length()-1);
     StringBuilder partitionPath = new StringBuilder();
     try {
       for (String partitionPathField : partitionPathFields) {
         partitionPath.append(DataSourceUtils.getNestedFieldValAsString(record, partitionPathField));
         partitionPath.append(DEFAULT_PARTITION_PATH_SEPARATOR);
       }
-      partitionPath.delete(partitionPath.length() - 1, partitionPath.length());
+      partitionPath.deleteCharAt(partitionPath.length() - 1);
     } catch (HoodieException e) {
-      // TODO : optimize this since throwing and catching exception is cpu intensive
-      // if field is not found, lump it into default partition
       partitionPath = partitionPath.append(DEFAULT_PARTITION_PATH);
     }
 

--- a/hoodie-spark/src/main/java/com/uber/hoodie/ComplexKeyGenerator.java
+++ b/hoodie-spark/src/main/java/com/uber/hoodie/ComplexKeyGenerator.java
@@ -54,9 +54,9 @@ public class ComplexKeyGenerator extends KeyGenerator {
     }
     StringBuilder recordKey = new StringBuilder();
     for (String recordKeyField : recordKeyFields) {
-      recordKey.append(recordKeyField+":"+DataSourceUtils.getNestedFieldValAsString(record, recordKeyField)+",");
+      recordKey.append(recordKeyField + ":" + DataSourceUtils.getNestedFieldValAsString(record, recordKeyField) + ",");
     }
-    recordKey.deleteCharAt(recordKey.length()-1);
+    recordKey.deleteCharAt(recordKey.length() - 1);
     StringBuilder partitionPath = new StringBuilder();
     try {
       for (String partitionPathField : partitionPathFields) {

--- a/hoodie-spark/src/main/java/com/uber/hoodie/ComplexKeyGenerator.java
+++ b/hoodie-spark/src/main/java/com/uber/hoodie/ComplexKeyGenerator.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.hoodie;
+
+import com.uber.hoodie.common.model.HoodieKey;
+import com.uber.hoodie.common.util.TypedProperties;
+import com.uber.hoodie.exception.HoodieException;
+import org.apache.avro.generic.GenericRecord;
+
+/**
+ * Complex key generator, which takes names of fields to be used for recordKey and partitionPath as
+ * configs.
+ */
+mport com.uber.hoodie.DataSourceUtils;
+import com.uber.hoodie.DataSourceWriteOptions;
+import com.uber.hoodie.KeyGenerator;
+import com.uber.hoodie.common.model.HoodieKey;
+import com.uber.hoodie.common.util.TypedProperties;
+import com.uber.hoodie.exception.HoodieException;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.avro.generic.GenericRecord;
+import com.google.gson.*;
+
+public class ComplexKeyGenerator extends KeyGenerator {
+
+  private static final String DEFAULT_PARTITION_PATH = "default";
+
+  private static final String DEFAULT_PARTITION_PATH_SEPARATOR = "/";
+
+  protected final List<String> recordKeyFields;
+
+  protected final List<String> partitionPathFields;
+
+  public ComplexKeyGenerator(TypedProperties props) {
+    super(props);
+    this.recordKeyFields = Arrays.asList(props.getString(DataSourceWriteOptions.RECORDKEY_FIELD_OPT_KEY()).split(","));
+    this.partitionPathFields = Arrays.asList(props
+            .getString(DataSourceWriteOptions.PARTITIONPATH_FIELD_OPT_KEY()).split(","));
+  }
+
+  @Override
+  public HoodieKey getKey(GenericRecord record) {
+    if (recordKeyFields == null || partitionPathFields == null) {
+      throw new HoodieException(
+              "Unable to find field names for record key or partition path in cfg");
+    }
+
+    JsonObject recordKeyJson = new JsonObject();
+
+
+    for (String recordKeyField : recordKeyFields) {
+      recordKeyJson.addProperty(recordKeyField,DataSourceUtils.getNestedFieldValAsString(record, recordKeyField));
+    }
+    Gson gson = new Gson();
+    String recordKey = gson.toJson(recordKeyJson);
+    StringBuilder partitionPath = new StringBuilder();
+    try {
+      for (String partitionPathField : partitionPathFields) {
+        partitionPath.append(DataSourceUtils.getNestedFieldValAsString(record, partitionPathField));
+        partitionPath.append(DEFAULT_PARTITION_PATH_SEPARATOR);
+      }
+      partitionPath.delete(partitionPath.length() - 1, partitionPath.length());
+    } catch (HoodieException e) {
+      // TODO : optimize this since throwing and catching exception is cpu intensive
+      // if field is not found, lump it into default partition
+      partitionPath = partitionPath.append(DEFAULT_PARTITION_PATH);
+    }
+
+    return new HoodieKey(recordKey.toString(), partitionPath.toString());
+  }
+
+  public List<String> getRecordKeyFields() {
+    return recordKeyFields;
+  }
+
+  public List<String> getPartitionPathFields() {
+    return partitionPathFields;
+  }
+}

--- a/hoodie-spark/src/main/java/com/uber/hoodie/ComplexKeyGenerator.java
+++ b/hoodie-spark/src/main/java/com/uber/hoodie/ComplexKeyGenerator.java
@@ -18,22 +18,19 @@
 
 package com.uber.hoodie;
 
-
-/**
- * Complex key generator, which takes names of fields to be used for recordKey and partitionPath as
- * configs.
- */
-import com.uber.hoodie.DataSourceUtils;
-import com.uber.hoodie.DataSourceWriteOptions;
-import com.uber.hoodie.KeyGenerator;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 import com.uber.hoodie.common.model.HoodieKey;
 import com.uber.hoodie.common.util.TypedProperties;
 import com.uber.hoodie.exception.HoodieException;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.avro.generic.GenericRecord;
-import com.google.gson.*;
 
+/**
+ * Complex key generator, which takes names of fields to be used for recordKey and partitionPath as
+ * configs.
+ */
 public class ComplexKeyGenerator extends KeyGenerator {
 
   private static final String DEFAULT_PARTITION_PATH = "default";

--- a/pom.xml
+++ b/pom.xml
@@ -455,6 +455,7 @@
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>
         <version>2.3.1</version>
+        <scope>test</scope>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -455,7 +455,6 @@
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>
         <version>2.3.1</version>
-        <scope>test</scope>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Resolving the issue related to ambiguity in recordKey by creating and parsing json object as string.

Now HoodieKey looks like this:
HoodieKey { recordKey={"_row_key":"16bf0b32-7557-42ac-b367-9fe32ae4795e","timestamp":"0.0"} partitionPath=rider-002/driver-002}