### PR TITLE
[HUDI-205] Let checkstyle ban Java and Guava Optional instead of using Option provided by Hudi

### DIFF
--- a/style/checkstyle-suppressions.xml
+++ b/style/checkstyle-suppressions.xml
@@ -9,4 +9,5 @@
   <suppress checks="indentation" files="HoodieLogFileCommand.java" lines="1-9999"/>
   <!-- Member Names expected to start with "_"  -->
   <suppress checks="naming" files="TestRecord.java" lines="1-9999"/>
+  <suppress checks="IllegalImport" files="Option.java" />
 </suppressions>

--- a/style/checkstyle.xml
+++ b/style/checkstyle.xml
@@ -242,5 +242,8 @@
             <property name="exceptionVariableName" value="expected"/>
         </module>
         <module name="CommentsIndentation"/>
+        <module name="IllegalImport">
+            <property name="illegalClasses" value="java.util.Optional, com.google.common.base.Optional" />
+        </module>
     </module>
 </module>


### PR DESCRIPTION
jira issue ref : https://jira.apache.org/jira/browse/HUDI-205