### PR TITLE
when column type is decimal, should add precision and scale

### DIFF
--- a/hoodie-hive/src/main/java/com/uber/hoodie/hive/HoodieHiveClient.java
+++ b/hoodie-hive/src/main/java/com/uber/hoodie/hive/HoodieHiveClient.java
@@ -285,6 +285,11 @@ public class HoodieHiveClient {
       while (result.next()) {
         String columnName = result.getString(4);
         String columnType = result.getString(6);
+        if ("DECIMAL".equals(columnType)) {
+          int columnSize = result.getInt("COLUMN_SIZE");
+          int decimalDigits = result.getInt("DECIMAL_DIGITS");
+          columnType += String.format("(%s,%s)", columnSize, decimalDigits);
+        }
         schema.put(columnName, columnType);
       }
       return schema;


### PR DESCRIPTION
When using HoodieHiveClient to create a hive table, I found that a decimal column just only show `DECIMAL` in schema and don't have precision and scale. So that hoodie will report error, if hoodie is analysing this schema.
Try to fix this problem.