### PR TITLE
[MINOR] Fix logging in HoodieSparkSqlWriter

### DIFF
--- a/hudi-spark/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
+++ b/hudi-spark/src/main/scala/org/apache/hudi/HoodieSparkSqlWriter.scala
@@ -38,7 +38,7 @@ import scala.collection.mutable.ListBuffer
 
 private[hudi] object HoodieSparkSqlWriter {
 
-  private val log = LogManager.getLogger("HoodieSparkSQLWriter")
+  private val log = LogManager.getLogger(getClass)
 
   def write(sqlContext: SQLContext,
             mode: SaveMode,


### PR DESCRIPTION
The class name used for logging in HoodieSparkSqlWriter is not correct. Thus, when we configure logging for Hudi in spark's `log4j.properties` using `log4j.logger.org.apache.hudi=INFO` it does not get applied to this scala object/class because the class name provided does not have `org.apache.hudi` namespace.