### PR TITLE
Support building Hoodie with Hadoop 2.8.x

### DIFF
--- a/hoodie-common/pom.xml
+++ b/hoodie-common/pom.xml
@@ -126,11 +126,17 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdfs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdfs</artifactId>
+      <scope>test</scope>
       <classifier>tests</classifier>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
+      <scope>test</scope>
       <classifier>tests</classifier>
     </dependency>
     <dependency>


### PR DESCRIPTION
This unblocks Hudi from building against Hadoop 2.8.x (when specified as an argument during the maven build).  The following command should now work to support building Hoodie against newer versions of Hadoop.

```
mvn clean install -Dhadoop.version=2.8.5
```

