### PR TITLE
[HUDI-235] Log files generated after pending compaction does not get deleted when using restoreToCommit

### DIFF
--- a/hudi-client/src/main/java/org/apache/hudi/HoodieWriteClient.java
+++ b/hudi-client/src/main/java/org/apache/hudi/HoodieWriteClient.java
@@ -808,16 +808,13 @@ public class HoodieWriteClient<T extends HoodieRecordPayload> extends AbstractHo
             instantsToStats.put(instant.getTimestamp(), statsForInstant);
             break;
           case HoodieTimeline.COMPACTION_ACTION:
-            if (instant.isRequested()) {
-              // TODO : Get file status and create a rollback stat and file
-              // TODO : Delete the .aux files along with the instant file, okay for now since the archival process will
-              // delete these files when it does not see a corresponding instant file under .hoodie
-              deleteRequestedCompaction(instant.getTimestamp());
-              logger.info("Deleted pending scheduled compaction " + instant.getTimestamp());
-            } else {
-              List<HoodieRollbackStat> statsForCompaction = doRollbackAndGetStats(instant.getTimestamp());
-              instantsToStats.put(instant.getTimestamp(), statsForCompaction);
-            }
+            // TODO : Get file status and create a rollback stat and file
+            // TODO : Delete the .aux files along with the instant file, okay for now since the archival process will
+            // delete these files when it does not see a corresponding instant file under .hoodie
+            List<HoodieRollbackStat> statsForCompaction = doRollbackAndGetStats(instant.getTimestamp());
+            logger.info("Rollback stats for instant " + instant);
+            instantsToStats.put(instant.getTimestamp(), statsForCompaction);
+            logger.info("Deleted compaction instant " + instant);
             break;
           default:
             throw new IllegalArgumentException("invalid action name " + instant.getAction());

--- a/hudi-client/src/test/java/org/apache/hudi/table/TestMergeOnReadTable.java
+++ b/hudi-client/src/test/java/org/apache/hudi/table/TestMergeOnReadTable.java
@@ -681,6 +681,10 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
           .toList());
       assertTrue(fileGroups.isEmpty());
     }
+    // make sure there are no log files remaining
+    HoodieTableMetaClient metaClient = new HoodieTableMetaClient(jsc.hadoopConfiguration(), cfg.getBasePath());
+    assertTrue(new HoodieTableFileSystemView(metaClient, metaClient.getActiveTimeline()).getAllFileGroups()
+        .noneMatch(fileGroup -> fileGroup.getAllRawFileSlices().anyMatch(f -> f.getLogFiles().count() > 0)));
   }
 
   protected HoodieWriteConfig getHoodieWriteConfigWithSmallFileHandlingOff() {


### PR DESCRIPTION
@n3nash : This is the bug fix that you made in production branch. Can you review it. 

