### PR TITLE
[HUDI-244] : Hive sync should escape partition field name

### DIFF
--- a/hudi-hive/src/main/java/org/apache/hudi/hive/util/SchemaUtil.java
+++ b/hudi-hive/src/main/java/org/apache/hudi/hive/util/SchemaUtil.java
@@ -410,7 +410,7 @@ public class SchemaUtil {
     List<String> partitionFields = new ArrayList<>();
     for (String partitionKey : config.partitionFields) {
       String partitionKeyWithTicks = tickSurround(partitionKey);
-      partitionFields.add(new StringBuilder().append(partitionKey).append(" ")
+      partitionFields.add(new StringBuilder().append(partitionKeyWithTicks).append(" ")
           .append(getPartitionKeyType(hiveSchema, partitionKeyWithTicks)).toString());
     }
 


### PR DESCRIPTION
  - now supports field names beginning with '_' for e.g