### PR TITLE
[HUDI-130] Paths written in compaction plan needs to be relative to base-path

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/CompactionCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/CompactionCommand.java
@@ -290,9 +290,10 @@ public class CompactionCommand implements CommandMarker {
         String message = "\n\n\t COMPACTION PLAN " + (valid ? "VALID" : "INVALID") + "\n\n";
         List<Comparable[]> rows = new ArrayList<>();
         res.stream().forEach(r -> {
-          Comparable[] row = new Comparable[] {r.getOperation().getFileId(), r.getOperation().getBaseInstantTime(),
-              r.getOperation().getDataFilePath().isPresent() ? r.getOperation().getDataFilePath().get() : "",
-              r.getOperation().getDeltaFilePaths().size(), r.isSuccess(),
+          Comparable[] row = new Comparable[]{r.getOperation().getFileId(),
+              r.getOperation().getBaseInstantTime(),
+              r.getOperation().getDataFileName().isPresent() ? r.getOperation().getDataFileName().get() : "",
+              r.getOperation().getDeltaFileNames().size(), r.isSuccess(),
               r.getException().isPresent() ? r.getException().get().getMessage() : ""};
           rows.add(row);
         });

--- a/hudi-client/src/main/java/org/apache/hudi/CompactionAdminClient.java
+++ b/hudi-client/src/main/java/org/apache/hudi/CompactionAdminClient.java
@@ -239,8 +239,9 @@ public class CompactionAdminClient extends AbstractHoodieClient {
     FileSlice merged =
         fileSystemView.getLatestMergedFileSlicesBeforeOrOn(op.getPartitionPath(), lastInstant.getTimestamp())
             .filter(fs -> fs.getFileId().equals(op.getFileId())).findFirst().get();
-    final int maxVersion = op.getDeltaFilePaths().stream().map(lf -> FSUtils.getFileVersionFromLog(new Path(lf)))
-        .reduce((x, y) -> x > y ? x : y).orElse(0);
+    final int maxVersion =
+            op.getDeltaFileNames().stream().map(lf -> FSUtils.getFileVersionFromLog(new Path(lf)))
+                    .reduce((x, y) -> x > y ? x : y).orElse(0);
     List<HoodieLogFile> logFilesToBeMoved =
         merged.getLogFiles().filter(lf -> lf.getLogVersion() > maxVersion).collect(Collectors.toList());
     return logFilesToBeMoved.stream().map(lf -> {
@@ -291,28 +292,34 @@ public class CompactionAdminClient extends AbstractHoodieClient {
         if (fileSliceOptional.isPresent()) {
           FileSlice fs = fileSliceOptional.get();
           Option<HoodieDataFile> df = fs.getDataFile();
-          if (operation.getDataFilePath().isPresent()) {
-            String expPath =
-                metaClient.getFs().getFileStatus(new Path(operation.getDataFilePath().get())).getPath().toString();
-            Preconditions.checkArgument(df.isPresent(),
-                "Data File must be present. File Slice was : " + fs + ", operation :" + operation);
+          if (operation.getDataFileName().isPresent()) {
+            String expPath = metaClient.getFs().getFileStatus(new Path(
+                FSUtils.getPartitionPath(metaClient.getBasePath(), operation.getPartitionPath()),
+                    new Path(operation.getDataFileName().get()))).getPath()
+                .toString();
+            Preconditions.checkArgument(df.isPresent(), "Data File must be present. File Slice was : "
+                + fs + ", operation :" + operation);
             Preconditions.checkArgument(df.get().getPath().equals(expPath),
                 "Base Path in operation is specified as " + expPath + " but got path " + df.get().getPath());
           }
           Set<HoodieLogFile> logFilesInFileSlice = fs.getLogFiles().collect(Collectors.toSet());
-          Set<HoodieLogFile> logFilesInCompactionOp = operation.getDeltaFilePaths().stream().map(dp -> {
-            try {
-              FileStatus[] fileStatuses = metaClient.getFs().listStatus(new Path(dp));
-              Preconditions.checkArgument(fileStatuses.length == 1, "Expect only 1 file-status");
-              return new HoodieLogFile(fileStatuses[0]);
-            } catch (FileNotFoundException fe) {
-              throw new CompactionValidationException(fe.getMessage());
-            } catch (IOException ioe) {
-              throw new HoodieIOException(ioe.getMessage(), ioe);
-            }
-          }).collect(Collectors.toSet());
-          Set<HoodieLogFile> missing = logFilesInCompactionOp.stream().filter(lf -> !logFilesInFileSlice.contains(lf))
-              .collect(Collectors.toSet());
+          Set<HoodieLogFile> logFilesInCompactionOp = operation.getDeltaFileNames().stream()
+              .map(dp -> {
+                try {
+                  FileStatus[] fileStatuses = metaClient.getFs().listStatus(
+                      new Path(FSUtils.getPartitionPath(metaClient.getBasePath(), operation.getPartitionPath()),
+                          new Path(dp)));
+                  Preconditions.checkArgument(fileStatuses.length == 1, "Expect only 1 file-status");
+                  return new HoodieLogFile(fileStatuses[0]);
+                } catch (FileNotFoundException fe) {
+                  throw new CompactionValidationException(fe.getMessage());
+                } catch (IOException ioe) {
+                  throw new HoodieIOException(ioe.getMessage(), ioe);
+                }
+              }).collect(Collectors.toSet());
+          Set<HoodieLogFile> missing =
+              logFilesInCompactionOp.stream().filter(lf -> !logFilesInFileSlice.contains(lf))
+                  .collect(Collectors.toSet());
           Preconditions.checkArgument(missing.isEmpty(),
               "All log files specified in compaction operation is not present. Missing :" + missing + ", Exp :"
                   + logFilesInCompactionOp + ", Got :" + logFilesInFileSlice);

--- a/hudi-client/src/main/java/org/apache/hudi/io/compact/strategy/CompactionStrategy.java
+++ b/hudi-client/src/main/java/org/apache/hudi/io/compact/strategy/CompactionStrategy.java
@@ -26,6 +26,7 @@ import org.apache.hudi.avro.model.HoodieCompactionOperation;
 import org.apache.hudi.avro.model.HoodieCompactionPlan;
 import org.apache.hudi.common.model.HoodieDataFile;
 import org.apache.hudi.common.model.HoodieLogFile;
+import org.apache.hudi.common.util.CompactionUtils;
 import org.apache.hudi.common.util.FSUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.config.HoodieWriteConfig;
@@ -94,7 +95,9 @@ public abstract class CompactionStrategy implements Serializable {
       List<HoodieCompactionOperation> operations, List<HoodieCompactionPlan> pendingCompactionPlans) {
     // Strategy implementation can overload this method to set specific compactor-id
     return HoodieCompactionPlan.newBuilder()
-        .setOperations(orderAndFilter(writeConfig, operations, pendingCompactionPlans)).build();
+        .setOperations(orderAndFilter(writeConfig, operations, pendingCompactionPlans))
+        .setVersion(CompactionUtils.LATEST_COMPACTION_METADATA_VERSION)
+        .build();
   }
 
   /**

--- a/hudi-common/pom.xml
+++ b/hudi-common/pom.xml
@@ -67,11 +67,13 @@
           <imports>
             <!-- import avro files -->
             <import>${basedir}/src/main/avro/HoodieCommitMetadata.avsc</import>
+            <import>${basedir}/src/main/avro/HoodieCompactionOperation.avsc</import>
             <import>${basedir}/src/main/avro/HoodieSavePointMetadata.avsc</import>
             <import>${basedir}/src/main/avro/HoodieCompactionMetadata.avsc</import>
             <import>${basedir}/src/main/avro/HoodieCleanMetadata.avsc</import>
             <import>${basedir}/src/main/avro/HoodieRollbackMetadata.avsc</import>
             <import>${basedir}/src/main/avro/HoodieRestoreMetadata.avsc</import>
+            <import>${basedir}/src/main/avro/HoodieArchivedMetaEntry.avsc</import>
           </imports>
         </configuration>
       </plugin>

--- a/hudi-common/src/main/avro/HoodieArchivedMetaEntry.avsc
+++ b/hudi-common/src/main/avro/HoodieArchivedMetaEntry.avsc
@@ -67,6 +67,11 @@
       {
          "name":"actionType",
          "type":["null","string"]
+      },
+      {
+         "name":"version",
+         "type":["int", "null"],
+         "default": 1
       }
    ]
 }

--- a/hudi-common/src/main/avro/HoodieCleanMetadata.avsc
+++ b/hudi-common/src/main/avro/HoodieCleanMetadata.avsc
@@ -36,6 +36,11 @@
         ]
      }
      }
+     },
+     {
+        "name":"version",
+        "type":["int", "null"],
+        "default": 1
      }
  ]
 }

--- a/hudi-common/src/main/avro/HoodieCommitMetadata.avsc
+++ b/hudi-common/src/main/avro/HoodieCommitMetadata.avsc
@@ -126,6 +126,11 @@
             "type":"map",
             "values":"string"
          }]
+      },
+      {
+         "name":"version",
+         "type":["int", "null"],
+         "default": 1
       }
    ]
 }

--- a/hudi-common/src/main/avro/HoodieCompactionOperation.avsc
+++ b/hudi-common/src/main/avro/HoodieCompactionOperation.avsc
@@ -74,6 +74,11 @@
           "values":"string"
        }],
        "default": null
+    },
+    {
+       "name":"version",
+       "type":["int", "null"],
+       "default": 1
     }
   ]
 }

--- a/hudi-common/src/main/avro/HoodieRollbackMetadata.avsc
+++ b/hudi-common/src/main/avro/HoodieRollbackMetadata.avsc
@@ -34,6 +34,11 @@
         ]
      }
      }
+     },
+     {
+        "name":"version",
+        "type":["int", "null"],
+        "default": 1
      }
  ]
 }

--- a/hudi-common/src/main/avro/HoodieSavePointMetadata.avsc
+++ b/hudi-common/src/main/avro/HoodieSavePointMetadata.avsc
@@ -32,6 +32,11 @@
              ]
           }
           }
+     },
+     {
+        "name":"version",
+        "type":["int", "null"],
+        "default": 1
      }
  ]
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/dto/CompactionOpDTO.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/dto/CompactionOpDTO.java
@@ -61,8 +61,8 @@ public class CompactionOpDTO {
     dto.compactionInstantTime = compactionInstantTime;
     dto.baseInstantTime = op.getBaseInstantTime();
     dto.dataFileCommitTime = op.getDataFileCommitTime().orElse(null);
-    dto.dataFilePath = op.getDataFilePath().orElse(null);
-    dto.deltaFilePaths = new ArrayList<>(op.getDeltaFilePaths());
+    dto.dataFilePath = op.getDataFileName().orElse(null);
+    dto.deltaFilePaths = new ArrayList<>(op.getDeltaFileNames());
     dto.partitionPath = op.getPartitionPath();
     dto.metrics = op.getMetrics() == null ? new HashMap<>() : new HashMap<>(op.getMetrics());
     return dto;

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/AvroUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/AvroUtils.java
@@ -47,6 +47,8 @@ import org.apache.hudi.common.HoodieRollbackStat;
 
 public class AvroUtils {
 
+  private static final Integer DEFAULT_VERSION = 1;
+
   public static HoodieCleanMetadata convertCleanMetadata(String startCleanTime, Option<Long> durationInMs,
       List<HoodieCleanStat> cleanStats) {
     ImmutableMap.Builder<String, HoodieCleanPartitionMetadata> partitionMetadataBuilder = ImmutableMap.builder();
@@ -64,7 +66,7 @@ public class AvroUtils {
       }
     }
     return new HoodieCleanMetadata(startCleanTime, durationInMs.orElseGet(() -> -1L), totalDeleted,
-        earliestCommitToRetain, partitionMetadataBuilder.build());
+        earliestCommitToRetain, partitionMetadataBuilder.build(), DEFAULT_VERSION);
   }
 
   public static HoodieRestoreMetadata convertRestoreMetadata(String startRestoreTime, Option<Long> durationInMs,
@@ -75,7 +77,7 @@ public class AvroUtils {
           Arrays.asList(convertRollbackMetadata(startRestoreTime, durationInMs, commits, commitToStat.getValue())));
     }
     return new HoodieRestoreMetadata(startRestoreTime, durationInMs.orElseGet(() -> -1L), commits,
-        commitToStatBuilder.build());
+        commitToStatBuilder.build(), DEFAULT_VERSION);
   }
 
   public static HoodieRollbackMetadata convertRollbackMetadata(String startRollbackTime, Option<Long> durationInMs,
@@ -88,8 +90,9 @@ public class AvroUtils {
       partitionMetadataBuilder.put(stat.getPartitionPath(), metadata);
       totalDeleted += stat.getSuccessDeleteFiles().size();
     }
+
     return new HoodieRollbackMetadata(startRollbackTime, durationInMs.orElseGet(() -> -1L), totalDeleted, commits,
-        partitionMetadataBuilder.build());
+        partitionMetadataBuilder.build(), DEFAULT_VERSION);
   }
 
   public static HoodieSavepointMetadata convertSavepointMetadata(String user, String comment,
@@ -99,7 +102,8 @@ public class AvroUtils {
       HoodieSavepointPartitionMetadata metadata = new HoodieSavepointPartitionMetadata(stat.getKey(), stat.getValue());
       partitionMetadataBuilder.put(stat.getKey(), metadata);
     }
-    return new HoodieSavepointMetadata(user, System.currentTimeMillis(), comment, partitionMetadataBuilder.build());
+    return new HoodieSavepointMetadata(user, System.currentTimeMillis(), comment, partitionMetadataBuilder.build(),
+        DEFAULT_VERSION);
   }
 
   public static Option<byte[]> serializeCompactionPlan(HoodieCompactionPlan compactionWorkload) throws IOException {

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/CompactionUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/CompactionUtils.java
@@ -34,6 +34,9 @@ import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.table.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.util.collection.Pair;
+import org.apache.hudi.common.versioning.compaction.CompactionPlanMigrator;
+import org.apache.hudi.common.versioning.compaction.CompactionV1MigrationHandler;
+import org.apache.hudi.common.versioning.compaction.CompactionV2MigrationHandler;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
@@ -44,6 +47,10 @@ import org.apache.log4j.Logger;
 public class CompactionUtils {
 
   private static final Logger LOG = LogManager.getLogger(CompactionUtils.class);
+
+  public static final Integer COMPACTION_METADATA_VERSION_1 = CompactionV1MigrationHandler.VERSION;
+  public static final Integer COMPACTION_METADATA_VERSION_2 = CompactionV2MigrationHandler.VERSION;
+  public static final Integer LATEST_COMPACTION_METADATA_VERSION = COMPACTION_METADATA_VERSION_2;
 
   /**
    * Generate compaction operation from file-slice
@@ -59,9 +66,9 @@ public class CompactionUtils {
     builder.setPartitionPath(partitionPath);
     builder.setFileId(fileSlice.getFileId());
     builder.setBaseInstantTime(fileSlice.getBaseInstantTime());
-    builder.setDeltaFilePaths(fileSlice.getLogFiles().map(lf -> lf.getPath().toString()).collect(Collectors.toList()));
+    builder.setDeltaFilePaths(fileSlice.getLogFiles().map(lf -> lf.getPath().getName()).collect(Collectors.toList()));
     if (fileSlice.getDataFile().isPresent()) {
-      builder.setDataFilePath(fileSlice.getDataFile().get().getPath());
+      builder.setDataFilePath(fileSlice.getDataFile().get().getFileName());
     }
 
     if (metricsCaptureFunction.isPresent()) {
@@ -82,9 +89,11 @@ public class CompactionUtils {
       Option<Function<Pair<String, FileSlice>, Map<String, Double>>> metricsCaptureFunction) {
     HoodieCompactionPlan.Builder builder = HoodieCompactionPlan.newBuilder();
     extraMetadata.ifPresent(m -> builder.setExtraMetadata(m));
+
     builder.setOperations(partitionFileSlicePairs.stream()
         .map(pfPair -> buildFromFileSlice(pfPair.getKey(), pfPair.getValue(), metricsCaptureFunction))
         .collect(Collectors.toList()));
+    builder.setVersion(LATEST_COMPACTION_METADATA_VERSION);
     return builder.build();
   }
 
@@ -94,8 +103,8 @@ public class CompactionUtils {
   public static HoodieCompactionOperation buildHoodieCompactionOperation(CompactionOperation op) {
     return HoodieCompactionOperation.newBuilder().setFileId(op.getFileId()).setBaseInstantTime(op.getBaseInstantTime())
         .setPartitionPath(op.getPartitionPath())
-        .setDataFilePath(op.getDataFilePath().isPresent() ? op.getDataFilePath().get() : null)
-        .setDeltaFilePaths(op.getDeltaFilePaths()).setMetrics(op.getMetrics()).build();
+        .setDataFilePath(op.getDataFileName().isPresent() ? op.getDataFileName().get() : null)
+        .setDeltaFilePaths(op.getDeltaFileNames()).setMetrics(op.getMetrics()).build();
   }
 
   /**
@@ -127,9 +136,10 @@ public class CompactionUtils {
 
   public static HoodieCompactionPlan getCompactionPlan(HoodieTableMetaClient metaClient, String compactionInstant)
       throws IOException {
+    CompactionPlanMigrator migrator = new CompactionPlanMigrator(metaClient);
     HoodieCompactionPlan compactionPlan = AvroUtils.deserializeCompactionPlan(metaClient.getActiveTimeline()
         .getInstantAuxiliaryDetails(HoodieTimeline.getCompactionRequestedInstant(compactionInstant)).get());
-    return compactionPlan;
+    return migrator.upgradeToLatest(compactionPlan, compactionPlan.getVersion());
   }
 
   /**

--- a/hudi-common/src/main/java/org/apache/hudi/common/versioning/AbstractMigratorBase.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/versioning/AbstractMigratorBase.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,25 +15,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-{"namespace": "org.apache.hudi.avro.model",
- "type": "record",
- "name": "HoodieRestoreMetadata",
- "fields": [
-     {"name": "startRestoreTime", "type": "string"},
-     {"name": "timeTakenInMillis", "type": "long"},
-     {"name": "instantsToRollback", "type": {"type": "array", "items": "string"}},
-     {"name": "hoodieRestoreMetadata", "type": {
-     "type" : "map", "values" : {
-        "type": "array",
-        "default": "null",
-        "items": "HoodieRollbackMetadata",
-        "name": "hoodieRollbackMetadata"
-     }
-   }},
-     {
-        "name":"version",
-        "type":["int", "null"],
-        "default": 1
-     }
- ]
+
+package org.apache.hudi.common.versioning;
+
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+
+public abstract class AbstractMigratorBase<T> implements VersionMigrator<T> {
+
+  protected final HoodieTableMetaClient metaClient;
+
+  public AbstractMigratorBase(HoodieTableMetaClient metaClient) {
+    this.metaClient = metaClient;
+  }
+
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/versioning/MetadataMigrator.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/versioning/MetadataMigrator.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.versioning;
+
+import com.google.common.base.Preconditions;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.util.collection.Pair;
+
+/**
+ * Migrates a specific metadata type stored in .hoodie folder to latest version
+ * @param <T>
+ */
+public class MetadataMigrator<T> {
+
+  private final Map<Integer, VersionMigrator<T>> migrators;
+  private final Integer latestVersion;
+  private final Integer oldestVersion;
+
+  public MetadataMigrator(HoodieTableMetaClient metaClient, List<VersionMigrator<T>> migratorList) {
+    migrators = migratorList.stream().map(m ->
+        Pair.of(m.getManagedVersion(), m)).collect(Collectors.toMap(Pair::getKey, Pair::getValue));
+    latestVersion = migrators.keySet().stream().reduce((x, y) -> x > y ? x : y).get();
+    oldestVersion = migrators.keySet().stream().reduce((x, y) -> x < y ? x : y).get();
+  }
+
+  /**
+   * Upgrade Metadata version to its latest
+   * @param metadata  Metadata
+   * @param metadataVersion Current version of metadata
+   * @return Metadata conforming to the latest version of this metadata
+   */
+  public T upgradeToLatest(T metadata, int metadataVersion) {
+    if (metadataVersion == latestVersion) {
+      return metadata;
+    }
+
+    int newVersion = metadataVersion + 1;
+    while (newVersion <= latestVersion) {
+      VersionMigrator<T> upgrader = migrators.get(newVersion);
+      metadata = upgrader.upgradeFrom(metadata);
+      newVersion += 1;
+    }
+    return metadata;
+  }
+
+  /**
+   * Migrate metadata to a specific version
+   * @param metadata         Hoodie Table Meta Client
+   * @param metadataVersion   Metadata Version
+   * @param targetVersion     Target Version
+   * @return Metadata conforming to the target version
+   */
+  public T migrateToVersion(T metadata, int metadataVersion, int targetVersion) {
+    Preconditions.checkArgument(targetVersion >= oldestVersion);
+    Preconditions.checkArgument(targetVersion <= latestVersion);
+    if (metadataVersion == targetVersion) {
+      return metadata;
+    } else if (metadataVersion > targetVersion) {
+      return dowgradeToVersion(metadata, metadataVersion, targetVersion);
+    } else {
+      return upgradeToVersion(metadata, metadataVersion, targetVersion);
+    }
+  }
+
+  private T upgradeToVersion(T metadata, int metadataVersion, int targetVersion) {
+    int newVersion = metadataVersion + 1;
+    while (newVersion <= targetVersion) {
+      VersionMigrator<T> upgrader = migrators.get(newVersion);
+      metadata = upgrader.upgradeFrom(metadata);
+      newVersion += 1;
+    }
+    return metadata;
+  }
+
+  private T dowgradeToVersion(T metadata, int metadataVersion, int targetVersion) {
+    int newVersion = metadataVersion - 1;
+    while (newVersion >= targetVersion) {
+      VersionMigrator<T> downgrader = migrators.get(newVersion);
+      metadata = downgrader.downgradeFrom(metadata);
+      newVersion -= 1;
+    }
+    return metadata;
+  }
+
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/versioning/VersionMigrator.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/versioning/VersionMigrator.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.versioning;
+
+import java.io.Serializable;
+
+/**
+ * Responsible for upgrading and downgrading metadata versions for a specific metadata
+ * @param <T> Metadata Type
+ */
+public interface VersionMigrator<T> extends Serializable {
+
+  /**
+   * Version of Metadata that this class will handle
+   * @return
+   */
+  Integer getManagedVersion();
+
+  /**
+   * Upgrades metadata of type T from previous version to this version
+   * @param input Metadata as of previous version.
+   * @return Metadata compatible with the version managed by this class
+   */
+  T upgradeFrom(T input);
+
+  /**
+   * Downgrades metadata of type T from next version to this version
+   * @param input Metadata as of next highest version
+   * @return Metadata compatible with the version managed by this class
+   */
+  T downgradeFrom(T input);
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/versioning/compaction/CompactionPlanMigrator.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/versioning/compaction/CompactionPlanMigrator.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,25 +15,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-{"namespace": "org.apache.hudi.avro.model",
- "type": "record",
- "name": "HoodieRestoreMetadata",
- "fields": [
-     {"name": "startRestoreTime", "type": "string"},
-     {"name": "timeTakenInMillis", "type": "long"},
-     {"name": "instantsToRollback", "type": {"type": "array", "items": "string"}},
-     {"name": "hoodieRestoreMetadata", "type": {
-     "type" : "map", "values" : {
-        "type": "array",
-        "default": "null",
-        "items": "HoodieRollbackMetadata",
-        "name": "hoodieRollbackMetadata"
-     }
-   }},
-     {
-        "name":"version",
-        "type":["int", "null"],
-        "default": 1
-     }
- ]
+
+package org.apache.hudi.common.versioning.compaction;
+
+import java.util.Arrays;
+import org.apache.hudi.avro.model.HoodieCompactionPlan;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.versioning.MetadataMigrator;
+
+/**
+ * Responsible for handling different versions of compaction plan
+ */
+public class CompactionPlanMigrator extends MetadataMigrator<HoodieCompactionPlan> {
+
+  public CompactionPlanMigrator(HoodieTableMetaClient metaClient) {
+    super(metaClient, Arrays.asList(
+        new CompactionV1MigrationHandler(metaClient),
+        new CompactionV2MigrationHandler(metaClient)));
+  }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/versioning/compaction/CompactionV1MigrationHandler.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/versioning/compaction/CompactionV1MigrationHandler.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.versioning.compaction;
+
+import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.hadoop.fs.Path;
+import org.apache.hudi.avro.model.HoodieCompactionOperation;
+import org.apache.hudi.avro.model.HoodieCompactionPlan;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.util.FSUtils;
+import org.apache.hudi.common.versioning.AbstractMigratorBase;
+
+/**
+ * Compaction V1 has absolute paths as part of compaction operations
+ */
+public class CompactionV1MigrationHandler extends AbstractMigratorBase<HoodieCompactionPlan> {
+
+  public static final Integer VERSION = 1;
+
+  public CompactionV1MigrationHandler(HoodieTableMetaClient metaClient) {
+    super(metaClient);
+  }
+
+  @Override
+  public Integer getManagedVersion() {
+    return VERSION;
+  }
+
+  @Override
+  public HoodieCompactionPlan upgradeFrom(HoodieCompactionPlan input) {
+    throw new IllegalArgumentException("This is the lowest version. Input cannot be any lower version");
+  }
+
+  @Override
+  public HoodieCompactionPlan downgradeFrom(HoodieCompactionPlan input) {
+    Preconditions.checkArgument(input.getVersion() == 2, "Input version is "
+        + input.getVersion() + ". Must be 2");
+    HoodieCompactionPlan compactionPlan = new HoodieCompactionPlan();
+    final Path basePath = new Path(metaClient.getBasePath());
+    List<HoodieCompactionOperation> v1CompactionOperationList = new ArrayList<>();
+    if (null != input.getOperations()) {
+      v1CompactionOperationList = input.getOperations().stream().map(inp -> {
+        return HoodieCompactionOperation.newBuilder()
+            .setBaseInstantTime(inp.getBaseInstantTime())
+            .setFileId(inp.getFileId())
+            .setPartitionPath(inp.getPartitionPath())
+            .setMetrics(inp.getMetrics())
+            .setDataFilePath(convertToV1Path(basePath, inp.getPartitionPath(), inp.getDataFilePath()))
+            .setDeltaFilePaths(inp.getDeltaFilePaths().stream().map(s -> convertToV1Path(basePath,
+                inp.getPartitionPath(), s)).collect(Collectors.toList()))
+            .build();
+      }).collect(Collectors.toList());
+    }
+    compactionPlan.setOperations(v1CompactionOperationList);
+    compactionPlan.setExtraMetadata(input.getExtraMetadata());
+    compactionPlan.setVersion(getManagedVersion());
+    return compactionPlan;
+  }
+
+  private static String convertToV1Path(Path basePath, String partitionPath, String fileName) {
+    if ((fileName == null) || (fileName.isEmpty())) {
+      return fileName;
+    }
+
+    return new Path(FSUtils.getPartitionPath(basePath, partitionPath), fileName).toString();
+  }
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/versioning/compaction/CompactionV2MigrationHandler.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/versioning/compaction/CompactionV2MigrationHandler.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.versioning.compaction;
+
+import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.hadoop.fs.Path;
+import org.apache.hudi.avro.model.HoodieCompactionOperation;
+import org.apache.hudi.avro.model.HoodieCompactionPlan;
+import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.versioning.AbstractMigratorBase;
+
+/**
+ * With version 2 of compaction plan, paths are no longer absolute.
+ */
+public class CompactionV2MigrationHandler extends AbstractMigratorBase<HoodieCompactionPlan> {
+
+  public static final Integer VERSION = 2;
+
+  public CompactionV2MigrationHandler(HoodieTableMetaClient metaClient) {
+    super(metaClient);
+  }
+
+  @Override
+  public Integer getManagedVersion() {
+    return VERSION;
+  }
+
+  @Override
+  public HoodieCompactionPlan upgradeFrom(HoodieCompactionPlan input) {
+    Preconditions.checkArgument(input.getVersion() == 1, "Input version is "
+        + input.getVersion() + ". Must be 1");
+    HoodieCompactionPlan compactionPlan = new HoodieCompactionPlan();
+    List<HoodieCompactionOperation> v2CompactionOperationList = new ArrayList<>();
+    if (null != input.getOperations()) {
+      v2CompactionOperationList = input.getOperations().stream().map(inp -> {
+        return HoodieCompactionOperation.newBuilder()
+            .setBaseInstantTime(inp.getBaseInstantTime())
+            .setFileId(inp.getFileId())
+            .setPartitionPath(inp.getPartitionPath())
+            .setMetrics(inp.getMetrics())
+            .setDataFilePath(new Path(inp.getDataFilePath()).getName())
+            .setDeltaFilePaths(inp.getDeltaFilePaths().stream().map(s -> new Path(s).getName())
+                .collect(Collectors.toList()))
+            .build();
+      }).collect(Collectors.toList());
+    }
+    compactionPlan.setOperations(v2CompactionOperationList);
+    compactionPlan.setExtraMetadata(input.getExtraMetadata());
+    compactionPlan.setVersion(getManagedVersion());
+    return compactionPlan;
+  }
+
+  @Override
+  public HoodieCompactionPlan downgradeFrom(HoodieCompactionPlan input) {
+    throw new IllegalArgumentException("This is the current highest version. Input cannot be any higher version");
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/CompactionTestUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/CompactionTestUtils.java
@@ -171,7 +171,8 @@ public class CompactionTestUtils {
         throw new HoodieIOException(e.getMessage(), e);
       }
     }).collect(Collectors.toList());
-    return new HoodieCompactionPlan(ops.isEmpty() ? null : ops, new HashMap<>());
+    return new HoodieCompactionPlan(ops.isEmpty() ? null : ops, new HashMap<>(),
+        CompactionUtils.LATEST_COMPACTION_METADATA_VERSION);
   }
 
   public static class TestHoodieDataFile extends HoodieDataFile {
@@ -179,7 +180,7 @@ public class CompactionTestUtils {
     private final String path;
 
     public TestHoodieDataFile(String path) {
-      super("/tmp/ce481ee7-9e53-4a2e-9992-f9e295fa79c0_11_20180918020003.parquet");
+      super(path);
       this.path = path;
     }
 


### PR DESCRIPTION

1. Seamlessly handle old compaction plans written with absolute Paths
2. Also add version to all avro metadata