### PR TITLE
[HUDI-250]  Ensure Hudi CLI wrapper works with non snapshot jars too

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,9 +7,9 @@ Release 0.5.0-incubating
  * Complete Redo of Hudi Jar bundling
  * Bug fixes in query side integration, DeltaStreamer, compaction, rollbacks, restore
 
-
 ### Full PR List
-
+  * **Balaji Varadarajan** [HUDI-250] Ensure Hudi CLI wrapper works with non snapshot jars too
+  * **Nishith Agarwal** [HUDI-235] Fix scheduled compaction rollback in restore command
   * **Balaji Varadarajan** [HUDI-249] Update Release-notes. Add sign-artifacts to POM and release related scripts. Add missing license headers
   * **yanghua** [HUDI-217] Provide a unified resource management class to standardize the resource allocation and release for hudi client test cases
   * **Bhavani Sudha Saktheeswaran** [HUDI-164] Fixes incorrect averageBytesPerRecord

--- a/hudi-cli/hudi-cli.sh
+++ b/hudi-cli/hudi-cli.sh
@@ -19,7 +19,7 @@
 ################################################################################
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-HOODIE_JAR=`ls $DIR/target/hudi-cli-*-SNAPSHOT.jar | grep -v source | grep -v javadoc`
+HOODIE_JAR=`ls $DIR/target/hudi-cli-*.jar | grep -v source | grep -v javadoc`
 if [ -z "$HADOOP_CONF_DIR" ]; then
   echo "setting hadoop conf dir"
   HADOOP_CONF_DIR="/etc/hadoop/conf"

--- a/release/scripts/cut_release_branch.sh
+++ b/release/scripts/cut_release_branch.sh
@@ -58,7 +58,7 @@ fi
 
 MASTER_BRANCH=master
 RELEASE_BRANCH=release-${RELEASE}
-GITHUB_REPO_URL=https://gitbox.apache.org/repos/asf/incubator-hudi.git
+GITHUB_REPO_URL=git@github.com:apache/incubator-hudi.git
 HUDI_ROOT_DIR=incubator-hudi
 LOCAL_CLONE_DIR=hudi_release_${RELEASE}
 


### PR DESCRIPTION
Two Changes:
Ensure Hudi CLI wrapper works with non snapshot jars too
Also Fix bug in cut_release_branch script