### PR TITLE
Fix HUDI-170 Updating hoodie record before inserting it into ExternalSpillableMap

### DIFF
--- a/hoodie-client/src/main/java/com/uber/hoodie/io/HoodieMergeHandle.java
+++ b/hoodie-client/src/main/java/com/uber/hoodie/io/HoodieMergeHandle.java
@@ -206,9 +206,12 @@ public class HoodieMergeHandle<T extends HoodieRecordPayload> extends HoodieWrit
     while (newRecordsItr.hasNext()) {
       HoodieRecord<T> record = newRecordsItr.next();
       partitionPath = record.getPartitionPath();
-      keyToNewRecords.put(record.getRecordKey(), record);
       // update the new location of the record, so we know where to find it next
       record.setNewLocation(new HoodieRecordLocation(instantTime, fileId));
+      // ensure all updates to "record" are done prior to inserting it into "keyToNewRecords"
+      // (which is backed by ExternalSpillableMap. Once record is written to disk then future
+      // updates to it will be lost.
+      keyToNewRecords.put(record.getRecordKey(), record);
     }
     logger.info("Number of entries in MemoryBasedMap => "
         + ((ExternalSpillableMap) keyToNewRecords).getInMemoryMapNumEntries()


### PR DESCRIPTION
fixes #773 

Problem - If ExternalSpillableMap has reached its size limit then we start writing newly inserted records onto disk. Any future updates we make into the in memory copy of it will not be reflected on to on disk copy. 

Fix - In HoodieMergeHandle we are ensuring that we update the record before inserting it into ExternalSpillableMap so that we don't loose any updates done to it.

cc @bvaradar @n3nash @vinothchandar - PTAL.

fixes https://issues.apache.org/jira/browse/HUDI-170