### PR TITLE
HUDI-124 : Exclude jdk.tools from hadoop-common and update Notice files

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -26,13 +26,11 @@ This project includes:
   Apache Calcite Avatica under Apache License, Version 2.0
   Apache Calcite Avatica Metrics under Apache License, Version 2.0
   Apache Commons Collections under Apache License, Version 2.0
-  Apache Commons Compress under Apache License, Version 2.0
-  Apache Commons Configuration under Apache License, Version 2.0
+  Apache Commons Compress under The Apache Software License, Version 2.0
   Apache Commons Crypto under Apache License, Version 2.0
   Apache Commons IO under Apache License, Version 2.0
   Apache Commons Lang under Apache License, Version 2.0
   Apache Commons Logging under The Apache Software License, Version 2.0
-  Apache Commons Math under The Apache Software License, Version 2.0
   Apache Curator under The Apache Software License, Version 2.0
   Apache Derby Database Engine and Embedded JDBC Driver under Apache 2
   Apache Directory API ASN.1 API under The Apache Software License, Version 2.0
@@ -55,7 +53,6 @@ This project includes:
   Apache HBase - Server under Apache License, Version 2.0
   Apache HBase - Testing Util under Apache License, Version 2.0
   Apache HttpClient under Apache License, Version 2.0
-  Apache HttpClient Fluent API under Apache License, Version 2.0
   Apache HttpCore under Apache License, Version 2.0
   Apache Ivy under The Apache Software License, Version 2.0
   Apache Kafka under The Apache Software License, Version 2.0
@@ -66,21 +63,13 @@ This project includes:
   Apache Log4j SLF4J Binding under The Apache Software License, Version 2.0
   Apache Log4j Web under The Apache Software License, Version 2.0
   Apache Parquet Avro under The Apache Software License, Version 2.0
-  Apache Parquet Avro (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Column under The Apache Software License, Version 2.0
-  Apache Parquet Column (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Common under The Apache Software License, Version 2.0
-  Apache Parquet Common (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Encodings under The Apache Software License, Version 2.0
-  Apache Parquet Encodings (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Format (Incubating) under The Apache Software License, Version 2.0
-  Apache Parquet Generator (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Hadoop under The Apache Software License, Version 2.0
-  Apache Parquet Hadoop (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Hadoop Bundle under The Apache Software License, Version 2.0
-  Apache Parquet Hadoop Bundle (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Jackson under The Apache Software License, Version 2.0
-  Apache Parquet Jackson (Incubating) under The Apache Software License, Version 2.0
   Apache Thrift under The Apache Software License, Version 2.0
   Apache Twill API under The Apache Software License, Version 2.0
   Apache Twill common library under The Apache Software License, Version 2.0
@@ -92,8 +81,6 @@ This project includes:
   Apache XBean :: ASM 5 shaded (repackaged) under null or null
   ApacheDS I18n under The Apache Software License, Version 2.0
   ApacheDS Protocol Kerberos Codec under The Apache Software License, Version 2.0
-  ASCII List under Apache 2
-  Ascii Table under Apache 2
   ASM Commons under 3-Clause BSD License
   ASM Core under 3-Clause BSD License
   ASM Tree under 3-Clause BSD License
@@ -109,10 +96,10 @@ This project includes:
   Calcite Linq4j under Apache License, Version 2.0
   chill under Apache 2
   chill-java under Apache 2
-  com.twitter.common:objectsize under Apache License, Version 2.0
   Commons BeanUtils Core under The Apache Software License, Version 2.0
   Commons CLI under The Apache Software License, Version 2.0
   Commons Codec under The Apache Software License, Version 2.0
+  Commons Collections under The Apache Software License, Version 2.0
   Commons Compiler under New BSD License
   Commons Compress under The Apache Software License, Version 2.0
   Commons Configuration under The Apache Software License, Version 2.0
@@ -161,12 +148,12 @@ This project includes:
   hadoop-yarn-client under Apache License, Version 2.0
   hadoop-yarn-common under Apache License, Version 2.0
   hadoop-yarn-registry under Apache License, Version 2.0
-  hadoop-yarn-server-applicationhistoryservice under Apache License, Version 2.0
+  hadoop-yarn-server-applicationhistoryservice under The Apache Software License, Version 2.0
   hadoop-yarn-server-common under Apache License, Version 2.0
   hadoop-yarn-server-nodemanager under The Apache Software License, Version 2.0
-  hadoop-yarn-server-resourcemanager under Apache License, Version 2.0
+  hadoop-yarn-server-resourcemanager under The Apache Software License, Version 2.0
   hadoop-yarn-server-tests under The Apache Software License, Version 2.0
-  hadoop-yarn-server-web-proxy under Apache License, Version 2.0
+  hadoop-yarn-server-web-proxy under The Apache Software License, Version 2.0
   Hamcrest Core under New BSD License
   Hamcrest library under New BSD License
   HBase - Common under The Apache Software License, Version 2.0
@@ -195,47 +182,48 @@ This project includes:
   Hive Vector-Code-Gen Utilities under The Apache Software License, Version 2.0
   HK2 API module under CDDL + GPLv2 with classpath exception
   HK2 Implementation Utilities under CDDL + GPLv2 with classpath exception
-  Hoodie under Apache License, Version 2.0
-  hoodie-cli under Apache License, Version 2.0
-  hoodie-client under Apache License, Version 2.0
-  hoodie-common under Apache License, Version 2.0
-  hoodie-hadoop-base-docker under Apache License, Version 2.0
-  hoodie-hadoop-datanode-docker under Apache License, Version 2.0
-  hoodie-hadoop-docker under Apache License, Version 2.0
-  hoodie-hadoop-history-docker under Apache License, Version 2.0
-  hoodie-hadoop-hive-docker under Apache License, Version 2.0
-  hoodie-hadoop-mr under Apache License, Version 2.0
-  hoodie-hadoop-mr-bundle under Apache License, Version 2.0
-  hoodie-hadoop-namenode-docker under Apache License, Version 2.0
-  hoodie-hadoop-sparkadhoc-docker under Apache License, Version 2.0
-  hoodie-hadoop-sparkbase-docker under Apache License, Version 2.0
-  hoodie-hadoop-sparkmaster-docker under Apache License, Version 2.0
-  hoodie-hadoop-sparkworker-docker under Apache License, Version 2.0
-  hoodie-hive under Apache License, Version 2.0
-  hoodie-hive-bundle under Apache License, Version 2.0
-  hoodie-integ-test under Apache License, Version 2.0
-  hoodie-presto-bundle under Apache License, Version 2.0
-  hoodie-spark under Apache License, Version 2.0
-  hoodie-spark-bundle under Apache License, Version 2.0
-  hoodie-timeline-service under Apache License, Version 2.0
-  hoodie-utilities under Apache License, Version 2.0
-  hoodie-utilities-bundle under Apache License, Version 2.0
   htrace-core under The Apache Software License, Version 2.0
   HttpClient under Apache License
+  Hudi under Apache License, Version 2.0
+  hudi-cli under Apache License, Version 2.0
+  hudi-client under Apache License, Version 2.0
+  hudi-common under Apache License, Version 2.0
+  hudi-hadoop-base-docker under Apache License, Version 2.0
+  hudi-hadoop-datanode-docker under Apache License, Version 2.0
+  hudi-hadoop-docker under Apache License, Version 2.0
+  hudi-hadoop-history-docker under Apache License, Version 2.0
+  hudi-hadoop-hive-docker under Apache License, Version 2.0
+  hudi-hadoop-mr under Apache License, Version 2.0
+  hudi-hadoop-mr-bundle under Apache License, Version 2.0
+  hudi-hadoop-namenode-docker under Apache License, Version 2.0
+  hudi-hadoop-presto-docker under Apache License, Version 2.0
+  hudi-hadoop-sparkadhoc-docker under Apache License, Version 2.0
+  hudi-hadoop-sparkbase-docker under Apache License, Version 2.0
+  hudi-hadoop-sparkmaster-docker under Apache License, Version 2.0
+  hudi-hadoop-sparkworker-docker under Apache License, Version 2.0
+  hudi-hive under Apache License, Version 2.0
+  hudi-hive-bundle under Apache License, Version 2.0
+  hudi-integ-test under Apache License, Version 2.0
+  hudi-presto-bundle under Apache License, Version 2.0
+  hudi-spark under Apache License, Version 2.0
+  hudi-spark-bundle under Apache License, Version 2.0
+  hudi-timeline-service under Apache License, Version 2.0
+  hudi-utilities under Apache License, Version 2.0
+  hudi-utilities-bundle under Apache License, Version 2.0
   IntelliJ IDEA Annotations under The Apache Software License, Version 2.0
   io.confluent:common-config under Apache License, Version 2.0
   io.confluent:common-utils under Apache License, Version 2.0
   io.confluent:kafka-avro-serializer under Apache License, Version 2.0
   io.confluent:kafka-schema-registry-client under Apache License, Version 2.0
   Jackson under The Apache Software License, Version 2.0
-  Jackson datatype: Guava under The Apache Software License, Version 2.0
   Jackson Integration for Metrics under Apache License 2.0
+  Jackson module: JAXB Annotations under The Apache Software License, Version 2.0
   Jackson-annotations under The Apache Software License, Version 2.0
   Jackson-core under The Apache Software License, Version 2.0
   jackson-databind under The Apache Software License, Version 2.0
+  Jackson-datatype-Guava under The Apache Software License, Version 2.0
   Jackson-JAXRS-base under The Apache Software License, Version 2.0
   Jackson-JAXRS-JSON under The Apache Software License, Version 2.0
-  Jackson-module-JAXB-annotations under The Apache Software License, Version 2.0
   Jackson-module-paranamer under The Apache Software License, Version 2.0
   jackson-module-scala under The Apache Software License, Version 2.0
   jamon-runtime under Mozilla Public License Version 2.0
@@ -258,6 +246,7 @@ This project includes:
   JAXB API bundle for GlassFish V3 under CDDL 1.1 or GPL2 w/ CPE
   JAXB RI under CDDL 1.1 or GPL2 w/ CPE
   JCL 1.1.1 implemented over SLF4J under MIT License
+  JCL 1.2 implemented over SLF4J under MIT License
   JCodings under MIT License
   jcommander under Apache 2.0
   JDO API under Apache 2
@@ -270,7 +259,7 @@ This project includes:
   jersey-core-common under CDDL+GPL License
   jersey-core-server under CDDL+GPL License
   jersey-guice under CDDL 1.1 or GPL2 w/ CPE
-  jersey-inject-hk2 under CDDL 1.1 or GPL2 w/ CPE
+  jersey-inject-hk2 under CDDL 1.1 or GPL2 w/ CPE or Apache License, 2.0 or Public Domain or Modified BSD
   jersey-json under CDDL 1.1 or GPL2 w/ CPE
   jersey-media-jaxb under CDDL+GPL License
   jersey-repackaged-guava under CDDL+GPL License
@@ -319,7 +308,6 @@ This project includes:
   Metrics Core Library under Apache License 2.0
   MinLog under New BSD License
   Mockito under The MIT License
-  Native Library Loader under CC0 1.0 Universal License
   Netty/All-in-One under Apache License, Version 2.0
   Netty/Buffer under Apache License, Version 2.0
   Netty/Codec under Apache License, Version 2.0

--- a/docker/hoodie/hadoop/NOTICE.txt
+++ b/docker/hoodie/hadoop/NOTICE.txt
@@ -23,7 +23,6 @@ This project includes:
   Apache Calcite Avatica under Apache License, Version 2.0
   Apache Calcite Avatica Metrics under Apache License, Version 2.0
   Apache Commons Collections under Apache License, Version 2.0
-  Apache Commons Configuration under Apache License, Version 2.0
   Apache Commons IO under Apache License, Version 2.0
   Apache Commons Logging under The Apache Software License, Version 2.0
   Apache Curator under The Apache Software License, Version 2.0
@@ -38,6 +37,7 @@ This project includes:
   Apache Hadoop HDFS under Apache License, Version 2.0
   Apache HBase - Annotations under Apache License, Version 2.0
   Apache HBase - Client under Apache License, Version 2.0
+  Apache HBase - Common under Apache License, Version 2.0
   Apache HBase - Protocol under Apache License, Version 2.0
   Apache HttpClient under Apache License, Version 2.0
   Apache HttpCore under Apache License, Version 2.0
@@ -49,21 +49,13 @@ This project includes:
   Apache Log4j SLF4J Binding under The Apache Software License, Version 2.0
   Apache Log4j Web under The Apache Software License, Version 2.0
   Apache Parquet Avro under The Apache Software License, Version 2.0
-  Apache Parquet Avro (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Column under The Apache Software License, Version 2.0
-  Apache Parquet Column (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Common under The Apache Software License, Version 2.0
-  Apache Parquet Common (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Encodings under The Apache Software License, Version 2.0
-  Apache Parquet Encodings (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Format (Incubating) under The Apache Software License, Version 2.0
-  Apache Parquet Generator (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Hadoop under The Apache Software License, Version 2.0
-  Apache Parquet Hadoop (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Hadoop Bundle under The Apache Software License, Version 2.0
-  Apache Parquet Hadoop Bundle (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Jackson under The Apache Software License, Version 2.0
-  Apache Parquet Jackson (Incubating) under The Apache Software License, Version 2.0
   Apache Thrift under The Apache Software License, Version 2.0
   Apache Twill API under The Apache Software License, Version 2.0
   Apache Twill common library under The Apache Software License, Version 2.0
@@ -81,7 +73,6 @@ This project includes:
   Calcite Core under Apache License, Version 2.0
   Calcite Druid under Apache License, Version 2.0
   Calcite Linq4j under Apache License, Version 2.0
-  com.twitter.common:objectsize under Apache License, Version 2.0
   Commons BeanUtils Core under The Apache Software License, Version 2.0
   Commons CLI under The Apache Software License, Version 2.0
   Commons Codec under The Apache Software License, Version 2.0
@@ -156,25 +147,26 @@ This project includes:
   Hive Shims Scheduler under The Apache Software License, Version 2.0
   Hive Storage API under Apache License, Version 2.0
   Hive Vector-Code-Gen Utilities under The Apache Software License, Version 2.0
-  hoodie-client under Apache License, Version 2.0
-  hoodie-common under Apache License, Version 2.0
-  hoodie-hadoop-base-docker under Apache License, Version 2.0
-  hoodie-hadoop-datanode-docker under Apache License, Version 2.0
-  hoodie-hadoop-docker under Apache License, Version 2.0
-  hoodie-hadoop-history-docker under Apache License, Version 2.0
-  hoodie-hadoop-hive-docker under Apache License, Version 2.0
-  hoodie-hadoop-mr under Apache License, Version 2.0
-  hoodie-hadoop-namenode-docker under Apache License, Version 2.0
-  hoodie-hadoop-sparkadhoc-docker under Apache License, Version 2.0
-  hoodie-hadoop-sparkbase-docker under Apache License, Version 2.0
-  hoodie-hadoop-sparkmaster-docker under Apache License, Version 2.0
-  hoodie-hadoop-sparkworker-docker under Apache License, Version 2.0
-  hoodie-hive under Apache License, Version 2.0
-  hoodie-spark under Apache License, Version 2.0
-  hoodie-spark-bundle under Apache License, Version 2.0
-  hoodie-timeline-service under Apache License, Version 2.0
   htrace-core under The Apache Software License, Version 2.0
   HttpClient under Apache License
+  hudi-client under Apache License, Version 2.0
+  hudi-common under Apache License, Version 2.0
+  hudi-hadoop-base-docker under Apache License, Version 2.0
+  hudi-hadoop-datanode-docker under Apache License, Version 2.0
+  hudi-hadoop-docker under Apache License, Version 2.0
+  hudi-hadoop-history-docker under Apache License, Version 2.0
+  hudi-hadoop-hive-docker under Apache License, Version 2.0
+  hudi-hadoop-mr under Apache License, Version 2.0
+  hudi-hadoop-namenode-docker under Apache License, Version 2.0
+  hudi-hadoop-presto-docker under Apache License, Version 2.0
+  hudi-hadoop-sparkadhoc-docker under Apache License, Version 2.0
+  hudi-hadoop-sparkbase-docker under Apache License, Version 2.0
+  hudi-hadoop-sparkmaster-docker under Apache License, Version 2.0
+  hudi-hadoop-sparkworker-docker under Apache License, Version 2.0
+  hudi-hive under Apache License, Version 2.0
+  hudi-spark under Apache License, Version 2.0
+  hudi-spark-bundle under Apache License, Version 2.0
+  hudi-timeline-service under Apache License, Version 2.0
   IntelliJ IDEA Annotations under The Apache Software License, Version 2.0
   Jackson under The Apache Software License, Version 2.0
   Jackson Integration for Metrics under Apache License 2.0
@@ -225,6 +217,7 @@ This project includes:
   Jetty Server under Apache Software License - Version 2.0 or Eclipse Public License - Version 1.0
   Jetty SSLEngine under Apache License Version 2
   Jetty Utilities under Apache Software License - Version 2.0 or Eclipse Public License - Version 1.0
+  JLine under The BSD License
   Joda-Time under Apache 2
   Joni under MIT License
   JPam under The Apache Software License, Version 2.0

--- a/docker/hoodie/hadoop/base/NOTICE.txt
+++ b/docker/hoodie/hadoop/base/NOTICE.txt
@@ -23,7 +23,6 @@ This project includes:
   Apache Calcite Avatica under Apache License, Version 2.0
   Apache Calcite Avatica Metrics under Apache License, Version 2.0
   Apache Commons Collections under Apache License, Version 2.0
-  Apache Commons Configuration under Apache License, Version 2.0
   Apache Commons IO under Apache License, Version 2.0
   Apache Commons Logging under The Apache Software License, Version 2.0
   Apache Curator under The Apache Software License, Version 2.0
@@ -38,6 +37,7 @@ This project includes:
   Apache Hadoop HDFS under Apache License, Version 2.0
   Apache HBase - Annotations under Apache License, Version 2.0
   Apache HBase - Client under Apache License, Version 2.0
+  Apache HBase - Common under Apache License, Version 2.0
   Apache HBase - Protocol under Apache License, Version 2.0
   Apache HttpClient under Apache License, Version 2.0
   Apache HttpCore under Apache License, Version 2.0
@@ -49,21 +49,13 @@ This project includes:
   Apache Log4j SLF4J Binding under The Apache Software License, Version 2.0
   Apache Log4j Web under The Apache Software License, Version 2.0
   Apache Parquet Avro under The Apache Software License, Version 2.0
-  Apache Parquet Avro (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Column under The Apache Software License, Version 2.0
-  Apache Parquet Column (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Common under The Apache Software License, Version 2.0
-  Apache Parquet Common (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Encodings under The Apache Software License, Version 2.0
-  Apache Parquet Encodings (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Format (Incubating) under The Apache Software License, Version 2.0
-  Apache Parquet Generator (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Hadoop under The Apache Software License, Version 2.0
-  Apache Parquet Hadoop (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Hadoop Bundle under The Apache Software License, Version 2.0
-  Apache Parquet Hadoop Bundle (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Jackson under The Apache Software License, Version 2.0
-  Apache Parquet Jackson (Incubating) under The Apache Software License, Version 2.0
   Apache Thrift under The Apache Software License, Version 2.0
   Apache Twill API under The Apache Software License, Version 2.0
   Apache Twill common library under The Apache Software License, Version 2.0
@@ -81,7 +73,6 @@ This project includes:
   Calcite Core under Apache License, Version 2.0
   Calcite Druid under Apache License, Version 2.0
   Calcite Linq4j under Apache License, Version 2.0
-  com.twitter.common:objectsize under Apache License, Version 2.0
   Commons BeanUtils Core under The Apache Software License, Version 2.0
   Commons CLI under The Apache Software License, Version 2.0
   Commons Codec under The Apache Software License, Version 2.0
@@ -156,17 +147,16 @@ This project includes:
   Hive Shims Scheduler under The Apache Software License, Version 2.0
   Hive Storage API under Apache License, Version 2.0
   Hive Vector-Code-Gen Utilities under The Apache Software License, Version 2.0
-  hoodie-client under Apache License, Version 2.0
-  hoodie-common under Apache License, Version 2.0
-  hoodie-hadoop-base-docker under Apache License, Version 2.0
-  hoodie-hadoop-docker under Apache License, Version 2.0
-  hoodie-hadoop-mr under Apache License, Version 2.0
-  hoodie-hive under Apache License, Version 2.0
-  hoodie-spark under Apache License, Version 2.0
-  hoodie-spark-bundle under Apache License, Version 2.0
-  hoodie-timeline-service under Apache License, Version 2.0
   htrace-core under The Apache Software License, Version 2.0
   HttpClient under Apache License
+  hudi-client under Apache License, Version 2.0
+  hudi-common under Apache License, Version 2.0
+  hudi-hadoop-base-docker under Apache License, Version 2.0
+  hudi-hadoop-mr under Apache License, Version 2.0
+  hudi-hive under Apache License, Version 2.0
+  hudi-spark under Apache License, Version 2.0
+  hudi-spark-bundle under Apache License, Version 2.0
+  hudi-timeline-service under Apache License, Version 2.0
   IntelliJ IDEA Annotations under The Apache Software License, Version 2.0
   Jackson under The Apache Software License, Version 2.0
   Jackson Integration for Metrics under Apache License 2.0
@@ -217,6 +207,7 @@ This project includes:
   Jetty Server under Apache Software License - Version 2.0 or Eclipse Public License - Version 1.0
   Jetty SSLEngine under Apache License Version 2
   Jetty Utilities under Apache Software License - Version 2.0 or Eclipse Public License - Version 1.0
+  JLine under The BSD License
   Joda-Time under Apache 2
   Joni under MIT License
   JPam under The Apache Software License, Version 2.0

--- a/docker/hoodie/hadoop/datanode/NOTICE.txt
+++ b/docker/hoodie/hadoop/datanode/NOTICE.txt
@@ -23,7 +23,6 @@ This project includes:
   Apache Calcite Avatica under Apache License, Version 2.0
   Apache Calcite Avatica Metrics under Apache License, Version 2.0
   Apache Commons Collections under Apache License, Version 2.0
-  Apache Commons Configuration under Apache License, Version 2.0
   Apache Commons IO under Apache License, Version 2.0
   Apache Commons Logging under The Apache Software License, Version 2.0
   Apache Curator under The Apache Software License, Version 2.0
@@ -38,6 +37,7 @@ This project includes:
   Apache Hadoop HDFS under Apache License, Version 2.0
   Apache HBase - Annotations under Apache License, Version 2.0
   Apache HBase - Client under Apache License, Version 2.0
+  Apache HBase - Common under Apache License, Version 2.0
   Apache HBase - Protocol under Apache License, Version 2.0
   Apache HttpClient under Apache License, Version 2.0
   Apache HttpCore under Apache License, Version 2.0
@@ -49,21 +49,13 @@ This project includes:
   Apache Log4j SLF4J Binding under The Apache Software License, Version 2.0
   Apache Log4j Web under The Apache Software License, Version 2.0
   Apache Parquet Avro under The Apache Software License, Version 2.0
-  Apache Parquet Avro (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Column under The Apache Software License, Version 2.0
-  Apache Parquet Column (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Common under The Apache Software License, Version 2.0
-  Apache Parquet Common (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Encodings under The Apache Software License, Version 2.0
-  Apache Parquet Encodings (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Format (Incubating) under The Apache Software License, Version 2.0
-  Apache Parquet Generator (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Hadoop under The Apache Software License, Version 2.0
-  Apache Parquet Hadoop (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Hadoop Bundle under The Apache Software License, Version 2.0
-  Apache Parquet Hadoop Bundle (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Jackson under The Apache Software License, Version 2.0
-  Apache Parquet Jackson (Incubating) under The Apache Software License, Version 2.0
   Apache Thrift under The Apache Software License, Version 2.0
   Apache Twill API under The Apache Software License, Version 2.0
   Apache Twill common library under The Apache Software License, Version 2.0
@@ -81,7 +73,6 @@ This project includes:
   Calcite Core under Apache License, Version 2.0
   Calcite Druid under Apache License, Version 2.0
   Calcite Linq4j under Apache License, Version 2.0
-  com.twitter.common:objectsize under Apache License, Version 2.0
   Commons BeanUtils Core under The Apache Software License, Version 2.0
   Commons CLI under The Apache Software License, Version 2.0
   Commons Codec under The Apache Software License, Version 2.0
@@ -156,18 +147,16 @@ This project includes:
   Hive Shims Scheduler under The Apache Software License, Version 2.0
   Hive Storage API under Apache License, Version 2.0
   Hive Vector-Code-Gen Utilities under The Apache Software License, Version 2.0
-  hoodie-client under Apache License, Version 2.0
-  hoodie-common under Apache License, Version 2.0
-  hoodie-hadoop-base-docker under Apache License, Version 2.0
-  hoodie-hadoop-datanode-docker under Apache License, Version 2.0
-  hoodie-hadoop-docker under Apache License, Version 2.0
-  hoodie-hadoop-mr under Apache License, Version 2.0
-  hoodie-hive under Apache License, Version 2.0
-  hoodie-spark under Apache License, Version 2.0
-  hoodie-spark-bundle under Apache License, Version 2.0
-  hoodie-timeline-service under Apache License, Version 2.0
   htrace-core under The Apache Software License, Version 2.0
   HttpClient under Apache License
+  hudi-client under Apache License, Version 2.0
+  hudi-common under Apache License, Version 2.0
+  hudi-hadoop-datanode-docker under Apache License, Version 2.0
+  hudi-hadoop-mr under Apache License, Version 2.0
+  hudi-hive under Apache License, Version 2.0
+  hudi-spark under Apache License, Version 2.0
+  hudi-spark-bundle under Apache License, Version 2.0
+  hudi-timeline-service under Apache License, Version 2.0
   IntelliJ IDEA Annotations under The Apache Software License, Version 2.0
   Jackson under The Apache Software License, Version 2.0
   Jackson Integration for Metrics under Apache License 2.0
@@ -218,6 +207,7 @@ This project includes:
   Jetty Server under Apache Software License - Version 2.0 or Eclipse Public License - Version 1.0
   Jetty SSLEngine under Apache License Version 2
   Jetty Utilities under Apache Software License - Version 2.0 or Eclipse Public License - Version 1.0
+  JLine under The BSD License
   Joda-Time under Apache 2
   Joni under MIT License
   JPam under The Apache Software License, Version 2.0

--- a/docker/hoodie/hadoop/historyserver/NOTICE.txt
+++ b/docker/hoodie/hadoop/historyserver/NOTICE.txt
@@ -23,7 +23,6 @@ This project includes:
   Apache Calcite Avatica under Apache License, Version 2.0
   Apache Calcite Avatica Metrics under Apache License, Version 2.0
   Apache Commons Collections under Apache License, Version 2.0
-  Apache Commons Configuration under Apache License, Version 2.0
   Apache Commons IO under Apache License, Version 2.0
   Apache Commons Logging under The Apache Software License, Version 2.0
   Apache Curator under The Apache Software License, Version 2.0
@@ -38,6 +37,7 @@ This project includes:
   Apache Hadoop HDFS under Apache License, Version 2.0
   Apache HBase - Annotations under Apache License, Version 2.0
   Apache HBase - Client under Apache License, Version 2.0
+  Apache HBase - Common under Apache License, Version 2.0
   Apache HBase - Protocol under Apache License, Version 2.0
   Apache HttpClient under Apache License, Version 2.0
   Apache HttpCore under Apache License, Version 2.0
@@ -49,21 +49,13 @@ This project includes:
   Apache Log4j SLF4J Binding under The Apache Software License, Version 2.0
   Apache Log4j Web under The Apache Software License, Version 2.0
   Apache Parquet Avro under The Apache Software License, Version 2.0
-  Apache Parquet Avro (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Column under The Apache Software License, Version 2.0
-  Apache Parquet Column (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Common under The Apache Software License, Version 2.0
-  Apache Parquet Common (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Encodings under The Apache Software License, Version 2.0
-  Apache Parquet Encodings (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Format (Incubating) under The Apache Software License, Version 2.0
-  Apache Parquet Generator (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Hadoop under The Apache Software License, Version 2.0
-  Apache Parquet Hadoop (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Hadoop Bundle under The Apache Software License, Version 2.0
-  Apache Parquet Hadoop Bundle (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Jackson under The Apache Software License, Version 2.0
-  Apache Parquet Jackson (Incubating) under The Apache Software License, Version 2.0
   Apache Thrift under The Apache Software License, Version 2.0
   Apache Twill API under The Apache Software License, Version 2.0
   Apache Twill common library under The Apache Software License, Version 2.0
@@ -81,7 +73,6 @@ This project includes:
   Calcite Core under Apache License, Version 2.0
   Calcite Druid under Apache License, Version 2.0
   Calcite Linq4j under Apache License, Version 2.0
-  com.twitter.common:objectsize under Apache License, Version 2.0
   Commons BeanUtils Core under The Apache Software License, Version 2.0
   Commons CLI under The Apache Software License, Version 2.0
   Commons Codec under The Apache Software License, Version 2.0
@@ -156,18 +147,16 @@ This project includes:
   Hive Shims Scheduler under The Apache Software License, Version 2.0
   Hive Storage API under Apache License, Version 2.0
   Hive Vector-Code-Gen Utilities under The Apache Software License, Version 2.0
-  hoodie-client under Apache License, Version 2.0
-  hoodie-common under Apache License, Version 2.0
-  hoodie-hadoop-base-docker under Apache License, Version 2.0
-  hoodie-hadoop-docker under Apache License, Version 2.0
-  hoodie-hadoop-history-docker under Apache License, Version 2.0
-  hoodie-hadoop-mr under Apache License, Version 2.0
-  hoodie-hive under Apache License, Version 2.0
-  hoodie-spark under Apache License, Version 2.0
-  hoodie-spark-bundle under Apache License, Version 2.0
-  hoodie-timeline-service under Apache License, Version 2.0
   htrace-core under The Apache Software License, Version 2.0
   HttpClient under Apache License
+  hudi-client under Apache License, Version 2.0
+  hudi-common under Apache License, Version 2.0
+  hudi-hadoop-history-docker under Apache License, Version 2.0
+  hudi-hadoop-mr under Apache License, Version 2.0
+  hudi-hive under Apache License, Version 2.0
+  hudi-spark under Apache License, Version 2.0
+  hudi-spark-bundle under Apache License, Version 2.0
+  hudi-timeline-service under Apache License, Version 2.0
   IntelliJ IDEA Annotations under The Apache Software License, Version 2.0
   Jackson under The Apache Software License, Version 2.0
   Jackson Integration for Metrics under Apache License 2.0
@@ -218,6 +207,7 @@ This project includes:
   Jetty Server under Apache Software License - Version 2.0 or Eclipse Public License - Version 1.0
   Jetty SSLEngine under Apache License Version 2
   Jetty Utilities under Apache Software License - Version 2.0 or Eclipse Public License - Version 1.0
+  JLine under The BSD License
   Joda-Time under Apache 2
   Joni under MIT License
   JPam under The Apache Software License, Version 2.0

--- a/docker/hoodie/hadoop/hive_base/NOTICE.txt
+++ b/docker/hoodie/hadoop/hive_base/NOTICE.txt
@@ -23,7 +23,6 @@ This project includes:
   Apache Calcite Avatica under Apache License, Version 2.0
   Apache Calcite Avatica Metrics under Apache License, Version 2.0
   Apache Commons Collections under Apache License, Version 2.0
-  Apache Commons Configuration under Apache License, Version 2.0
   Apache Commons IO under Apache License, Version 2.0
   Apache Commons Logging under The Apache Software License, Version 2.0
   Apache Curator under The Apache Software License, Version 2.0
@@ -38,6 +37,7 @@ This project includes:
   Apache Hadoop HDFS under Apache License, Version 2.0
   Apache HBase - Annotations under Apache License, Version 2.0
   Apache HBase - Client under Apache License, Version 2.0
+  Apache HBase - Common under Apache License, Version 2.0
   Apache HBase - Protocol under Apache License, Version 2.0
   Apache HttpClient under Apache License, Version 2.0
   Apache HttpCore under Apache License, Version 2.0
@@ -49,21 +49,13 @@ This project includes:
   Apache Log4j SLF4J Binding under The Apache Software License, Version 2.0
   Apache Log4j Web under The Apache Software License, Version 2.0
   Apache Parquet Avro under The Apache Software License, Version 2.0
-  Apache Parquet Avro (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Column under The Apache Software License, Version 2.0
-  Apache Parquet Column (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Common under The Apache Software License, Version 2.0
-  Apache Parquet Common (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Encodings under The Apache Software License, Version 2.0
-  Apache Parquet Encodings (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Format (Incubating) under The Apache Software License, Version 2.0
-  Apache Parquet Generator (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Hadoop under The Apache Software License, Version 2.0
-  Apache Parquet Hadoop (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Hadoop Bundle under The Apache Software License, Version 2.0
-  Apache Parquet Hadoop Bundle (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Jackson under The Apache Software License, Version 2.0
-  Apache Parquet Jackson (Incubating) under The Apache Software License, Version 2.0
   Apache Thrift under The Apache Software License, Version 2.0
   Apache Twill API under The Apache Software License, Version 2.0
   Apache Twill common library under The Apache Software License, Version 2.0
@@ -81,7 +73,6 @@ This project includes:
   Calcite Core under Apache License, Version 2.0
   Calcite Druid under Apache License, Version 2.0
   Calcite Linq4j under Apache License, Version 2.0
-  com.twitter.common:objectsize under Apache License, Version 2.0
   Commons BeanUtils Core under The Apache Software License, Version 2.0
   Commons CLI under The Apache Software License, Version 2.0
   Commons Codec under The Apache Software License, Version 2.0
@@ -156,18 +147,16 @@ This project includes:
   Hive Shims Scheduler under The Apache Software License, Version 2.0
   Hive Storage API under Apache License, Version 2.0
   Hive Vector-Code-Gen Utilities under The Apache Software License, Version 2.0
-  hoodie-client under Apache License, Version 2.0
-  hoodie-common under Apache License, Version 2.0
-  hoodie-hadoop-base-docker under Apache License, Version 2.0
-  hoodie-hadoop-docker under Apache License, Version 2.0
-  hoodie-hadoop-hive-docker under Apache License, Version 2.0
-  hoodie-hadoop-mr under Apache License, Version 2.0
-  hoodie-hive under Apache License, Version 2.0
-  hoodie-spark under Apache License, Version 2.0
-  hoodie-spark-bundle under Apache License, Version 2.0
-  hoodie-timeline-service under Apache License, Version 2.0
   htrace-core under The Apache Software License, Version 2.0
   HttpClient under Apache License
+  hudi-client under Apache License, Version 2.0
+  hudi-common under Apache License, Version 2.0
+  hudi-hadoop-hive-docker under Apache License, Version 2.0
+  hudi-hadoop-mr under Apache License, Version 2.0
+  hudi-hive under Apache License, Version 2.0
+  hudi-spark under Apache License, Version 2.0
+  hudi-spark-bundle under Apache License, Version 2.0
+  hudi-timeline-service under Apache License, Version 2.0
   IntelliJ IDEA Annotations under The Apache Software License, Version 2.0
   Jackson under The Apache Software License, Version 2.0
   Jackson Integration for Metrics under Apache License 2.0
@@ -218,6 +207,7 @@ This project includes:
   Jetty Server under Apache Software License - Version 2.0 or Eclipse Public License - Version 1.0
   Jetty SSLEngine under Apache License Version 2
   Jetty Utilities under Apache Software License - Version 2.0 or Eclipse Public License - Version 1.0
+  JLine under The BSD License
   Joda-Time under Apache 2
   Joni under MIT License
   JPam under The Apache Software License, Version 2.0

--- a/docker/hoodie/hadoop/namenode/NOTICE.txt
+++ b/docker/hoodie/hadoop/namenode/NOTICE.txt
@@ -23,7 +23,6 @@ This project includes:
   Apache Calcite Avatica under Apache License, Version 2.0
   Apache Calcite Avatica Metrics under Apache License, Version 2.0
   Apache Commons Collections under Apache License, Version 2.0
-  Apache Commons Configuration under Apache License, Version 2.0
   Apache Commons IO under Apache License, Version 2.0
   Apache Commons Logging under The Apache Software License, Version 2.0
   Apache Curator under The Apache Software License, Version 2.0
@@ -38,6 +37,7 @@ This project includes:
   Apache Hadoop HDFS under Apache License, Version 2.0
   Apache HBase - Annotations under Apache License, Version 2.0
   Apache HBase - Client under Apache License, Version 2.0
+  Apache HBase - Common under Apache License, Version 2.0
   Apache HBase - Protocol under Apache License, Version 2.0
   Apache HttpClient under Apache License, Version 2.0
   Apache HttpCore under Apache License, Version 2.0
@@ -49,21 +49,13 @@ This project includes:
   Apache Log4j SLF4J Binding under The Apache Software License, Version 2.0
   Apache Log4j Web under The Apache Software License, Version 2.0
   Apache Parquet Avro under The Apache Software License, Version 2.0
-  Apache Parquet Avro (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Column under The Apache Software License, Version 2.0
-  Apache Parquet Column (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Common under The Apache Software License, Version 2.0
-  Apache Parquet Common (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Encodings under The Apache Software License, Version 2.0
-  Apache Parquet Encodings (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Format (Incubating) under The Apache Software License, Version 2.0
-  Apache Parquet Generator (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Hadoop under The Apache Software License, Version 2.0
-  Apache Parquet Hadoop (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Hadoop Bundle under The Apache Software License, Version 2.0
-  Apache Parquet Hadoop Bundle (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Jackson under The Apache Software License, Version 2.0
-  Apache Parquet Jackson (Incubating) under The Apache Software License, Version 2.0
   Apache Thrift under The Apache Software License, Version 2.0
   Apache Twill API under The Apache Software License, Version 2.0
   Apache Twill common library under The Apache Software License, Version 2.0
@@ -81,7 +73,6 @@ This project includes:
   Calcite Core under Apache License, Version 2.0
   Calcite Druid under Apache License, Version 2.0
   Calcite Linq4j under Apache License, Version 2.0
-  com.twitter.common:objectsize under Apache License, Version 2.0
   Commons BeanUtils Core under The Apache Software License, Version 2.0
   Commons CLI under The Apache Software License, Version 2.0
   Commons Codec under The Apache Software License, Version 2.0
@@ -156,18 +147,16 @@ This project includes:
   Hive Shims Scheduler under The Apache Software License, Version 2.0
   Hive Storage API under Apache License, Version 2.0
   Hive Vector-Code-Gen Utilities under The Apache Software License, Version 2.0
-  hoodie-client under Apache License, Version 2.0
-  hoodie-common under Apache License, Version 2.0
-  hoodie-hadoop-base-docker under Apache License, Version 2.0
-  hoodie-hadoop-docker under Apache License, Version 2.0
-  hoodie-hadoop-mr under Apache License, Version 2.0
-  hoodie-hadoop-namenode-docker under Apache License, Version 2.0
-  hoodie-hive under Apache License, Version 2.0
-  hoodie-spark under Apache License, Version 2.0
-  hoodie-spark-bundle under Apache License, Version 2.0
-  hoodie-timeline-service under Apache License, Version 2.0
   htrace-core under The Apache Software License, Version 2.0
   HttpClient under Apache License
+  hudi-client under Apache License, Version 2.0
+  hudi-common under Apache License, Version 2.0
+  hudi-hadoop-mr under Apache License, Version 2.0
+  hudi-hadoop-namenode-docker under Apache License, Version 2.0
+  hudi-hive under Apache License, Version 2.0
+  hudi-spark under Apache License, Version 2.0
+  hudi-spark-bundle under Apache License, Version 2.0
+  hudi-timeline-service under Apache License, Version 2.0
   IntelliJ IDEA Annotations under The Apache Software License, Version 2.0
   Jackson under The Apache Software License, Version 2.0
   Jackson Integration for Metrics under Apache License 2.0
@@ -218,6 +207,7 @@ This project includes:
   Jetty Server under Apache Software License - Version 2.0 or Eclipse Public License - Version 1.0
   Jetty SSLEngine under Apache License Version 2
   Jetty Utilities under Apache Software License - Version 2.0 or Eclipse Public License - Version 1.0
+  JLine under The BSD License
   Joda-Time under Apache 2
   Joni under MIT License
   JPam under The Apache Software License, Version 2.0

--- a/docker/hoodie/hadoop/spark_base/NOTICE.txt
+++ b/docker/hoodie/hadoop/spark_base/NOTICE.txt
@@ -23,7 +23,6 @@ This project includes:
   Apache Calcite Avatica under Apache License, Version 2.0
   Apache Calcite Avatica Metrics under Apache License, Version 2.0
   Apache Commons Collections under Apache License, Version 2.0
-  Apache Commons Configuration under Apache License, Version 2.0
   Apache Commons IO under Apache License, Version 2.0
   Apache Commons Logging under The Apache Software License, Version 2.0
   Apache Curator under The Apache Software License, Version 2.0
@@ -38,6 +37,7 @@ This project includes:
   Apache Hadoop HDFS under Apache License, Version 2.0
   Apache HBase - Annotations under Apache License, Version 2.0
   Apache HBase - Client under Apache License, Version 2.0
+  Apache HBase - Common under Apache License, Version 2.0
   Apache HBase - Protocol under Apache License, Version 2.0
   Apache HttpClient under Apache License, Version 2.0
   Apache HttpCore under Apache License, Version 2.0
@@ -49,21 +49,13 @@ This project includes:
   Apache Log4j SLF4J Binding under The Apache Software License, Version 2.0
   Apache Log4j Web under The Apache Software License, Version 2.0
   Apache Parquet Avro under The Apache Software License, Version 2.0
-  Apache Parquet Avro (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Column under The Apache Software License, Version 2.0
-  Apache Parquet Column (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Common under The Apache Software License, Version 2.0
-  Apache Parquet Common (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Encodings under The Apache Software License, Version 2.0
-  Apache Parquet Encodings (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Format (Incubating) under The Apache Software License, Version 2.0
-  Apache Parquet Generator (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Hadoop under The Apache Software License, Version 2.0
-  Apache Parquet Hadoop (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Hadoop Bundle under The Apache Software License, Version 2.0
-  Apache Parquet Hadoop Bundle (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Jackson under The Apache Software License, Version 2.0
-  Apache Parquet Jackson (Incubating) under The Apache Software License, Version 2.0
   Apache Thrift under The Apache Software License, Version 2.0
   Apache Twill API under The Apache Software License, Version 2.0
   Apache Twill common library under The Apache Software License, Version 2.0
@@ -81,7 +73,6 @@ This project includes:
   Calcite Core under Apache License, Version 2.0
   Calcite Druid under Apache License, Version 2.0
   Calcite Linq4j under Apache License, Version 2.0
-  com.twitter.common:objectsize under Apache License, Version 2.0
   Commons BeanUtils Core under The Apache Software License, Version 2.0
   Commons CLI under The Apache Software License, Version 2.0
   Commons Codec under The Apache Software License, Version 2.0
@@ -156,19 +147,16 @@ This project includes:
   Hive Shims Scheduler under The Apache Software License, Version 2.0
   Hive Storage API under Apache License, Version 2.0
   Hive Vector-Code-Gen Utilities under The Apache Software License, Version 2.0
-  hoodie-client under Apache License, Version 2.0
-  hoodie-common under Apache License, Version 2.0
-  hoodie-hadoop-base-docker under Apache License, Version 2.0
-  hoodie-hadoop-docker under Apache License, Version 2.0
-  hoodie-hadoop-hive-docker under Apache License, Version 2.0
-  hoodie-hadoop-mr under Apache License, Version 2.0
-  hoodie-hadoop-sparkbase-docker under Apache License, Version 2.0
-  hoodie-hive under Apache License, Version 2.0
-  hoodie-spark under Apache License, Version 2.0
-  hoodie-spark-bundle under Apache License, Version 2.0
-  hoodie-timeline-service under Apache License, Version 2.0
   htrace-core under The Apache Software License, Version 2.0
   HttpClient under Apache License
+  hudi-client under Apache License, Version 2.0
+  hudi-common under Apache License, Version 2.0
+  hudi-hadoop-mr under Apache License, Version 2.0
+  hudi-hadoop-sparkbase-docker under Apache License, Version 2.0
+  hudi-hive under Apache License, Version 2.0
+  hudi-spark under Apache License, Version 2.0
+  hudi-spark-bundle under Apache License, Version 2.0
+  hudi-timeline-service under Apache License, Version 2.0
   IntelliJ IDEA Annotations under The Apache Software License, Version 2.0
   Jackson under The Apache Software License, Version 2.0
   Jackson Integration for Metrics under Apache License 2.0
@@ -219,6 +207,7 @@ This project includes:
   Jetty Server under Apache Software License - Version 2.0 or Eclipse Public License - Version 1.0
   Jetty SSLEngine under Apache License Version 2
   Jetty Utilities under Apache Software License - Version 2.0 or Eclipse Public License - Version 1.0
+  JLine under The BSD License
   Joda-Time under Apache 2
   Joni under MIT License
   JPam under The Apache Software License, Version 2.0

--- a/docker/hoodie/hadoop/sparkadhoc/NOTICE.txt
+++ b/docker/hoodie/hadoop/sparkadhoc/NOTICE.txt
@@ -23,7 +23,6 @@ This project includes:
   Apache Calcite Avatica under Apache License, Version 2.0
   Apache Calcite Avatica Metrics under Apache License, Version 2.0
   Apache Commons Collections under Apache License, Version 2.0
-  Apache Commons Configuration under Apache License, Version 2.0
   Apache Commons IO under Apache License, Version 2.0
   Apache Commons Logging under The Apache Software License, Version 2.0
   Apache Curator under The Apache Software License, Version 2.0
@@ -38,6 +37,7 @@ This project includes:
   Apache Hadoop HDFS under Apache License, Version 2.0
   Apache HBase - Annotations under Apache License, Version 2.0
   Apache HBase - Client under Apache License, Version 2.0
+  Apache HBase - Common under Apache License, Version 2.0
   Apache HBase - Protocol under Apache License, Version 2.0
   Apache HttpClient under Apache License, Version 2.0
   Apache HttpCore under Apache License, Version 2.0
@@ -49,21 +49,13 @@ This project includes:
   Apache Log4j SLF4J Binding under The Apache Software License, Version 2.0
   Apache Log4j Web under The Apache Software License, Version 2.0
   Apache Parquet Avro under The Apache Software License, Version 2.0
-  Apache Parquet Avro (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Column under The Apache Software License, Version 2.0
-  Apache Parquet Column (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Common under The Apache Software License, Version 2.0
-  Apache Parquet Common (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Encodings under The Apache Software License, Version 2.0
-  Apache Parquet Encodings (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Format (Incubating) under The Apache Software License, Version 2.0
-  Apache Parquet Generator (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Hadoop under The Apache Software License, Version 2.0
-  Apache Parquet Hadoop (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Hadoop Bundle under The Apache Software License, Version 2.0
-  Apache Parquet Hadoop Bundle (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Jackson under The Apache Software License, Version 2.0
-  Apache Parquet Jackson (Incubating) under The Apache Software License, Version 2.0
   Apache Thrift under The Apache Software License, Version 2.0
   Apache Twill API under The Apache Software License, Version 2.0
   Apache Twill common library under The Apache Software License, Version 2.0
@@ -81,7 +73,6 @@ This project includes:
   Calcite Core under Apache License, Version 2.0
   Calcite Druid under Apache License, Version 2.0
   Calcite Linq4j under Apache License, Version 2.0
-  com.twitter.common:objectsize under Apache License, Version 2.0
   Commons BeanUtils Core under The Apache Software License, Version 2.0
   Commons CLI under The Apache Software License, Version 2.0
   Commons Codec under The Apache Software License, Version 2.0
@@ -156,20 +147,16 @@ This project includes:
   Hive Shims Scheduler under The Apache Software License, Version 2.0
   Hive Storage API under Apache License, Version 2.0
   Hive Vector-Code-Gen Utilities under The Apache Software License, Version 2.0
-  hoodie-client under Apache License, Version 2.0
-  hoodie-common under Apache License, Version 2.0
-  hoodie-hadoop-base-docker under Apache License, Version 2.0
-  hoodie-hadoop-docker under Apache License, Version 2.0
-  hoodie-hadoop-hive-docker under Apache License, Version 2.0
-  hoodie-hadoop-mr under Apache License, Version 2.0
-  hoodie-hadoop-sparkadhoc-docker under Apache License, Version 2.0
-  hoodie-hadoop-sparkbase-docker under Apache License, Version 2.0
-  hoodie-hive under Apache License, Version 2.0
-  hoodie-spark under Apache License, Version 2.0
-  hoodie-spark-bundle under Apache License, Version 2.0
-  hoodie-timeline-service under Apache License, Version 2.0
   htrace-core under The Apache Software License, Version 2.0
   HttpClient under Apache License
+  hudi-client under Apache License, Version 2.0
+  hudi-common under Apache License, Version 2.0
+  hudi-hadoop-mr under Apache License, Version 2.0
+  hudi-hadoop-sparkadhoc-docker under Apache License, Version 2.0
+  hudi-hive under Apache License, Version 2.0
+  hudi-spark under Apache License, Version 2.0
+  hudi-spark-bundle under Apache License, Version 2.0
+  hudi-timeline-service under Apache License, Version 2.0
   IntelliJ IDEA Annotations under The Apache Software License, Version 2.0
   Jackson under The Apache Software License, Version 2.0
   Jackson Integration for Metrics under Apache License 2.0
@@ -220,6 +207,7 @@ This project includes:
   Jetty Server under Apache Software License - Version 2.0 or Eclipse Public License - Version 1.0
   Jetty SSLEngine under Apache License Version 2
   Jetty Utilities under Apache Software License - Version 2.0 or Eclipse Public License - Version 1.0
+  JLine under The BSD License
   Joda-Time under Apache 2
   Joni under MIT License
   JPam under The Apache Software License, Version 2.0

--- a/docker/hoodie/hadoop/sparkmaster/NOTICE.txt
+++ b/docker/hoodie/hadoop/sparkmaster/NOTICE.txt
@@ -23,7 +23,6 @@ This project includes:
   Apache Calcite Avatica under Apache License, Version 2.0
   Apache Calcite Avatica Metrics under Apache License, Version 2.0
   Apache Commons Collections under Apache License, Version 2.0
-  Apache Commons Configuration under Apache License, Version 2.0
   Apache Commons IO under Apache License, Version 2.0
   Apache Commons Logging under The Apache Software License, Version 2.0
   Apache Curator under The Apache Software License, Version 2.0
@@ -38,6 +37,7 @@ This project includes:
   Apache Hadoop HDFS under Apache License, Version 2.0
   Apache HBase - Annotations under Apache License, Version 2.0
   Apache HBase - Client under Apache License, Version 2.0
+  Apache HBase - Common under Apache License, Version 2.0
   Apache HBase - Protocol under Apache License, Version 2.0
   Apache HttpClient under Apache License, Version 2.0
   Apache HttpCore under Apache License, Version 2.0
@@ -49,21 +49,13 @@ This project includes:
   Apache Log4j SLF4J Binding under The Apache Software License, Version 2.0
   Apache Log4j Web under The Apache Software License, Version 2.0
   Apache Parquet Avro under The Apache Software License, Version 2.0
-  Apache Parquet Avro (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Column under The Apache Software License, Version 2.0
-  Apache Parquet Column (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Common under The Apache Software License, Version 2.0
-  Apache Parquet Common (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Encodings under The Apache Software License, Version 2.0
-  Apache Parquet Encodings (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Format (Incubating) under The Apache Software License, Version 2.0
-  Apache Parquet Generator (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Hadoop under The Apache Software License, Version 2.0
-  Apache Parquet Hadoop (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Hadoop Bundle under The Apache Software License, Version 2.0
-  Apache Parquet Hadoop Bundle (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Jackson under The Apache Software License, Version 2.0
-  Apache Parquet Jackson (Incubating) under The Apache Software License, Version 2.0
   Apache Thrift under The Apache Software License, Version 2.0
   Apache Twill API under The Apache Software License, Version 2.0
   Apache Twill common library under The Apache Software License, Version 2.0
@@ -81,7 +73,6 @@ This project includes:
   Calcite Core under Apache License, Version 2.0
   Calcite Druid under Apache License, Version 2.0
   Calcite Linq4j under Apache License, Version 2.0
-  com.twitter.common:objectsize under Apache License, Version 2.0
   Commons BeanUtils Core under The Apache Software License, Version 2.0
   Commons CLI under The Apache Software License, Version 2.0
   Commons Codec under The Apache Software License, Version 2.0
@@ -156,20 +147,16 @@ This project includes:
   Hive Shims Scheduler under The Apache Software License, Version 2.0
   Hive Storage API under Apache License, Version 2.0
   Hive Vector-Code-Gen Utilities under The Apache Software License, Version 2.0
-  hoodie-client under Apache License, Version 2.0
-  hoodie-common under Apache License, Version 2.0
-  hoodie-hadoop-base-docker under Apache License, Version 2.0
-  hoodie-hadoop-docker under Apache License, Version 2.0
-  hoodie-hadoop-hive-docker under Apache License, Version 2.0
-  hoodie-hadoop-mr under Apache License, Version 2.0
-  hoodie-hadoop-sparkbase-docker under Apache License, Version 2.0
-  hoodie-hadoop-sparkmaster-docker under Apache License, Version 2.0
-  hoodie-hive under Apache License, Version 2.0
-  hoodie-spark under Apache License, Version 2.0
-  hoodie-spark-bundle under Apache License, Version 2.0
-  hoodie-timeline-service under Apache License, Version 2.0
   htrace-core under The Apache Software License, Version 2.0
   HttpClient under Apache License
+  hudi-client under Apache License, Version 2.0
+  hudi-common under Apache License, Version 2.0
+  hudi-hadoop-mr under Apache License, Version 2.0
+  hudi-hadoop-sparkmaster-docker under Apache License, Version 2.0
+  hudi-hive under Apache License, Version 2.0
+  hudi-spark under Apache License, Version 2.0
+  hudi-spark-bundle under Apache License, Version 2.0
+  hudi-timeline-service under Apache License, Version 2.0
   IntelliJ IDEA Annotations under The Apache Software License, Version 2.0
   Jackson under The Apache Software License, Version 2.0
   Jackson Integration for Metrics under Apache License 2.0
@@ -220,6 +207,7 @@ This project includes:
   Jetty Server under Apache Software License - Version 2.0 or Eclipse Public License - Version 1.0
   Jetty SSLEngine under Apache License Version 2
   Jetty Utilities under Apache Software License - Version 2.0 or Eclipse Public License - Version 1.0
+  JLine under The BSD License
   Joda-Time under Apache 2
   Joni under MIT License
   JPam under The Apache Software License, Version 2.0

--- a/docker/hoodie/hadoop/sparkworker/NOTICE.txt
+++ b/docker/hoodie/hadoop/sparkworker/NOTICE.txt
@@ -23,7 +23,6 @@ This project includes:
   Apache Calcite Avatica under Apache License, Version 2.0
   Apache Calcite Avatica Metrics under Apache License, Version 2.0
   Apache Commons Collections under Apache License, Version 2.0
-  Apache Commons Configuration under Apache License, Version 2.0
   Apache Commons IO under Apache License, Version 2.0
   Apache Commons Logging under The Apache Software License, Version 2.0
   Apache Curator under The Apache Software License, Version 2.0
@@ -38,6 +37,7 @@ This project includes:
   Apache Hadoop HDFS under Apache License, Version 2.0
   Apache HBase - Annotations under Apache License, Version 2.0
   Apache HBase - Client under Apache License, Version 2.0
+  Apache HBase - Common under Apache License, Version 2.0
   Apache HBase - Protocol under Apache License, Version 2.0
   Apache HttpClient under Apache License, Version 2.0
   Apache HttpCore under Apache License, Version 2.0
@@ -49,21 +49,13 @@ This project includes:
   Apache Log4j SLF4J Binding under The Apache Software License, Version 2.0
   Apache Log4j Web under The Apache Software License, Version 2.0
   Apache Parquet Avro under The Apache Software License, Version 2.0
-  Apache Parquet Avro (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Column under The Apache Software License, Version 2.0
-  Apache Parquet Column (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Common under The Apache Software License, Version 2.0
-  Apache Parquet Common (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Encodings under The Apache Software License, Version 2.0
-  Apache Parquet Encodings (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Format (Incubating) under The Apache Software License, Version 2.0
-  Apache Parquet Generator (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Hadoop under The Apache Software License, Version 2.0
-  Apache Parquet Hadoop (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Hadoop Bundle under The Apache Software License, Version 2.0
-  Apache Parquet Hadoop Bundle (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Jackson under The Apache Software License, Version 2.0
-  Apache Parquet Jackson (Incubating) under The Apache Software License, Version 2.0
   Apache Thrift under The Apache Software License, Version 2.0
   Apache Twill API under The Apache Software License, Version 2.0
   Apache Twill common library under The Apache Software License, Version 2.0
@@ -81,7 +73,6 @@ This project includes:
   Calcite Core under Apache License, Version 2.0
   Calcite Druid under Apache License, Version 2.0
   Calcite Linq4j under Apache License, Version 2.0
-  com.twitter.common:objectsize under Apache License, Version 2.0
   Commons BeanUtils Core under The Apache Software License, Version 2.0
   Commons CLI under The Apache Software License, Version 2.0
   Commons Codec under The Apache Software License, Version 2.0
@@ -156,20 +147,16 @@ This project includes:
   Hive Shims Scheduler under The Apache Software License, Version 2.0
   Hive Storage API under Apache License, Version 2.0
   Hive Vector-Code-Gen Utilities under The Apache Software License, Version 2.0
-  hoodie-client under Apache License, Version 2.0
-  hoodie-common under Apache License, Version 2.0
-  hoodie-hadoop-base-docker under Apache License, Version 2.0
-  hoodie-hadoop-docker under Apache License, Version 2.0
-  hoodie-hadoop-hive-docker under Apache License, Version 2.0
-  hoodie-hadoop-mr under Apache License, Version 2.0
-  hoodie-hadoop-sparkbase-docker under Apache License, Version 2.0
-  hoodie-hadoop-sparkworker-docker under Apache License, Version 2.0
-  hoodie-hive under Apache License, Version 2.0
-  hoodie-spark under Apache License, Version 2.0
-  hoodie-spark-bundle under Apache License, Version 2.0
-  hoodie-timeline-service under Apache License, Version 2.0
   htrace-core under The Apache Software License, Version 2.0
   HttpClient under Apache License
+  hudi-client under Apache License, Version 2.0
+  hudi-common under Apache License, Version 2.0
+  hudi-hadoop-mr under Apache License, Version 2.0
+  hudi-hadoop-sparkworker-docker under Apache License, Version 2.0
+  hudi-hive under Apache License, Version 2.0
+  hudi-spark under Apache License, Version 2.0
+  hudi-spark-bundle under Apache License, Version 2.0
+  hudi-timeline-service under Apache License, Version 2.0
   IntelliJ IDEA Annotations under The Apache Software License, Version 2.0
   Jackson under The Apache Software License, Version 2.0
   Jackson Integration for Metrics under Apache License 2.0
@@ -220,6 +207,7 @@ This project includes:
   Jetty Server under Apache Software License - Version 2.0 or Eclipse Public License - Version 1.0
   Jetty SSLEngine under Apache License Version 2
   Jetty Utilities under Apache Software License - Version 2.0 or Eclipse Public License - Version 1.0
+  JLine under The BSD License
   Joda-Time under Apache 2
   Joni under MIT License
   JPam under The Apache Software License, Version 2.0

--- a/hudi-cli/src/main/resources/META-INF/NOTICE.txt
+++ b/hudi-cli/src/main/resources/META-INF/NOTICE.txt
@@ -18,7 +18,6 @@ This project includes:
   Apache Avro IPC under The Apache Software License, Version 2.0
   Apache Avro Mapred API under The Apache Software License, Version 2.0
   Apache Commons Collections under Apache License, Version 2.0
-  Apache Commons Configuration under Apache License, Version 2.0
   Apache Commons Crypto under Apache License, Version 2.0
   Apache Commons IO under Apache License, Version 2.0
   Apache Commons Lang under Apache License, Version 2.0
@@ -40,34 +39,22 @@ This project includes:
   Apache Kafka under The Apache Software License, Version 2.0
   Apache Log4j under The Apache Software License, Version 2.0
   Apache Parquet Avro under The Apache Software License, Version 2.0
-  Apache Parquet Avro (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Column under The Apache Software License, Version 2.0
-  Apache Parquet Column (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Common under The Apache Software License, Version 2.0
-  Apache Parquet Common (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Encodings under The Apache Software License, Version 2.0
-  Apache Parquet Encodings (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Format (Incubating) under The Apache Software License, Version 2.0
-  Apache Parquet Generator (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Hadoop under The Apache Software License, Version 2.0
-  Apache Parquet Hadoop (Incubating) under The Apache Software License, Version 2.0
-  Apache Parquet Hadoop Bundle (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Jackson under The Apache Software License, Version 2.0
-  Apache Parquet Jackson (Incubating) under The Apache Software License, Version 2.0
-  Apache Thrift under The Apache Software License, Version 2.0
   Apache Velocity under The Apache Software License, Version 2.0
   Apache XBean :: ASM 5 shaded (repackaged) under null or null
   ApacheDS I18n under The Apache Software License, Version 2.0
   ApacheDS Protocol Kerberos Codec under The Apache Software License, Version 2.0
-  ASCII List under Apache 2
-  Ascii Table under Apache 2
   ASM Core under 3-Clause BSD License
   Bean Validation API under The Apache Software License, Version 2.0
   bijection-avro under Apache 2
   bijection-core under Apache 2
   chill under Apache 2
   chill-java under Apache 2
-  com.twitter.common:objectsize under Apache License, Version 2.0
   Commons BeanUtils Core under The Apache Software License, Version 2.0
   Commons CLI under The Apache Software License, Version 2.0
   Commons Codec under The Apache Software License, Version 2.0
@@ -105,19 +92,19 @@ This project includes:
   hadoop-yarn-client under Apache License, Version 2.0
   hadoop-yarn-common under Apache License, Version 2.0
   hadoop-yarn-server-common under Apache License, Version 2.0
-  Hamcrest Core under BSD style
+  Hamcrest Core under New BSD License
   HK2 API module under CDDL + GPLv2 with classpath exception
   HK2 Implementation Utilities under CDDL + GPLv2 with classpath exception
-  hoodie-cli under Apache License, Version 2.0
-  hoodie-client under Apache License, Version 2.0
-  hoodie-common under Apache License, Version 2.0
-  hoodie-hadoop-mr under Apache License, Version 2.0
-  hoodie-hive under Apache License, Version 2.0
-  hoodie-spark under Apache License, Version 2.0
-  hoodie-timeline-service under Apache License, Version 2.0
-  hoodie-utilities under Apache License, Version 2.0
   htrace-core under The Apache Software License, Version 2.0
   HttpClient under Apache License
+  hudi-cli under Apache License, Version 2.0
+  hudi-client under Apache License, Version 2.0
+  hudi-common under Apache License, Version 2.0
+  hudi-hadoop-mr under Apache License, Version 2.0
+  hudi-hive under Apache License, Version 2.0
+  hudi-spark under Apache License, Version 2.0
+  hudi-timeline-service under Apache License, Version 2.0
+  hudi-utilities under Apache License, Version 2.0
   IntelliJ IDEA Annotations under The Apache Software License, Version 2.0
   io.confluent:common-config under Apache License, Version 2.0
   io.confluent:common-utils under Apache License, Version 2.0
@@ -131,6 +118,7 @@ This project includes:
   Jackson-module-paranamer under The Apache Software License, Version 2.0
   jackson-module-scala under The Apache Software License, Version 2.0
   Janino under New BSD License
+  Java Servlet API under CDDL + GPLv2 with classpath exception
   java-xmlbuilder under Apache License, Version 2.0
   Javalin under The Apache Software License, Version 2.0
   Javassist under MPL 1.1 or LGPL 2.1 or Apache License 2.0
@@ -155,7 +143,6 @@ This project includes:
   jersey-server under CDDL 1.1 or GPL2 w/ CPE
   Jettison under Apache License, Version 2.0
   Jetty :: Asynchronous HTTP Client under Apache Software License - Version 2.0 or Eclipse Public License - Version 1.0
-  Jetty :: Continuation under Apache Software License - Version 2.0 or Eclipse Public License - Version 1.0
   Jetty :: Http Utility under Apache Software License - Version 2.0 or Eclipse Public License - Version 1.0
   Jetty :: IO Utility under Apache Software License - Version 2.0 or Eclipse Public License - Version 1.0
   Jetty :: Security under Apache Software License - Version 2.0 or Eclipse Public License - Version 1.0
@@ -223,9 +210,9 @@ This project includes:
   Spark Project Shuffle Streaming Service under Apache 2.0 License
   Spark Project Sketch under Apache 2.0 License
   Spark Project SQL under Apache 2.0 License
+  Spark Project Streaming under Apache 2.0 License
   Spark Project Tags under Apache 2.0 License
   Spark Project Unsafe under Apache 2.0 License
-  spark-avro under Apache-2.0
   Spring AOP under The Apache Software License, Version 2.0
   Spring Beans under The Apache Software License, Version 2.0
   Spring Context under The Apache Software License, Version 2.0

--- a/hudi-client/src/main/resources/META-INF/NOTICE.txt
+++ b/hudi-client/src/main/resources/META-INF/NOTICE.txt
@@ -58,21 +58,13 @@ This project includes:
   Apache Log4j SLF4J Binding under The Apache Software License, Version 2.0
   Apache Log4j Web under The Apache Software License, Version 2.0
   Apache Parquet Avro under The Apache Software License, Version 2.0
-  Apache Parquet Avro (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Column under The Apache Software License, Version 2.0
-  Apache Parquet Column (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Common under The Apache Software License, Version 2.0
-  Apache Parquet Common (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Encodings under The Apache Software License, Version 2.0
-  Apache Parquet Encodings (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Format (Incubating) under The Apache Software License, Version 2.0
-  Apache Parquet Generator (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Hadoop under The Apache Software License, Version 2.0
-  Apache Parquet Hadoop (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Hadoop Bundle under The Apache Software License, Version 2.0
-  Apache Parquet Hadoop Bundle (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Jackson under The Apache Software License, Version 2.0
-  Apache Parquet Jackson (Incubating) under The Apache Software License, Version 2.0
   Apache Thrift under The Apache Software License, Version 2.0
   Apache Velocity under The Apache Software License, Version 2.0
   Apache XBean :: ASM 5 shaded (repackaged) under null or null
@@ -87,7 +79,6 @@ This project includes:
   Calcite Linq4j under Apache License, Version 2.0
   chill under Apache 2
   chill-java under Apache 2
-  com.twitter.common:objectsize under Apache License, Version 2.0
   Commons BeanUtils Core under The Apache Software License, Version 2.0
   Commons CLI under The Apache Software License, Version 2.0
   Commons Codec under The Apache Software License, Version 2.0
@@ -133,12 +124,12 @@ This project includes:
   hadoop-yarn-api under Apache License, Version 2.0
   hadoop-yarn-client under Apache License, Version 2.0
   hadoop-yarn-common under Apache License, Version 2.0
-  hadoop-yarn-server-applicationhistoryservice under Apache License, Version 2.0
+  hadoop-yarn-server-applicationhistoryservice under The Apache Software License, Version 2.0
   hadoop-yarn-server-common under Apache License, Version 2.0
   hadoop-yarn-server-nodemanager under The Apache Software License, Version 2.0
-  hadoop-yarn-server-resourcemanager under Apache License, Version 2.0
+  hadoop-yarn-server-resourcemanager under The Apache Software License, Version 2.0
   hadoop-yarn-server-tests under The Apache Software License, Version 2.0
-  hadoop-yarn-server-web-proxy under Apache License, Version 2.0
+  hadoop-yarn-server-web-proxy under The Apache Software License, Version 2.0
   Hamcrest Core under New BSD License
   Hive Common under The Apache Software License, Version 2.0
   Hive Llap Client under The Apache Software License, Version 2.0
@@ -155,12 +146,12 @@ This project includes:
   Hive Vector-Code-Gen Utilities under The Apache Software License, Version 2.0
   HK2 API module under CDDL + GPLv2 with classpath exception
   HK2 Implementation Utilities under CDDL + GPLv2 with classpath exception
-  hoodie-client under Apache License, Version 2.0
-  hoodie-common under Apache License, Version 2.0
-  hoodie-hadoop-mr under Apache License, Version 2.0
-  hoodie-timeline-service under Apache License, Version 2.0
   htrace-core under The Apache Software License, Version 2.0
   HttpClient under Apache License
+  hudi-client under Apache License, Version 2.0
+  hudi-common under Apache License, Version 2.0
+  hudi-hadoop-mr under Apache License, Version 2.0
+  hudi-timeline-service under Apache License, Version 2.0
   IntelliJ IDEA Annotations under The Apache Software License, Version 2.0
   Jackson under The Apache Software License, Version 2.0
   Jackson Integration for Metrics under Apache License 2.0

--- a/hudi-common/src/main/resources/META-INF/NOTICE.txt
+++ b/hudi-common/src/main/resources/META-INF/NOTICE.txt
@@ -12,7 +12,6 @@ This project includes:
   Apache Avro under The Apache Software License, Version 2.0
   Apache Avro IPC under The Apache Software License, Version 2.0
   Apache Avro Mapred API under The Apache Software License, Version 2.0
-  Apache Commons Collections under Apache License, Version 2.0
   Apache Commons IO under Apache License, Version 2.0
   Apache Commons Logging under The Apache Software License, Version 2.0
   Apache Directory API ASN.1 API under The Apache Software License, Version 2.0
@@ -23,7 +22,6 @@ This project includes:
   Apache Hadoop Common under Apache License, Version 2.0
   Apache Hadoop HDFS under Apache License, Version 2.0
   Apache HttpClient under Apache License, Version 2.0
-  Apache HttpClient Fluent API under Apache License, Version 2.0
   Apache HttpCore under Apache License, Version 2.0
   Apache Log4j under The Apache Software License, Version 2.0
   Apache Parquet Avro under The Apache Software License, Version 2.0
@@ -37,10 +35,10 @@ This project includes:
   ApacheDS I18n under The Apache Software License, Version 2.0
   ApacheDS Protocol Kerberos Codec under The Apache Software License, Version 2.0
   ASM Core under 3-Clause BSD License
-  com.twitter.common:objectsize under Apache License, Version 2.0
   Commons BeanUtils Core under The Apache Software License, Version 2.0
   Commons CLI under The Apache Software License, Version 2.0
   Commons Codec under The Apache Software License, Version 2.0
+  Commons Collections under The Apache Software License, Version 2.0
   Commons Compress under The Apache Software License, Version 2.0
   Commons Configuration under The Apache Software License, Version 2.0
   Commons Daemon under The Apache Software License, Version 2.0
@@ -55,6 +53,7 @@ This project includes:
   Digester under The Apache Software License, Version 2.0
   fastutil under Apache License, Version 2.0
   FindBugs-jsr305 under The Apache Software License, Version 2.0
+  Fluent API for Apache HttpClient under Apache License, Version 2.0
   Gson under The Apache Software License, Version 2.0
   Guava: Google Core Libraries for Java under The Apache Software License, Version 2.0
   hadoop-mapreduce-client-app under Apache License, Version 2.0
@@ -67,9 +66,9 @@ This project includes:
   hadoop-yarn-common under Apache License, Version 2.0
   hadoop-yarn-server-common under Apache License, Version 2.0
   Hamcrest Core under New BSD License
-  hoodie-common under Apache License, Version 2.0
   htrace-core under The Apache Software License, Version 2.0
   HttpClient under Apache License
+  hudi-common under Apache License, Version 2.0
   Jackson under The Apache Software License, Version 2.0
   Jackson-annotations under The Apache Software License, Version 2.0
   Jackson-core under The Apache Software License, Version 2.0
@@ -87,7 +86,6 @@ This project includes:
   JSch under BSD
   jsp-api under CDDL
   JUnit under Common Public License Version 1.0
-  Kryo under New BSD License
   Kryo Shaded under 3-Clause BSD License
   leveldbjni-all under The BSD 3-Clause License
   MinLog under New BSD License
@@ -96,7 +94,6 @@ This project includes:
   Objenesis under Apache 2
   ParaNamer Core under BSD
   Protocol Buffer Java API under New BSD license
-  ReflectASM under New BSD License
   RocksDB JNI under Apache License 2.0 or GNU General Public License, version 2
   Servlet Specification API under Apache License Version 2.0
   servlet-api under CDDL

--- a/hudi-hadoop-mr/src/main/resources/META-INF/NOTICE.txt
+++ b/hudi-hadoop-mr/src/main/resources/META-INF/NOTICE.txt
@@ -22,7 +22,6 @@ This project includes:
   Apache Avro Mapred API under The Apache Software License, Version 2.0
   Apache Calcite Avatica under Apache License, Version 2.0
   Apache Calcite Avatica Metrics under Apache License, Version 2.0
-  Apache Commons Collections under Apache License, Version 2.0
   Apache Commons IO under Apache License, Version 2.0
   Apache Commons Logging under The Apache Software License, Version 2.0
   Apache Curator under The Apache Software License, Version 2.0
@@ -48,21 +47,13 @@ This project includes:
   Apache Log4j SLF4J Binding under The Apache Software License, Version 2.0
   Apache Log4j Web under The Apache Software License, Version 2.0
   Apache Parquet Avro under The Apache Software License, Version 2.0
-  Apache Parquet Avro (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Column under The Apache Software License, Version 2.0
-  Apache Parquet Column (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Common under The Apache Software License, Version 2.0
-  Apache Parquet Common (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Encodings under The Apache Software License, Version 2.0
-  Apache Parquet Encodings (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Format (Incubating) under The Apache Software License, Version 2.0
-  Apache Parquet Generator (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Hadoop under The Apache Software License, Version 2.0
-  Apache Parquet Hadoop (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Hadoop Bundle under The Apache Software License, Version 2.0
-  Apache Parquet Hadoop Bundle (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Jackson under The Apache Software License, Version 2.0
-  Apache Parquet Jackson (Incubating) under The Apache Software License, Version 2.0
   Apache Thrift under The Apache Software License, Version 2.0
   Apache Twill API under The Apache Software License, Version 2.0
   Apache Twill common library under The Apache Software License, Version 2.0
@@ -80,10 +71,10 @@ This project includes:
   Calcite Core under Apache License, Version 2.0
   Calcite Druid under Apache License, Version 2.0
   Calcite Linq4j under Apache License, Version 2.0
-  com.twitter.common:objectsize under Apache License, Version 2.0
   Commons BeanUtils Core under The Apache Software License, Version 2.0
   Commons CLI under The Apache Software License, Version 2.0
   Commons Codec under The Apache Software License, Version 2.0
+  Commons Collections under The Apache Software License, Version 2.0
   Commons Compiler under New BSD License
   Commons Compress under The Apache Software License, Version 2.0
   Commons Configuration under The Apache Software License, Version 2.0
@@ -155,10 +146,10 @@ This project includes:
   Hive Shims Scheduler under The Apache Software License, Version 2.0
   Hive Storage API under Apache License, Version 2.0
   Hive Vector-Code-Gen Utilities under The Apache Software License, Version 2.0
-  hoodie-common under Apache License, Version 2.0
-  hoodie-hadoop-mr under Apache License, Version 2.0
   htrace-core under The Apache Software License, Version 2.0
   HttpClient under Apache License
+  hudi-common under Apache License, Version 2.0
+  hudi-hadoop-mr under Apache License, Version 2.0
   Jackson under The Apache Software License, Version 2.0
   Jackson Integration for Metrics under Apache License 2.0
   Jackson-annotations under The Apache Software License, Version 2.0
@@ -198,7 +189,6 @@ This project includes:
   JTA 1.1 under The Apache Software License, Version 2.0
   JUnit under Common Public License Version 1.0
   JVM Integration for Metrics under Apache License 2.0
-  Kryo under New BSD License
   Kryo Shaded under 3-Clause BSD License
   leveldbjni-all under The BSD 3-Clause License
   Metrics Core under Apache License 2.0
@@ -212,7 +202,6 @@ This project includes:
   org.pentaho:pentaho-aggdesigner-algorithm under Apache License, Version 2.0
   ParaNamer Core under BSD
   Protocol Buffer Java API under New BSD license
-  ReflectASM under New BSD License
   RocksDB JNI under Apache License 2.0 or GNU General Public License, version 2
   Servlet Specification 2.5 API under CDDL 1.0
   Servlet Specification API under Apache License Version 2.0

--- a/hudi-hive/src/main/resources/META-INF/NOTICE.txt
+++ b/hudi-hive/src/main/resources/META-INF/NOTICE.txt
@@ -48,21 +48,13 @@ This project includes:
   Apache Log4j SLF4J Binding under The Apache Software License, Version 2.0
   Apache Log4j Web under The Apache Software License, Version 2.0
   Apache Parquet Avro under The Apache Software License, Version 2.0
-  Apache Parquet Avro (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Column under The Apache Software License, Version 2.0
-  Apache Parquet Column (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Common under The Apache Software License, Version 2.0
-  Apache Parquet Common (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Encodings under The Apache Software License, Version 2.0
-  Apache Parquet Encodings (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Format (Incubating) under The Apache Software License, Version 2.0
-  Apache Parquet Generator (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Hadoop under The Apache Software License, Version 2.0
-  Apache Parquet Hadoop (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Hadoop Bundle under The Apache Software License, Version 2.0
-  Apache Parquet Hadoop Bundle (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Jackson under The Apache Software License, Version 2.0
-  Apache Parquet Jackson (Incubating) under The Apache Software License, Version 2.0
   Apache Thrift under The Apache Software License, Version 2.0
   Apache Twill API under The Apache Software License, Version 2.0
   Apache Twill common library under The Apache Software License, Version 2.0
@@ -80,7 +72,6 @@ This project includes:
   Calcite Core under Apache License, Version 2.0
   Calcite Druid under Apache License, Version 2.0
   Calcite Linq4j under Apache License, Version 2.0
-  com.twitter.common:objectsize under Apache License, Version 2.0
   Commons BeanUtils Core under The Apache Software License, Version 2.0
   Commons CLI under The Apache Software License, Version 2.0
   Commons Codec under The Apache Software License, Version 2.0
@@ -155,11 +146,11 @@ This project includes:
   Hive Shims Scheduler under The Apache Software License, Version 2.0
   Hive Storage API under Apache License, Version 2.0
   Hive Vector-Code-Gen Utilities under The Apache Software License, Version 2.0
-  hoodie-common under Apache License, Version 2.0
-  hoodie-hadoop-mr under Apache License, Version 2.0
-  hoodie-hive under Apache License, Version 2.0
   htrace-core under The Apache Software License, Version 2.0
   HttpClient under Apache License
+  hudi-common under Apache License, Version 2.0
+  hudi-hadoop-mr under Apache License, Version 2.0
+  hudi-hive under Apache License, Version 2.0
   Jackson under The Apache Software License, Version 2.0
   Jackson Integration for Metrics under Apache License 2.0
   Jackson-annotations under The Apache Software License, Version 2.0
@@ -191,6 +182,7 @@ This project includes:
   Jetty Server under Apache Software License - Version 2.0 or Eclipse Public License - Version 1.0
   Jetty SSLEngine under Apache License Version 2
   Jetty Utilities under Apache Software License - Version 2.0 or Eclipse Public License - Version 1.0
+  JLine under The BSD License
   Joda-Time under Apache 2
   Joni under MIT License
   JPam under The Apache Software License, Version 2.0
@@ -199,7 +191,6 @@ This project includes:
   JTA 1.1 under The Apache Software License, Version 2.0
   JUnit under Common Public License Version 1.0
   JVM Integration for Metrics under Apache License 2.0
-  Kryo under New BSD License
   Kryo Shaded under 3-Clause BSD License
   leveldbjni-all under The BSD 3-Clause License
   Metrics Core under Apache License 2.0
@@ -214,7 +205,6 @@ This project includes:
   org.pentaho:pentaho-aggdesigner-algorithm under Apache License, Version 2.0
   ParaNamer Core under BSD
   Protocol Buffer Java API under New BSD license
-  ReflectASM under New BSD License
   RocksDB JNI under Apache License 2.0 or GNU General Public License, version 2
   Servlet Specification 2.5 API under CDDL 1.0
   Servlet Specification API under Apache License Version 2.0

--- a/hudi-integ-test/src/main/resources/META-INF/NOTICE.txt
+++ b/hudi-integ-test/src/main/resources/META-INF/NOTICE.txt
@@ -24,10 +24,7 @@ This project includes:
   Apache Calcite Avatica under Apache License, Version 2.0
   Apache Calcite Avatica Metrics under Apache License, Version 2.0
   Apache Commons Collections under Apache License, Version 2.0
-  Apache Commons Compress under Apache License, Version 2.0
-  Apache Commons Configuration under Apache License, Version 2.0
   Apache Commons IO under Apache License, Version 2.0
-  Apache Commons Lang under The Apache Software License, Version 2.0
   Apache Commons Logging under The Apache Software License, Version 2.0
   Apache Curator under The Apache Software License, Version 2.0
   Apache Derby Database Engine and Embedded JDBC Driver under Apache 2
@@ -53,21 +50,13 @@ This project includes:
   Apache Log4j SLF4J Binding under The Apache Software License, Version 2.0
   Apache Log4j Web under The Apache Software License, Version 2.0
   Apache Parquet Avro under The Apache Software License, Version 2.0
-  Apache Parquet Avro (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Column under The Apache Software License, Version 2.0
-  Apache Parquet Column (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Common under The Apache Software License, Version 2.0
-  Apache Parquet Common (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Encodings under The Apache Software License, Version 2.0
-  Apache Parquet Encodings (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Format (Incubating) under The Apache Software License, Version 2.0
-  Apache Parquet Generator (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Hadoop under The Apache Software License, Version 2.0
-  Apache Parquet Hadoop (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Hadoop Bundle under The Apache Software License, Version 2.0
-  Apache Parquet Hadoop Bundle (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Jackson under The Apache Software License, Version 2.0
-  Apache Parquet Jackson (Incubating) under The Apache Software License, Version 2.0
   Apache Thrift under The Apache Software License, Version 2.0
   Apache Twill API under The Apache Software License, Version 2.0
   Apache Twill common library under The Apache Software License, Version 2.0
@@ -89,11 +78,11 @@ This project includes:
   Calcite Core under Apache License, Version 2.0
   Calcite Druid under Apache License, Version 2.0
   Calcite Linq4j under Apache License, Version 2.0
-  com.twitter.common:objectsize under Apache License, Version 2.0
   Commons BeanUtils Core under The Apache Software License, Version 2.0
   Commons CLI under The Apache Software License, Version 2.0
   Commons Codec under The Apache Software License, Version 2.0
   Commons Compiler under New BSD License
+  Commons Compress under The Apache Software License, Version 2.0
   Commons Configuration under The Apache Software License, Version 2.0
   Commons Daemon under The Apache Software License, Version 2.0
   Commons DBCP under The Apache Software License, Version 2.0
@@ -167,31 +156,27 @@ This project includes:
   Hive Vector-Code-Gen Utilities under The Apache Software License, Version 2.0
   HK2 API module under CDDL + GPLv2 with classpath exception
   HK2 Implementation Utilities under CDDL + GPLv2 with classpath exception
-  hoodie-client under Apache License, Version 2.0
-  hoodie-common under Apache License, Version 2.0
-  hoodie-hadoop-base-docker under Apache License, Version 2.0
-  hoodie-hadoop-docker under Apache License, Version 2.0
-  hoodie-hadoop-hive-docker under Apache License, Version 2.0
-  hoodie-hadoop-mr under Apache License, Version 2.0
-  hoodie-hadoop-sparkbase-docker under Apache License, Version 2.0
-  hoodie-hadoop-sparkworker-docker under Apache License, Version 2.0
-  hoodie-hive under Apache License, Version 2.0
-  hoodie-integ-test under Apache License, Version 2.0
-  hoodie-spark under Apache License, Version 2.0
-  hoodie-spark-bundle under Apache License, Version 2.0
-  hoodie-timeline-service under Apache License, Version 2.0
   htrace-core under The Apache Software License, Version 2.0
   HttpClient under Apache License
+  hudi-client under Apache License, Version 2.0
+  hudi-common under Apache License, Version 2.0
+  hudi-hadoop-mr under Apache License, Version 2.0
+  hudi-hadoop-sparkworker-docker under Apache License, Version 2.0
+  hudi-hive under Apache License, Version 2.0
+  hudi-integ-test under Apache License, Version 2.0
+  hudi-spark under Apache License, Version 2.0
+  hudi-spark-bundle under Apache License, Version 2.0
+  hudi-timeline-service under Apache License, Version 2.0
   IntelliJ IDEA Annotations under The Apache Software License, Version 2.0
   Jackson under The Apache Software License, Version 2.0
-  Jackson datatype: Guava under The Apache Software License, Version 2.0
   Jackson Integration for Metrics under Apache License 2.0
+  Jackson module: JAXB Annotations under The Apache Software License, Version 2.0
   Jackson-annotations under The Apache Software License, Version 2.0
   Jackson-core under The Apache Software License, Version 2.0
   jackson-databind under The Apache Software License, Version 2.0
+  Jackson-datatype-Guava under The Apache Software License, Version 2.0
   Jackson-JAXRS-base under The Apache Software License, Version 2.0
   Jackson-JAXRS-JSON under The Apache Software License, Version 2.0
-  Jackson-module-JAXB-annotations under The Apache Software License, Version 2.0
   Jackson-module-paranamer under The Apache Software License, Version 2.0
   jackson-module-scala under The Apache Software License, Version 2.0
   jamon-runtime under Mozilla Public License Version 1.1
@@ -212,7 +197,7 @@ This project includes:
   Javolution under BSD License
   JAX-RS provider for JSON content type under The Apache Software License, Version 2.0 or GNU Lesser General Public License (LGPL), Version 2.1
   JAXB RI under CDDL 1.1 or GPL2 w/ CPE
-  JCL 1.1.1 implemented over SLF4J under MIT License
+  JCL 1.2 implemented over SLF4J under MIT License
   JCodings under MIT License
   jcommander under Apache 2.0
   JDO API under Apache 2
@@ -224,7 +209,7 @@ This project includes:
   jersey-core-common under CDDL+GPL License
   jersey-core-server under CDDL+GPL License
   jersey-guice under CDDL 1.1 or GPL2 w/ CPE
-  jersey-inject-hk2 under CDDL 1.1 or GPL2 w/ CPE
+  jersey-inject-hk2 under CDDL 1.1 or GPL2 w/ CPE or Apache License, 2.0 or Public Domain or Modified BSD
   jersey-json under CDDL 1.1 or GPL2 w/ CPE
   jersey-media-jaxb under CDDL+GPL License
   jersey-repackaged-guava under CDDL+GPL License
@@ -265,7 +250,6 @@ This project includes:
   Metrics Core under Apache License 2.0
   Metrics Core Library under Apache License 2.0
   MinLog under New BSD License
-  Native Library Loader under CC0 1.0 Universal License
   Netty/All-in-One under Apache License, Version 2.0
   Netty/Buffer under Apache License, Version 2.0
   Netty/Codec under Apache License, Version 2.0

--- a/hudi-spark/src/main/resources/META-INF/NOTICE.txt
+++ b/hudi-spark/src/main/resources/META-INF/NOTICE.txt
@@ -25,7 +25,6 @@ This project includes:
   Apache Calcite Avatica under Apache License, Version 2.0
   Apache Calcite Avatica Metrics under Apache License, Version 2.0
   Apache Commons Collections under Apache License, Version 2.0
-  Apache Commons Configuration under Apache License, Version 2.0
   Apache Commons Crypto under Apache License, Version 2.0
   Apache Commons IO under Apache License, Version 2.0
   Apache Commons Lang under Apache License, Version 2.0
@@ -42,6 +41,7 @@ This project includes:
   Apache Hadoop HDFS under Apache License, Version 2.0
   Apache HBase - Annotations under Apache License, Version 2.0
   Apache HBase - Client under Apache License, Version 2.0
+  Apache HBase - Common under Apache License, Version 2.0
   Apache HBase - Protocol under Apache License, Version 2.0
   Apache HttpClient under Apache License, Version 2.0
   Apache HttpCore under Apache License, Version 2.0
@@ -53,21 +53,13 @@ This project includes:
   Apache Log4j SLF4J Binding under The Apache Software License, Version 2.0
   Apache Log4j Web under The Apache Software License, Version 2.0
   Apache Parquet Avro under The Apache Software License, Version 2.0
-  Apache Parquet Avro (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Column under The Apache Software License, Version 2.0
-  Apache Parquet Column (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Common under The Apache Software License, Version 2.0
-  Apache Parquet Common (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Encodings under The Apache Software License, Version 2.0
-  Apache Parquet Encodings (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Format (Incubating) under The Apache Software License, Version 2.0
-  Apache Parquet Generator (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Hadoop under The Apache Software License, Version 2.0
-  Apache Parquet Hadoop (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Hadoop Bundle under The Apache Software License, Version 2.0
-  Apache Parquet Hadoop Bundle (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Jackson under The Apache Software License, Version 2.0
-  Apache Parquet Jackson (Incubating) under The Apache Software License, Version 2.0
   Apache Thrift under The Apache Software License, Version 2.0
   Apache Twill API under The Apache Software License, Version 2.0
   Apache Twill common library under The Apache Software License, Version 2.0
@@ -89,7 +81,6 @@ This project includes:
   Calcite Linq4j under Apache License, Version 2.0
   chill under Apache 2
   chill-java under Apache 2
-  com.twitter.common:objectsize under Apache License, Version 2.0
   Commons BeanUtils Core under The Apache Software License, Version 2.0
   Commons CLI under The Apache Software License, Version 2.0
   Commons Codec under The Apache Software License, Version 2.0
@@ -142,7 +133,7 @@ This project includes:
   hadoop-yarn-server-common under Apache License, Version 2.0
   hadoop-yarn-server-resourcemanager under Apache License, Version 2.0
   hadoop-yarn-server-web-proxy under Apache License, Version 2.0
-  Hamcrest Core under BSD style
+  Hamcrest Core under New BSD License
   HBase - Common under The Apache Software License, Version 2.0
   HBase - Hadoop Compatibility under The Apache Software License, Version 2.0
   HBase - Hadoop Two Compatibility under The Apache Software License, Version 2.0
@@ -169,14 +160,14 @@ This project includes:
   Hive Vector-Code-Gen Utilities under The Apache Software License, Version 2.0
   HK2 API module under CDDL + GPLv2 with classpath exception
   HK2 Implementation Utilities under CDDL + GPLv2 with classpath exception
-  hoodie-client under Apache License, Version 2.0
-  hoodie-common under Apache License, Version 2.0
-  hoodie-hadoop-mr under Apache License, Version 2.0
-  hoodie-hive under Apache License, Version 2.0
-  hoodie-spark under Apache License, Version 2.0
-  hoodie-timeline-service under Apache License, Version 2.0
   htrace-core under The Apache Software License, Version 2.0
   HttpClient under Apache License
+  hudi-client under Apache License, Version 2.0
+  hudi-common under Apache License, Version 2.0
+  hudi-hadoop-mr under Apache License, Version 2.0
+  hudi-hive under Apache License, Version 2.0
+  hudi-spark under Apache License, Version 2.0
+  hudi-timeline-service under Apache License, Version 2.0
   IntelliJ IDEA Annotations under The Apache Software License, Version 2.0
   Jackson under The Apache Software License, Version 2.0
   Jackson Integration for Metrics under Apache License 2.0
@@ -239,6 +230,7 @@ This project includes:
   Jetty Server under Apache Software License - Version 2.0 or Eclipse Public License - Version 1.0
   Jetty SSLEngine under Apache License Version 2
   Jetty Utilities under Apache Software License - Version 2.0 or Eclipse Public License - Version 1.0
+  JLine under The BSD License
   Joda-Time under Apache 2
   Joni under MIT License
   JPam under The Apache Software License, Version 2.0

--- a/hudi-timeline-service/src/main/resources/META-INF/NOTICE.txt
+++ b/hudi-timeline-service/src/main/resources/META-INF/NOTICE.txt
@@ -36,7 +36,6 @@ This project includes:
   ApacheDS I18n under The Apache Software License, Version 2.0
   ApacheDS Protocol Kerberos Codec under The Apache Software License, Version 2.0
   ASM Core under 3-Clause BSD License
-  com.twitter.common:objectsize under Apache License, Version 2.0
   Commons BeanUtils Core under The Apache Software License, Version 2.0
   Commons CLI under The Apache Software License, Version 2.0
   Commons Codec under The Apache Software License, Version 2.0
@@ -67,10 +66,10 @@ This project includes:
   hadoop-yarn-common under Apache License, Version 2.0
   hadoop-yarn-server-common under Apache License, Version 2.0
   Hamcrest Core under New BSD License
-  hoodie-common under Apache License, Version 2.0
-  hoodie-timeline-service under Apache License, Version 2.0
   htrace-core under The Apache Software License, Version 2.0
   HttpClient under Apache License
+  hudi-common under Apache License, Version 2.0
+  hudi-timeline-service under Apache License, Version 2.0
   IntelliJ IDEA Annotations under The Apache Software License, Version 2.0
   Jackson under The Apache Software License, Version 2.0
   Jackson-annotations under The Apache Software License, Version 2.0
@@ -106,7 +105,6 @@ This project includes:
   JSch under BSD
   jsp-api under CDDL
   JUnit under Common Public License Version 1.0
-  Kryo under New BSD License
   Kryo Shaded under 3-Clause BSD License
   leveldbjni-all under The BSD 3-Clause License
   MinLog under New BSD License
@@ -119,7 +117,6 @@ This project includes:
   org.jetbrains.kotlin:kotlin-stdlib-jdk8 under The Apache License, Version 2.0
   ParaNamer Core under BSD
   Protocol Buffer Java API under New BSD license
-  ReflectASM under New BSD License
   RocksDB JNI under Apache License 2.0 or GNU General Public License, version 2
   Servlet Specification API under Apache License Version 2.0
   servlet-api under CDDL

--- a/hudi-utilities/src/main/resources/META-INF/NOTICE.txt
+++ b/hudi-utilities/src/main/resources/META-INF/NOTICE.txt
@@ -12,7 +12,7 @@ This project includes:
   An open source Java toolkit for Amazon S3 under Apache License, Version 2.0
   Annotation 1.0 under The Apache Software License, Version 2.0
   ant under The Apache Software License, Version 2.0
-  ANTLR 3 Runtime under BSD licence
+  Antlr 3 Runtime under BSD
   ANTLR 4 Runtime under The BSD License
   ANTLR ST4 4.0.4 under BSD licence
   ANTLR StringTemplate 4.0.2 under BSD licence
@@ -26,7 +26,6 @@ This project includes:
   Apache Calcite Avatica under Apache License, Version 2.0
   Apache Calcite Avatica Metrics under Apache License, Version 2.0
   Apache Commons Collections under Apache License, Version 2.0
-  Apache Commons Configuration under Apache License, Version 2.0
   Apache Commons Crypto under Apache License, Version 2.0
   Apache Commons IO under Apache License, Version 2.0
   Apache Commons Lang under Apache License, Version 2.0
@@ -56,21 +55,13 @@ This project includes:
   Apache Log4j SLF4J Binding under The Apache Software License, Version 2.0
   Apache Log4j Web under The Apache Software License, Version 2.0
   Apache Parquet Avro under The Apache Software License, Version 2.0
-  Apache Parquet Avro (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Column under The Apache Software License, Version 2.0
-  Apache Parquet Column (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Common under The Apache Software License, Version 2.0
-  Apache Parquet Common (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Encodings under The Apache Software License, Version 2.0
-  Apache Parquet Encodings (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Format (Incubating) under The Apache Software License, Version 2.0
-  Apache Parquet Generator (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Hadoop under The Apache Software License, Version 2.0
-  Apache Parquet Hadoop (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Hadoop Bundle under The Apache Software License, Version 2.0
-  Apache Parquet Hadoop Bundle (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Jackson under The Apache Software License, Version 2.0
-  Apache Parquet Jackson (Incubating) under The Apache Software License, Version 2.0
   Apache Thrift under The Apache Software License, Version 2.0
   Apache Twill API under The Apache Software License, Version 2.0
   Apache Twill common library under The Apache Software License, Version 2.0
@@ -94,7 +85,6 @@ This project includes:
   Calcite Linq4j under Apache License, Version 2.0
   chill under Apache 2
   chill-java under Apache 2
-  com.twitter.common:objectsize under Apache License, Version 2.0
   Commons BeanUtils Core under The Apache Software License, Version 2.0
   Commons CLI under The Apache Software License, Version 2.0
   Commons Codec under The Apache Software License, Version 2.0
@@ -175,15 +165,15 @@ This project includes:
   Hive Vector-Code-Gen Utilities under The Apache Software License, Version 2.0
   HK2 API module under CDDL + GPLv2 with classpath exception
   HK2 Implementation Utilities under CDDL + GPLv2 with classpath exception
-  hoodie-client under Apache License, Version 2.0
-  hoodie-common under Apache License, Version 2.0
-  hoodie-hadoop-mr under Apache License, Version 2.0
-  hoodie-hive under Apache License, Version 2.0
-  hoodie-spark under Apache License, Version 2.0
-  hoodie-timeline-service under Apache License, Version 2.0
-  hoodie-utilities under Apache License, Version 2.0
   htrace-core under The Apache Software License, Version 2.0
   HttpClient under Apache License
+  hudi-client under Apache License, Version 2.0
+  hudi-common under Apache License, Version 2.0
+  hudi-hadoop-mr under Apache License, Version 2.0
+  hudi-hive under Apache License, Version 2.0
+  hudi-spark under Apache License, Version 2.0
+  hudi-timeline-service under Apache License, Version 2.0
+  hudi-utilities under Apache License, Version 2.0
   IntelliJ IDEA Annotations under The Apache Software License, Version 2.0
   Jackson under The Apache Software License, Version 2.0
   Jackson Integration for Metrics under Apache License 2.0
@@ -243,7 +233,6 @@ This project includes:
   Jetty :: Websocket :: Server under Apache Software License - Version 2.0 or Eclipse Public License - Version 1.0
   Jetty :: Websocket :: Servlet Interface under Apache Software License - Version 2.0 or Eclipse Public License - Version 1.0
   Jetty :: XML utilities under Apache Software License - Version 2.0 or Eclipse Public License - Version 1.0
-  Jetty Orbit :: Servlet API under Apache Software License - Version 2.0 or Eclipse Public License - Version 1.0
   Jetty Server under Apache Software License - Version 2.0 or Eclipse Public License - Version 1.0
   Jetty SSLEngine under Apache License Version 2
   Jetty Utilities under Apache Software License - Version 2.0 or Eclipse Public License - Version 1.0

--- a/packaging/hudi-hadoop-mr-bundle/src/main/resources/META-INF/HUDI_NOTICE.txt
+++ b/packaging/hudi-hadoop-mr-bundle/src/main/resources/META-INF/HUDI_NOTICE.txt
@@ -22,7 +22,6 @@ This project includes:
   Apache Avro Mapred API under The Apache Software License, Version 2.0
   Apache Calcite Avatica under Apache License, Version 2.0
   Apache Calcite Avatica Metrics under Apache License, Version 2.0
-  Apache Commons Collections under Apache License, Version 2.0
   Apache Commons IO under Apache License, Version 2.0
   Apache Commons Logging under The Apache Software License, Version 2.0
   Apache Curator under The Apache Software License, Version 2.0
@@ -48,21 +47,13 @@ This project includes:
   Apache Log4j SLF4J Binding under The Apache Software License, Version 2.0
   Apache Log4j Web under The Apache Software License, Version 2.0
   Apache Parquet Avro under The Apache Software License, Version 2.0
-  Apache Parquet Avro (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Column under The Apache Software License, Version 2.0
-  Apache Parquet Column (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Common under The Apache Software License, Version 2.0
-  Apache Parquet Common (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Encodings under The Apache Software License, Version 2.0
-  Apache Parquet Encodings (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Format (Incubating) under The Apache Software License, Version 2.0
-  Apache Parquet Generator (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Hadoop under The Apache Software License, Version 2.0
-  Apache Parquet Hadoop (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Hadoop Bundle under The Apache Software License, Version 2.0
-  Apache Parquet Hadoop Bundle (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Jackson under The Apache Software License, Version 2.0
-  Apache Parquet Jackson (Incubating) under The Apache Software License, Version 2.0
   Apache Thrift under The Apache Software License, Version 2.0
   Apache Twill API under The Apache Software License, Version 2.0
   Apache Twill common library under The Apache Software License, Version 2.0
@@ -80,10 +71,10 @@ This project includes:
   Calcite Core under Apache License, Version 2.0
   Calcite Druid under Apache License, Version 2.0
   Calcite Linq4j under Apache License, Version 2.0
-  com.twitter.common:objectsize under Apache License, Version 2.0
   Commons BeanUtils Core under The Apache Software License, Version 2.0
   Commons CLI under The Apache Software License, Version 2.0
   Commons Codec under The Apache Software License, Version 2.0
+  Commons Collections under The Apache Software License, Version 2.0
   Commons Compiler under New BSD License
   Commons Compress under The Apache Software License, Version 2.0
   Commons Configuration under The Apache Software License, Version 2.0
@@ -155,11 +146,11 @@ This project includes:
   Hive Shims Scheduler under The Apache Software License, Version 2.0
   Hive Storage API under Apache License, Version 2.0
   Hive Vector-Code-Gen Utilities under The Apache Software License, Version 2.0
-  hoodie-common under Apache License, Version 2.0
-  hoodie-hadoop-mr under Apache License, Version 2.0
-  hoodie-hadoop-mr-bundle under Apache License, Version 2.0
   htrace-core under The Apache Software License, Version 2.0
   HttpClient under Apache License
+  hudi-common under Apache License, Version 2.0
+  hudi-hadoop-mr under Apache License, Version 2.0
+  hudi-hadoop-mr-bundle under Apache License, Version 2.0
   Jackson under The Apache Software License, Version 2.0
   Jackson Integration for Metrics under Apache License 2.0
   Jackson-annotations under The Apache Software License, Version 2.0
@@ -200,6 +191,7 @@ This project includes:
   JTA 1.1 under The Apache Software License, Version 2.0
   JUnit under Common Public License Version 1.0
   JVM Integration for Metrics under Apache License 2.0
+  Kryo under New BSD License
   Kryo Shaded under 3-Clause BSD License
   leveldbjni-all under The BSD 3-Clause License
   Metrics Core under Apache License 2.0
@@ -213,6 +205,7 @@ This project includes:
   org.pentaho:pentaho-aggdesigner-algorithm under Apache License, Version 2.0
   ParaNamer Core under BSD
   Protocol Buffer Java API under New BSD license
+  ReflectASM under New BSD License
   RocksDB JNI under Apache License 2.0 or GNU General Public License, version 2
   Servlet Specification 2.5 API under CDDL 1.0
   Servlet Specification API under Apache License Version 2.0

--- a/packaging/hudi-hive-bundle/src/main/resources/META-INF/HUDI_NOTICE.txt
+++ b/packaging/hudi-hive-bundle/src/main/resources/META-INF/HUDI_NOTICE.txt
@@ -23,6 +23,7 @@ This project includes:
   Apache Calcite Avatica under Apache License, Version 2.0
   Apache Calcite Avatica Metrics under Apache License, Version 2.0
   Apache Commons Collections under Apache License, Version 2.0
+  Apache Commons Compress under The Apache Software License, Version 2.0
   Apache Commons IO under Apache License, Version 2.0
   Apache Commons Logging under The Apache Software License, Version 2.0
   Apache Curator under The Apache Software License, Version 2.0
@@ -48,21 +49,13 @@ This project includes:
   Apache Log4j SLF4J Binding under The Apache Software License, Version 2.0
   Apache Log4j Web under The Apache Software License, Version 2.0
   Apache Parquet Avro under The Apache Software License, Version 2.0
-  Apache Parquet Avro (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Column under The Apache Software License, Version 2.0
-  Apache Parquet Column (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Common under The Apache Software License, Version 2.0
-  Apache Parquet Common (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Encodings under The Apache Software License, Version 2.0
-  Apache Parquet Encodings (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Format (Incubating) under The Apache Software License, Version 2.0
-  Apache Parquet Generator (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Hadoop under The Apache Software License, Version 2.0
-  Apache Parquet Hadoop (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Hadoop Bundle under The Apache Software License, Version 2.0
-  Apache Parquet Hadoop Bundle (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Jackson under The Apache Software License, Version 2.0
-  Apache Parquet Jackson (Incubating) under The Apache Software License, Version 2.0
   Apache Thrift under The Apache Software License, Version 2.0
   Apache Twill API under The Apache Software License, Version 2.0
   Apache Twill common library under The Apache Software License, Version 2.0
@@ -80,12 +73,10 @@ This project includes:
   Calcite Core under Apache License, Version 2.0
   Calcite Druid under Apache License, Version 2.0
   Calcite Linq4j under Apache License, Version 2.0
-  com.twitter.common:objectsize under Apache License, Version 2.0
   Commons BeanUtils Core under The Apache Software License, Version 2.0
   Commons CLI under The Apache Software License, Version 2.0
   Commons Codec under The Apache Software License, Version 2.0
   Commons Compiler under New BSD License
-  Commons Compress under The Apache Software License, Version 2.0
   Commons Configuration under The Apache Software License, Version 2.0
   Commons Daemon under The Apache Software License, Version 2.0
   Commons DBCP under The Apache Software License, Version 2.0
@@ -155,13 +146,13 @@ This project includes:
   Hive Shims Scheduler under The Apache Software License, Version 2.0
   Hive Storage API under Apache License, Version 2.0
   Hive Vector-Code-Gen Utilities under The Apache Software License, Version 2.0
-  hoodie-common under Apache License, Version 2.0
-  hoodie-hadoop-mr under Apache License, Version 2.0
-  hoodie-hadoop-mr-bundle under Apache License, Version 2.0
-  hoodie-hive under Apache License, Version 2.0
-  hoodie-hive-bundle under Apache License, Version 2.0
   htrace-core under The Apache Software License, Version 2.0
   HttpClient under Apache License
+  hudi-common under Apache License, Version 2.0
+  hudi-hadoop-mr under Apache License, Version 2.0
+  hudi-hadoop-mr-bundle under Apache License, Version 2.0
+  hudi-hive under Apache License, Version 2.0
+  hudi-hive-bundle under Apache License, Version 2.0
   Jackson under The Apache Software License, Version 2.0
   Jackson Integration for Metrics under Apache License 2.0
   Jackson-annotations under The Apache Software License, Version 2.0
@@ -193,6 +184,7 @@ This project includes:
   Jetty Server under Apache Software License - Version 2.0 or Eclipse Public License - Version 1.0
   Jetty SSLEngine under Apache License Version 2
   Jetty Utilities under Apache Software License - Version 2.0 or Eclipse Public License - Version 1.0
+  JLine under The BSD License
   Joda-Time under Apache 2
   Joni under MIT License
   JPam under The Apache Software License, Version 2.0

--- a/packaging/hudi-presto-bundle/src/main/resources/META-INF/HUDI_NOTICE.txt
+++ b/packaging/hudi-presto-bundle/src/main/resources/META-INF/HUDI_NOTICE.txt
@@ -12,7 +12,6 @@ This project includes:
   Apache Avro under The Apache Software License, Version 2.0
   Apache Avro IPC under The Apache Software License, Version 2.0
   Apache Avro Mapred API under The Apache Software License, Version 2.0
-  Apache Commons Collections under Apache License, Version 2.0
   Apache Commons IO under Apache License, Version 2.0
   Apache Commons Logging under The Apache Software License, Version 2.0
   Apache Directory API ASN.1 API under The Apache Software License, Version 2.0
@@ -26,29 +25,21 @@ This project includes:
   Apache HttpCore under Apache License, Version 2.0
   Apache Log4j under The Apache Software License, Version 2.0
   Apache Parquet Avro under The Apache Software License, Version 2.0
-  Apache Parquet Avro (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Column under The Apache Software License, Version 2.0
-  Apache Parquet Column (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Common under The Apache Software License, Version 2.0
-  Apache Parquet Common (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Encodings under The Apache Software License, Version 2.0
-  Apache Parquet Encodings (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Format (Incubating) under The Apache Software License, Version 2.0
-  Apache Parquet Generator (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Hadoop under The Apache Software License, Version 2.0
-  Apache Parquet Hadoop (Incubating) under The Apache Software License, Version 2.0
-  Apache Parquet Hadoop Bundle (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Jackson under The Apache Software License, Version 2.0
-  Apache Parquet Jackson (Incubating) under The Apache Software License, Version 2.0
   Apache Thrift under The Apache Software License, Version 2.0
   Apache Velocity under The Apache Software License, Version 2.0
   ApacheDS I18n under The Apache Software License, Version 2.0
   ApacheDS Protocol Kerberos Codec under The Apache Software License, Version 2.0
   ASM Core under 3-Clause BSD License
-  com.twitter.common:objectsize under Apache License, Version 2.0
   Commons BeanUtils Core under The Apache Software License, Version 2.0
   Commons CLI under The Apache Software License, Version 2.0
   Commons Codec under The Apache Software License, Version 2.0
+  Commons Collections under The Apache Software License, Version 2.0
   Commons Compress under The Apache Software License, Version 2.0
   Commons Configuration under The Apache Software License, Version 2.0
   Commons Daemon under The Apache Software License, Version 2.0
@@ -77,12 +68,12 @@ This project includes:
   hadoop-yarn-client under Apache License, Version 2.0
   hadoop-yarn-common under Apache License, Version 2.0
   hadoop-yarn-server-common under Apache License, Version 2.0
-  hoodie-common under Apache License, Version 2.0
-  hoodie-hadoop-mr under Apache License, Version 2.0
-  hoodie-hadoop-mr-bundle under Apache License, Version 2.0
-  hoodie-presto-bundle under Apache License, Version 2.0
   htrace-core under The Apache Software License, Version 2.0
   HttpClient under Apache License
+  hudi-common under Apache License, Version 2.0
+  hudi-hadoop-mr under Apache License, Version 2.0
+  hudi-hadoop-mr-bundle under Apache License, Version 2.0
+  hudi-presto-bundle under Apache License, Version 2.0
   Jackson under The Apache Software License, Version 2.0
   Jackson-annotations under The Apache Software License, Version 2.0
   Jackson-core under The Apache Software License, Version 2.0

--- a/packaging/hudi-spark-bundle/src/main/resources/META-INF/HUDI_NOTICE.txt
+++ b/packaging/hudi-spark-bundle/src/main/resources/META-INF/HUDI_NOTICE.txt
@@ -25,11 +25,9 @@ This project includes:
   Apache Calcite Avatica under Apache License, Version 2.0
   Apache Calcite Avatica Metrics under Apache License, Version 2.0
   Apache Commons Collections under Apache License, Version 2.0
-  Apache Commons Configuration under Apache License, Version 2.0
   Apache Commons Crypto under Apache License, Version 2.0
   Apache Commons IO under Apache License, Version 2.0
   Apache Commons Logging under The Apache Software License, Version 2.0
-  Apache Commons Math under The Apache Software License, Version 2.0
   Apache Curator under The Apache Software License, Version 2.0
   Apache Derby Database Engine and Embedded JDBC Driver under Apache 2
   Apache Directory API ASN.1 API under The Apache Software License, Version 2.0
@@ -42,6 +40,7 @@ This project includes:
   Apache Hadoop HDFS under Apache License, Version 2.0
   Apache HBase - Annotations under Apache License, Version 2.0
   Apache HBase - Client under Apache License, Version 2.0
+  Apache HBase - Common under Apache License, Version 2.0
   Apache HBase - Protocol under Apache License, Version 2.0
   Apache HttpClient under Apache License, Version 2.0
   Apache HttpCore under Apache License, Version 2.0
@@ -53,21 +52,13 @@ This project includes:
   Apache Log4j SLF4J Binding under The Apache Software License, Version 2.0
   Apache Log4j Web under The Apache Software License, Version 2.0
   Apache Parquet Avro under The Apache Software License, Version 2.0
-  Apache Parquet Avro (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Column under The Apache Software License, Version 2.0
-  Apache Parquet Column (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Common under The Apache Software License, Version 2.0
-  Apache Parquet Common (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Encodings under The Apache Software License, Version 2.0
-  Apache Parquet Encodings (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Format (Incubating) under The Apache Software License, Version 2.0
-  Apache Parquet Generator (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Hadoop under The Apache Software License, Version 2.0
-  Apache Parquet Hadoop (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Hadoop Bundle under The Apache Software License, Version 2.0
-  Apache Parquet Hadoop Bundle (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Jackson under The Apache Software License, Version 2.0
-  Apache Parquet Jackson (Incubating) under The Apache Software License, Version 2.0
   Apache Thrift under The Apache Software License, Version 2.0
   Apache Twill API under The Apache Software License, Version 2.0
   Apache Twill common library under The Apache Software License, Version 2.0
@@ -89,7 +80,6 @@ This project includes:
   Calcite Linq4j under Apache License, Version 2.0
   chill under Apache 2
   chill-java under Apache 2
-  com.twitter.common:objectsize under Apache License, Version 2.0
   Commons BeanUtils Core under The Apache Software License, Version 2.0
   Commons CLI under The Apache Software License, Version 2.0
   Commons Codec under The Apache Software License, Version 2.0
@@ -169,15 +159,15 @@ This project includes:
   Hive Vector-Code-Gen Utilities under The Apache Software License, Version 2.0
   HK2 API module under CDDL + GPLv2 with classpath exception
   HK2 Implementation Utilities under CDDL + GPLv2 with classpath exception
-  hoodie-client under Apache License, Version 2.0
-  hoodie-common under Apache License, Version 2.0
-  hoodie-hadoop-mr under Apache License, Version 2.0
-  hoodie-hive under Apache License, Version 2.0
-  hoodie-spark under Apache License, Version 2.0
-  hoodie-spark-bundle under Apache License, Version 2.0
-  hoodie-timeline-service under Apache License, Version 2.0
   htrace-core under The Apache Software License, Version 2.0
   HttpClient under Apache License
+  hudi-client under Apache License, Version 2.0
+  hudi-common under Apache License, Version 2.0
+  hudi-hadoop-mr under Apache License, Version 2.0
+  hudi-hive under Apache License, Version 2.0
+  hudi-spark under Apache License, Version 2.0
+  hudi-spark-bundle under Apache License, Version 2.0
+  hudi-timeline-service under Apache License, Version 2.0
   IntelliJ IDEA Annotations under The Apache Software License, Version 2.0
   Jackson under The Apache Software License, Version 2.0
   Jackson Integration for Metrics under Apache License 2.0

--- a/packaging/hudi-utilities-bundle/src/main/resources/META-INF/HUDI_NOTICE.txt
+++ b/packaging/hudi-utilities-bundle/src/main/resources/META-INF/HUDI_NOTICE.txt
@@ -26,7 +26,6 @@ This project includes:
   Apache Calcite Avatica under Apache License, Version 2.0
   Apache Calcite Avatica Metrics under Apache License, Version 2.0
   Apache Commons Collections under Apache License, Version 2.0
-  Apache Commons Configuration under Apache License, Version 2.0
   Apache Commons Crypto under Apache License, Version 2.0
   Apache Commons IO under Apache License, Version 2.0
   Apache Commons Lang under Apache License, Version 2.0
@@ -56,21 +55,13 @@ This project includes:
   Apache Log4j SLF4J Binding under The Apache Software License, Version 2.0
   Apache Log4j Web under The Apache Software License, Version 2.0
   Apache Parquet Avro under The Apache Software License, Version 2.0
-  Apache Parquet Avro (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Column under The Apache Software License, Version 2.0
-  Apache Parquet Column (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Common under The Apache Software License, Version 2.0
-  Apache Parquet Common (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Encodings under The Apache Software License, Version 2.0
-  Apache Parquet Encodings (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Format (Incubating) under The Apache Software License, Version 2.0
-  Apache Parquet Generator (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Hadoop under The Apache Software License, Version 2.0
-  Apache Parquet Hadoop (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Hadoop Bundle under The Apache Software License, Version 2.0
-  Apache Parquet Hadoop Bundle (Incubating) under The Apache Software License, Version 2.0
   Apache Parquet Jackson under The Apache Software License, Version 2.0
-  Apache Parquet Jackson (Incubating) under The Apache Software License, Version 2.0
   Apache Thrift under The Apache Software License, Version 2.0
   Apache Twill API under The Apache Software License, Version 2.0
   Apache Twill common library under The Apache Software License, Version 2.0
@@ -94,7 +85,6 @@ This project includes:
   Calcite Linq4j under Apache License, Version 2.0
   chill under Apache 2
   chill-java under Apache 2
-  com.twitter.common:objectsize under Apache License, Version 2.0
   Commons BeanUtils Core under The Apache Software License, Version 2.0
   Commons CLI under The Apache Software License, Version 2.0
   Commons Codec under The Apache Software License, Version 2.0
@@ -148,7 +138,7 @@ This project includes:
   hadoop-yarn-server-common under Apache License, Version 2.0
   hadoop-yarn-server-resourcemanager under Apache License, Version 2.0
   hadoop-yarn-server-web-proxy under Apache License, Version 2.0
-  Hamcrest Core under BSD style
+  Hamcrest Core under New BSD License
   HBase - Common under The Apache Software License, Version 2.0
   HBase - Hadoop Compatibility under The Apache Software License, Version 2.0
   HBase - Hadoop Two Compatibility under The Apache Software License, Version 2.0
@@ -175,16 +165,16 @@ This project includes:
   Hive Vector-Code-Gen Utilities under The Apache Software License, Version 2.0
   HK2 API module under CDDL + GPLv2 with classpath exception
   HK2 Implementation Utilities under CDDL + GPLv2 with classpath exception
-  hoodie-client under Apache License, Version 2.0
-  hoodie-common under Apache License, Version 2.0
-  hoodie-hadoop-mr under Apache License, Version 2.0
-  hoodie-hive under Apache License, Version 2.0
-  hoodie-spark under Apache License, Version 2.0
-  hoodie-timeline-service under Apache License, Version 2.0
-  hoodie-utilities under Apache License, Version 2.0
-  hoodie-utilities-bundle under Apache License, Version 2.0
   htrace-core under The Apache Software License, Version 2.0
   HttpClient under Apache License
+  hudi-client under Apache License, Version 2.0
+  hudi-common under Apache License, Version 2.0
+  hudi-hadoop-mr under Apache License, Version 2.0
+  hudi-hive under Apache License, Version 2.0
+  hudi-spark under Apache License, Version 2.0
+  hudi-timeline-service under Apache License, Version 2.0
+  hudi-utilities under Apache License, Version 2.0
+  hudi-utilities-bundle under Apache License, Version 2.0
   IntelliJ IDEA Annotations under The Apache Software License, Version 2.0
   Jackson under The Apache Software License, Version 2.0
   Jackson Integration for Metrics under Apache License 2.0
@@ -312,7 +302,6 @@ This project includes:
   Spark Project Streaming under Apache 2.0 License
   Spark Project Tags under Apache 2.0 License
   Spark Project Unsafe under Apache 2.0 License
-  spark-avro under Apache-2.0
   StAX API under The Apache Software License, Version 2.0
   stream-lib under Apache License, Version 2.0
   Tephra API under The Apache Software License, Version 2.0

--- a/pom.xml
+++ b/pom.xml
@@ -702,6 +702,16 @@
         <artifactId>hadoop-common</artifactId>
         <version>${hadoop.version}</version>
         <scope>provided</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>jdk.tools</groupId>
+            <artifactId>jdk.tools</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
Updating NOTICE.txt to be in sync with latest master.  Added exclusion in hadoop-common dependency to exclude jdk.tools 