### PR TITLE
[HUDI-254]: Bundle and shade databricks/avro with spark bundle

### DIFF
--- a/hudi-spark/pom.xml
+++ b/hudi-spark/pom.xml
@@ -216,7 +216,6 @@
       <groupId>com.databricks</groupId>
       <artifactId>spark-avro_2.11</artifactId>
       <version>4.0.0</version>
-      <scope>provided</scope>
     </dependency>
 
     <!-- Hadoop -->

--- a/packaging/hudi-spark-bundle/pom.xml
+++ b/packaging/hudi-spark-bundle/pom.xml
@@ -84,6 +84,8 @@
                   <include>org.apache.hive:hive-service-rpc</include>
                   <include>org.apache.hive:hive-metastore</include>
                   <include>org.apache.hive:hive-jdbc</include>
+
+                  <include>com.databricks:spark-avro_2.11</include>
                 </includes>
               </artifactSet>
               <relocations>
@@ -126,6 +128,10 @@
                 <relocation>
                   <pattern>org.apache.commons.codec.</pattern>
                   <shadedPattern>org.apache.hudi.org.apache.commons.codec.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.databricks.</pattern>
+                  <shadedPattern>org.apache.hudi.com.databricks.</shadedPattern>
                 </relocation>
                 <!-- TODO: Revisit GH ISSUE #533 & PR#633-->
                 <!--


### PR DESCRIPTION
 - spark 2.4 onwards, spark has built in support. shading to avoid conflicts
 - spark 2.3 still needs this bundled, so that dropping bundle into jars folder would work