### PR TITLE
Remove --key-generator-class CLI arg for DeltaStreamer

### DIFF
--- a/docs/writing_data.md
+++ b/docs/writing_data.md
@@ -42,12 +42,6 @@ Usage: <main class> [options]
           parameter "--propsFilePath") can also be passed command line using this 
           parameter 
           Default: []
-    --key-generator-class
-      Subclass of com.uber.hoodie.KeyGenerator to generate a HoodieKey from
-      the given avro record. Built in: SimpleKeyGenerator (uses provided field
-      names as recordkey & partitionpath. Nested fields specified via dot
-      notation, e.g: a.b.c)
-      Default: com.uber.hoodie.SimpleKeyGenerator
     --op
       Takes one of these values : UPSERT (default), INSERT (use when input is
       purely new data/inserts to gain speed)


### PR DESCRIPTION
This is a follow-on of another PR: https://github.com/apache/incubator-hudi/pull/781.

This PR removes the `--key-generator-class` CLI arg for DeltaStreamer in the docs according the code change.