### PR TITLE
Fixing bugs found during running hoodie demo

### DIFF
--- a/hoodie-common/src/main/java/com/uber/hoodie/common/table/view/AbstractTableFileSystemView.java
+++ b/hoodie-common/src/main/java/com/uber/hoodie/common/table/view/AbstractTableFileSystemView.java
@@ -216,7 +216,7 @@ public abstract class AbstractTableFileSystemView implements SyncableFileSystemV
           log.info("Building file system view for partition (" + partitionPathStr + ")");
 
           // Create the path if it does not exist already
-          Path partitionPath = new Path(metaClient.getBasePath(), partitionPathStr);
+          Path partitionPath = FSUtils.getPartitionPath(metaClient.getBasePath(), partitionPathStr);
           FSUtils.createPathIfNotExists(metaClient.getFs(), partitionPath);
           long beginLsTs = System.currentTimeMillis();
           FileStatus[] statuses = metaClient.getFs().listStatus(partitionPath);


### PR DESCRIPTION
1. With recent changes, inline compaction is always running for MOR table in non-continuous mode. This breaks the demo scenario where we show difference between RT and non-RT table
2. Fix a bug which causes MOR ingest (non-continuous) to hang. This was caused by changes done to     continuous mode Deltastreamer PR  after initially testing demo.  
2. Bug fix related to non-partitioned table's file-system view generation.