### PR TITLE
[HUDI-235] Fix scheduled compaction rollback in restore command

### DIFF
--- a/hudi-client/src/main/java/org/apache/hudi/HoodieWriteClient.java
+++ b/hudi-client/src/main/java/org/apache/hudi/HoodieWriteClient.java
@@ -808,16 +808,12 @@ public class HoodieWriteClient<T extends HoodieRecordPayload> extends AbstractHo
             instantsToStats.put(instant.getTimestamp(), statsForInstant);
             break;
           case HoodieTimeline.COMPACTION_ACTION:
-            if (instant.isRequested()) {
-              // TODO : Get file status and create a rollback stat and file
-              // TODO : Delete the .aux files along with the instant file, okay for now since the archival process will
-              // delete these files when it does not see a corresponding instant file under .hoodie
-              deleteRequestedCompaction(instant.getTimestamp());
-              logger.info("Deleted pending scheduled compaction " + instant.getTimestamp());
-            } else {
-              List<HoodieRollbackStat> statsForCompaction = doRollbackAndGetStats(instant.getTimestamp());
-              instantsToStats.put(instant.getTimestamp(), statsForCompaction);
-            }
+            // TODO : Get file status and create a rollback stat and file
+            // TODO : Delete the .aux files along with the instant file, okay for now since the archival process will
+            // delete these files when it does not see a corresponding instant file under .hoodie
+            List<HoodieRollbackStat> statsForCompaction = doRollbackAndGetStats(instant.getTimestamp());
+            instantsToStats.put(instant.getTimestamp(), statsForCompaction);
+            logger.info("Deleted compaction instant " + instant);
             break;
           default:
             throw new IllegalArgumentException("invalid action name " + instant.getAction());

--- a/hudi-client/src/test/java/org/apache/hudi/table/TestMergeOnReadTable.java
+++ b/hudi-client/src/test/java/org/apache/hudi/table/TestMergeOnReadTable.java
@@ -680,6 +680,11 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
       List<HoodieFileGroup> fileGroups = ((HoodieTableFileSystemView) rtView).getAllFileGroups().collect(Collectors
           .toList());
       assertTrue(fileGroups.isEmpty());
+
+      // make sure there are no log files remaining
+      assertTrue(((HoodieTableFileSystemView) rtView).getAllFileGroups().filter(fileGroup -> fileGroup
+          .getAllRawFileSlices().filter(f -> f.getLogFiles().count() == 0).count() == 0).count() == 0L);
+
     }
   }
 


### PR DESCRIPTION
Once a compaction is scheduled, any updates to the file slices part of the requested compaction goto a new log file under a phantom commit time. 
The restoreToInstant command does not delete these log files when reverting the requested compaction instant.