### PR TITLE
[HUDI-222] Rename main class path to org.apache.hudi.timeline.serviceTimelineService in run_server.sh

### DIFF
--- a/hudi-timeline-service/run_server.sh
+++ b/hudi-timeline-service/run_server.sh
@@ -10,5 +10,5 @@ if [ -z "$HADOOP_CONF_DIR" ]; then
 fi
 
 OTHER_JARS=`ls -1 $DIR/target/lib/*jar | grep -v '*avro*-1.' | tr '\n' ':'`
-echo "Running command : java -cp $DIR/target/:${HADOOP_CONF_DIR}:$HOODIE_JAR:$OTHER_JARS com.uber.hoodie.timeline.service.TimelineService $@"
-java -Xmx4G -cp $DIR/target/test-classes/:${HADOOP_CONF_DIR}:$HOODIE_JAR:$OTHER_JARS com.uber.hoodie.timeline.service.TimelineService "$@"
+echo "Running command : java -cp $DIR/target/:${HADOOP_CONF_DIR}:$HOODIE_JAR:$OTHER_JARS org.apache.hudi.timeline.service.TimelineService $@"
+java -Xmx4G -cp $DIR/target/test-classes/:${HADOOP_CONF_DIR}:$HOODIE_JAR:$OTHER_JARS org.apache.hudi.timeline.service.TimelineService "$@"


### PR DESCRIPTION
see jira: [HUDI-222](https://jira.apache.org/jira/projects/HUDI/issues/HUDI-222)

Rename main class path to org.apache.hudi.timeline.serviceTimelineService in run_server.sh