### PR TITLE
Fix typo in hoodie-presto-bundle

### DIFF
--- a/packaging/hoodie-presto-bundle/pom.xml
+++ b/packaging/hoodie-presto-bundle/pom.xml
@@ -192,9 +192,9 @@
                   <!--Provided by aws-java-sdk-core dependency in presto-hive connector-->
                   <exclude>org.apache.httpcomponents:*</exclude>
                   <!--Provided by hive-hadoop2-->
-                  <excude>com.fasterxml.jackson.core:*</excude>
-                  <excude>com.fasterxml.jackson.datatype:jackson-datatype-guava</excude>
-                  <excude>org.apache.parquet:*</excude>
+                  <exclude>com.fasterxml.jackson.core:*</exclude>
+                  <exclude>com.fasterxml.jackson.datatype:jackson-datatype-guava</exclude>
+                  <exclude>org.apache.parquet:*</exclude>
                 </excludes>
               </artifactSet>
               <filters>


### PR DESCRIPTION
I was getting some java import error involving Jackson which was resolved after I removed https://mvnrepository.com/artifact/com.uber.hoodie/hoodie-presto-bundle/0.4.7 from `plugins/hive-hadoop2/`.

I'm not sure if this resolves the entire import issue but I think it's a good idea for future debugging to happen with this change made, so future contributors no longer have to worry about typos.