### PR TITLE
[HUDI-137] Fix state transitions for Hudi cleaning action

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/CompactionCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/CompactionCommand.java
@@ -288,8 +288,7 @@ public class CompactionCommand implements CommandMarker {
         String message = "\n\n\t COMPACTION PLAN " + (valid ? "VALID" : "INVALID") + "\n\n";
         List<Comparable[]> rows = new ArrayList<>();
         res.stream().forEach(r -> {
-          Comparable[] row = new Comparable[]{r.getOperation().getFileId(),
-              r.getOperation().getBaseInstantTime(),
+          Comparable[] row = new Comparable[] {r.getOperation().getFileId(), r.getOperation().getBaseInstantTime(),
               r.getOperation().getDataFileName().isPresent() ? r.getOperation().getDataFileName().get() : "",
               r.getOperation().getDeltaFileNames().size(), r.isSuccess(),
               r.getException().isPresent() ? r.getException().get().getMessage() : ""};

--- a/hudi-client/src/main/java/org/apache/hudi/HoodieCleanClient.java
+++ b/hudi-client/src/main/java/org/apache/hudi/HoodieCleanClient.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi;
+
+import com.codahale.metrics.Timer;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import java.io.IOException;
+import java.util.List;
+import org.apache.hudi.avro.model.HoodieCleanMetadata;
+import org.apache.hudi.avro.model.HoodieCleanerPlan;
+import org.apache.hudi.client.embedded.EmbeddedTimelineService;
+import org.apache.hudi.common.HoodieCleanStat;
+import org.apache.hudi.common.model.HoodieRecordPayload;
+import org.apache.hudi.common.table.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
+import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.table.timeline.HoodieInstant.State;
+import org.apache.hudi.common.util.AvroUtils;
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.exception.HoodieIOException;
+import org.apache.hudi.metrics.HoodieMetrics;
+import org.apache.hudi.table.HoodieTable;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.apache.spark.api.java.JavaSparkContext;
+
+public class HoodieCleanClient<T extends HoodieRecordPayload> extends AbstractHoodieClient {
+
+  private static Logger logger = LogManager.getLogger(HoodieCleanClient.class);
+  private final transient HoodieMetrics metrics;
+
+  public HoodieCleanClient(JavaSparkContext jsc, HoodieWriteConfig clientConfig, HoodieMetrics metrics) {
+    this(jsc, clientConfig, metrics, Option.empty());
+  }
+
+  public HoodieCleanClient(JavaSparkContext jsc, HoodieWriteConfig clientConfig, HoodieMetrics metrics,
+      Option<EmbeddedTimelineService> timelineService) {
+    super(jsc, clientConfig, timelineService);
+    this.metrics = metrics;
+  }
+
+  /**
+   * Clean up any stale/old files/data lying around (either on file storage or index storage) based on the
+   * configurations and CleaningPolicy used. (typically files that no longer can be used by a running query can be
+   * cleaned)
+   */
+  public void clean() throws HoodieIOException {
+    String startCleanTime = HoodieActiveTimeline.createNewCommitTime();
+    clean(startCleanTime);
+  }
+
+  /**
+   * Clean up any stale/old files/data lying around (either on file storage or index storage) based on the
+   * configurations and CleaningPolicy used. (typically files that no longer can be used by a running query can be
+   * cleaned)
+   *
+   * @param startCleanTime Cleaner Instant Timestamp
+   * @throws HoodieIOException in case of any IOException
+   */
+  protected HoodieCleanMetadata clean(String startCleanTime) throws HoodieIOException {
+    // Create a Hoodie table which encapsulated the commits and files visible
+    final HoodieTable<T> table = HoodieTable.getHoodieTable(createMetaClient(true), config, jsc);
+
+    // If there are inflight(failed) or previously requested clean operation, first perform them
+    table.getCleanTimeline().filterInflightsAndRequested().getInstants().forEach(hoodieInstant -> {
+      logger.info("There were previously unfinished cleaner operations. Finishing Instant=" + hoodieInstant);
+      runClean(table, hoodieInstant.getTimestamp());
+    });
+
+    Option<HoodieCleanerPlan> cleanerPlanOpt = scheduleClean(startCleanTime);
+
+    if (cleanerPlanOpt.isPresent()) {
+      HoodieCleanerPlan cleanerPlan = cleanerPlanOpt.get();
+      if ((cleanerPlan.getFilesToBeDeletedPerPartition() != null)
+          && !cleanerPlan.getFilesToBeDeletedPerPartition().isEmpty()) {
+        final HoodieTable<T> hoodieTable = HoodieTable.getHoodieTable(createMetaClient(true), config, jsc);
+        return runClean(hoodieTable, startCleanTime);
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Creates a Cleaner plan if there are files to be cleaned and stores them in instant file
+   *
+   * @param startCleanTime Cleaner Instant Time
+   * @return Cleaner Plan if generated
+   */
+  @VisibleForTesting
+  protected Option<HoodieCleanerPlan> scheduleClean(String startCleanTime) {
+    // Create a Hoodie table which encapsulated the commits and files visible
+    HoodieTable<T> table = HoodieTable.getHoodieTable(createMetaClient(true), config, jsc);
+
+    HoodieCleanerPlan cleanerPlan = table.scheduleClean(jsc);
+
+    if ((cleanerPlan.getFilesToBeDeletedPerPartition() != null)
+        && !cleanerPlan.getFilesToBeDeletedPerPartition().isEmpty()) {
+
+      HoodieInstant cleanInstant = new HoodieInstant(State.REQUESTED, HoodieTimeline.CLEAN_ACTION, startCleanTime);
+      // Save to both aux and timeline folder
+      try {
+        table.getActiveTimeline().saveToCleanRequested(cleanInstant, AvroUtils.serializeCleanerPlan(cleanerPlan));
+        logger.info("Requesting Cleaning with instant time " + cleanInstant);
+      } catch (IOException e) {
+        logger.error("Got exception when saving cleaner requested file", e);
+        throw new HoodieIOException(e.getMessage(), e);
+      }
+      return Option.of(cleanerPlan);
+    }
+    return Option.empty();
+  }
+
+  /**
+   * Executes the Cleaner plan stored in the instant metadata
+   *
+   * @param table Hoodie Table
+   * @param cleanInstantTs Cleaner Instant Timestamp
+   */
+  @VisibleForTesting
+  protected HoodieCleanMetadata runClean(HoodieTable<T> table, String cleanInstantTs) {
+    HoodieInstant cleanInstant =
+        table.getCleanTimeline().getInstants().filter(x -> x.getTimestamp().equals(cleanInstantTs)).findFirst().get();
+
+    Preconditions.checkArgument(
+        cleanInstant.getState().equals(State.REQUESTED) || cleanInstant.getState().equals(State.INFLIGHT));
+
+    try {
+      logger.info("Cleaner started");
+      final Timer.Context context = metrics.getCleanCtx();
+
+      if (!cleanInstant.isInflight()) {
+        // Mark as inflight first
+        cleanInstant = table.getActiveTimeline().transitionCleanRequestedToInflight(cleanInstant);
+      }
+
+      List<HoodieCleanStat> cleanStats = table.clean(jsc, cleanInstant);
+
+      if (cleanStats.isEmpty()) {
+        return HoodieCleanMetadata.newBuilder().build();
+      }
+
+      // Emit metrics (duration, numFilesDeleted) if needed
+      Option<Long> durationInMs = Option.empty();
+      if (context != null) {
+        durationInMs = Option.of(metrics.getDurationInMs(context.stop()));
+        logger.info("cleanerElaspsedTime (Minutes): " + durationInMs.get() / (1000 * 60));
+      }
+
+      // Create the metadata and save it
+      HoodieCleanMetadata metadata =
+          AvroUtils.convertCleanMetadata(cleanInstant.getTimestamp(), durationInMs, cleanStats);
+      logger.info("Cleaned " + metadata.getTotalFilesDeleted() + " files");
+      metrics.updateCleanMetrics(durationInMs.orElseGet(() -> -1L), metadata.getTotalFilesDeleted());
+
+      table.getActiveTimeline().transitionCleanInflightToComplete(
+          new HoodieInstant(true, HoodieTimeline.CLEAN_ACTION, cleanInstant.getTimestamp()),
+          AvroUtils.serializeCleanMetadata(metadata));
+      logger.info("Marked clean started on " + cleanInstant.getTimestamp() + " as complete");
+      return metadata;
+    } catch (IOException e) {
+      throw new HoodieIOException("Failed to clean up after commit", e);
+    }
+  }
+}

--- a/hudi-client/src/main/java/org/apache/hudi/client/embedded/EmbeddedTimelineService.java
+++ b/hudi-client/src/main/java/org/apache/hudi/client/embedded/EmbeddedTimelineService.java
@@ -97,9 +97,11 @@ public class EmbeddedTimelineService {
 
   public void stop() {
     if (null != server) {
+      logger.info("Closing Timeline server");
       this.server.close();
       this.server = null;
       this.viewManager = null;
+      logger.info("Closed Timeline server");
     }
   }
 }

--- a/hudi-client/src/main/java/org/apache/hudi/io/HoodieMergeHandle.java
+++ b/hudi-client/src/main/java/org/apache/hudi/io/HoodieMergeHandle.java
@@ -195,9 +195,8 @@ public class HoodieMergeHandle<T extends HoodieRecordPayload> extends HoodieWrit
       // Load the new records in a map
       long memoryForMerge = config.getMaxMemoryPerPartitionMerge();
       logger.info("MaxMemoryPerPartitionMerge => " + memoryForMerge);
-      this.keyToNewRecords = new ExternalSpillableMap<>(memoryForMerge,
-          config.getSpillableMapBasePath(), new DefaultSizeEstimator(),
-          new HoodieRecordSizeEstimator(originalSchema));
+      this.keyToNewRecords = new ExternalSpillableMap<>(memoryForMerge, config.getSpillableMapBasePath(),
+          new DefaultSizeEstimator(), new HoodieRecordSizeEstimator(originalSchema));
     } catch (IOException io) {
       throw new HoodieIOException("Cannot instantiate an ExternalSpillableMap", io);
     }

--- a/hudi-client/src/main/java/org/apache/hudi/io/compact/strategy/CompactionStrategy.java
+++ b/hudi-client/src/main/java/org/apache/hudi/io/compact/strategy/CompactionStrategy.java
@@ -96,8 +96,7 @@ public abstract class CompactionStrategy implements Serializable {
     // Strategy implementation can overload this method to set specific compactor-id
     return HoodieCompactionPlan.newBuilder()
         .setOperations(orderAndFilter(writeConfig, operations, pendingCompactionPlans))
-        .setVersion(CompactionUtils.LATEST_COMPACTION_METADATA_VERSION)
-        .build();
+        .setVersion(CompactionUtils.LATEST_COMPACTION_METADATA_VERSION).build();
   }
 
   /**

--- a/hudi-client/src/main/java/org/apache/hudi/table/HoodieCopyOnWriteTable.java
+++ b/hudi-client/src/main/java/org/apache/hudi/table/HoodieCopyOnWriteTable.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.table;
 
 import com.google.common.hash.Hashing;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
@@ -35,9 +36,12 @@ import org.apache.avro.generic.IndexedRecord;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hudi.WriteStatus;
+import org.apache.hudi.avro.model.HoodieActionInstant;
+import org.apache.hudi.avro.model.HoodieCleanerPlan;
 import org.apache.hudi.avro.model.HoodieCompactionPlan;
 import org.apache.hudi.common.HoodieCleanStat;
 import org.apache.hudi.common.HoodieRollbackStat;
+import org.apache.hudi.common.model.HoodieCleaningPolicy;
 import org.apache.hudi.common.model.HoodieCommitMetadata;
 import org.apache.hudi.common.model.HoodieDataFile;
 import org.apache.hudi.common.model.HoodieKey;
@@ -48,6 +52,7 @@ import org.apache.hudi.common.model.HoodieRollingStatMetadata;
 import org.apache.hudi.common.table.HoodieTimeline;
 import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
+import org.apache.hudi.common.util.AvroUtils;
 import org.apache.hudi.common.util.FSUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.collection.Pair;
@@ -72,9 +77,9 @@ import org.apache.parquet.hadoop.ParquetReader;
 import org.apache.spark.Partitioner;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
-import org.apache.spark.api.java.function.Function2;
 import org.apache.spark.api.java.function.PairFlatMapFunction;
 import scala.Tuple2;
+
 
 /**
  * Implementation of a very heavily read-optimized Hoodie Table where
@@ -97,10 +102,12 @@ public class HoodieCopyOnWriteTable<T extends HoodieRecordPayload> extends Hoodi
       Map<String, PartitionCleanStat> partitionCleanStatMap = new HashMap<>();
 
       FileSystem fs = table.getMetaClient().getFs();
+      Path basePath = new Path(table.getMetaClient().getBasePath());
       while (iter.hasNext()) {
         Tuple2<String, String> partitionDelFileTuple = iter.next();
         String partitionPath = partitionDelFileTuple._1();
-        String deletePathStr = partitionDelFileTuple._2();
+        String delFileName = partitionDelFileTuple._2();
+        String deletePathStr = new Path(new Path(basePath, partitionPath), delFileName).toString();
         Boolean deletedFileResult = deleteFileAndGetResult(fs, deletePathStr);
         if (!partitionCleanStatMap.containsKey(partitionPath)) {
           partitionCleanStatMap.put(partitionPath, new PartitionCleanStat(partitionPath));
@@ -109,29 +116,24 @@ public class HoodieCopyOnWriteTable<T extends HoodieRecordPayload> extends Hoodi
         partitionCleanStat.addDeleteFilePatterns(deletePathStr);
         partitionCleanStat.addDeletedFileResult(deletePathStr, deletedFileResult);
       }
-
       return partitionCleanStatMap.entrySet().stream().map(e -> new Tuple2<>(e.getKey(), e.getValue()))
           .collect(Collectors.toList()).iterator();
-    };
-  }
-
-  private static PairFlatMapFunction<String, String, String> getFilesToDeleteFunc(HoodieTable table,
-      HoodieWriteConfig config) {
-    return (PairFlatMapFunction<String, String, String>) partitionPathToClean -> {
-      HoodieCleanHelper cleaner = new HoodieCleanHelper(table, config);
-      return cleaner.getDeletePaths(partitionPathToClean).stream()
-          .map(deleteFile -> new Tuple2<>(partitionPathToClean, deleteFile.toString())).iterator();
     };
   }
 
   private static Boolean deleteFileAndGetResult(FileSystem fs, String deletePathStr) throws IOException {
     Path deletePath = new Path(deletePathStr);
     logger.debug("Working on delete path :" + deletePath);
-    boolean deleteResult = fs.delete(deletePath, false);
-    if (deleteResult) {
-      logger.debug("Cleaned file at path :" + deletePath);
+    try {
+      boolean deleteResult = fs.delete(deletePath, false);
+      if (deleteResult) {
+        logger.debug("Cleaned file at path :" + deletePath);
+      }
+      return deleteResult;
+    } catch (FileNotFoundException fio) {
+      // With cleanPlan being used for retried cleaning operations, its possible to clean a file twice
+      return false;
     }
-    return deleteResult;
   }
 
   @Override
@@ -269,23 +271,80 @@ public class HoodieCopyOnWriteTable<T extends HoodieRecordPayload> extends Hoodi
   }
 
   /**
+   * Generates List of files to be cleaned
+   * 
+   * @param jsc JavaSparkContext
+   * @return Cleaner Plan
+   */
+  public HoodieCleanerPlan scheduleClean(JavaSparkContext jsc) {
+    try {
+      FileSystem fs = getMetaClient().getFs();
+
+      List<String> partitionsToClean =
+          FSUtils.getAllPartitionPaths(fs, getMetaClient().getBasePath(), config.shouldAssumeDatePartitioning());
+      if (partitionsToClean.isEmpty()) {
+        logger.info("Nothing to clean here. It is already clean");
+        return HoodieCleanerPlan.newBuilder().setPolicy(HoodieCleaningPolicy.KEEP_LATEST_COMMITS.name()).build();
+      }
+      logger.info(
+          "Total Partitions to clean : " + partitionsToClean.size() + ", with policy " + config.getCleanerPolicy());
+      int cleanerParallelism = Math.min(partitionsToClean.size(), config.getCleanerParallelism());
+      logger.info("Using cleanerParallelism: " + cleanerParallelism);
+      HoodieCleanHelper cleaner = new HoodieCleanHelper(this, config);
+      Option<HoodieInstant> earliestInstant = cleaner.getEarliestCommitToRetain();
+
+      Map<String, List<String>> cleanOps = jsc.parallelize(partitionsToClean, cleanerParallelism)
+          .map(partitionPathToClean -> Pair.of(partitionPathToClean, cleaner.getDeletePaths(partitionPathToClean)))
+          .collect().stream().collect(Collectors.toMap(Pair::getKey, Pair::getValue));
+      return new HoodieCleanerPlan(earliestInstant
+          .map(x -> new HoodieActionInstant(x.getTimestamp(), x.getAction(), x.getState().name())).orElse(null),
+          config.getCleanerPolicy().name(), cleanOps, 1);
+    } catch (IOException e) {
+      throw new HoodieIOException("Failed to schedule clean operation", e);
+    }
+  }
+
+  /**
    * Performs cleaning of partition paths according to cleaning policy and returns the number of files cleaned. Handles
    * skews in partitions to clean by making files to clean as the unit of task distribution.
    *
    * @throws IllegalArgumentException if unknown cleaning policy is provided
    */
   @Override
-  public List<HoodieCleanStat> clean(JavaSparkContext jsc) {
+  public List<HoodieCleanStat> clean(JavaSparkContext jsc, HoodieInstant cleanInstant) {
     try {
-      FileSystem fs = getMetaClient().getFs();
-      List<String> partitionsToClean =
-          FSUtils.getAllPartitionPaths(fs, getMetaClient().getBasePath(), config.shouldAssumeDatePartitioning());
-      logger.info("Partitions to clean up : " + partitionsToClean + ", with policy " + config.getCleanerPolicy());
-      if (partitionsToClean.isEmpty()) {
-        logger.info("Nothing to clean here mom. It is already clean");
-        return Collections.emptyList();
-      }
-      return cleanPartitionPaths(partitionsToClean, jsc);
+      HoodieCleanerPlan cleanerPlan = AvroUtils.deserializeCleanerPlan(getActiveTimeline()
+          .getInstantAuxiliaryDetails(HoodieTimeline.getCleanRequestedInstant(cleanInstant.getTimestamp())).get());
+
+      int cleanerParallelism = Math.min(
+          (int) (cleanerPlan.getFilesToBeDeletedPerPartition().values().stream().mapToInt(x -> x.size()).count()),
+          config.getCleanerParallelism());
+      logger.info("Using cleanerParallelism: " + cleanerParallelism);
+      List<Tuple2<String, PartitionCleanStat>> partitionCleanStats = jsc
+          .parallelize(cleanerPlan.getFilesToBeDeletedPerPartition().entrySet().stream()
+              .flatMap(x -> x.getValue().stream().map(y -> new Tuple2<String, String>(x.getKey(), y)))
+              .collect(Collectors.toList()), cleanerParallelism)
+          .mapPartitionsToPair(deleteFilesFunc(this)).reduceByKey((e1, e2) -> e1.merge(e2)).collect();
+
+      Map<String, PartitionCleanStat> partitionCleanStatsMap =
+          partitionCleanStats.stream().collect(Collectors.toMap(Tuple2::_1, Tuple2::_2));
+
+      // Return PartitionCleanStat for each partition passed.
+      return cleanerPlan.getFilesToBeDeletedPerPartition().keySet().stream().map(partitionPath -> {
+        PartitionCleanStat partitionCleanStat =
+            (partitionCleanStatsMap.containsKey(partitionPath)) ? partitionCleanStatsMap.get(partitionPath)
+                : new PartitionCleanStat(partitionPath);
+        HoodieActionInstant actionInstant = cleanerPlan.getEarliestInstantToRetain();
+        return HoodieCleanStat.newBuilder().withPolicy(config.getCleanerPolicy()).withPartitionPath(partitionPath)
+            .withEarliestCommitRetained(Option.ofNullable(
+                actionInstant != null
+                    ? new HoodieInstant(HoodieInstant.State.valueOf(actionInstant.getState()),
+                        actionInstant.getAction(), actionInstant.getTimestamp())
+                    : null))
+            .withDeletePathPattern(partitionCleanStat.deletePathPatterns)
+            .withSuccessfulDeletes(partitionCleanStat.successDeleteFiles)
+            .withFailedDeletes(partitionCleanStat.failedDeleteFiles).build();
+      }).collect(Collectors.toList());
     } catch (IOException e) {
       throw new HoodieIOException("Failed to clean up after commit", e);
     }
@@ -311,7 +370,7 @@ public class HoodieCopyOnWriteTable<T extends HoodieRecordPayload> extends Hoodi
     logger.info("Clean out all parquet files generated for commit: " + commit);
     List<RollbackRequest> rollbackRequests = generateRollbackRequests(instantToRollback);
 
-    //TODO: We need to persist this as rollback workload and use it in case of partial failures
+    // TODO: We need to persist this as rollback workload and use it in case of partial failures
     List<HoodieRollbackStat> stats =
         new RollbackExecutor(metaClient, config).performRollback(jsc, instantToRollback, rollbackRequests);
 
@@ -321,8 +380,7 @@ public class HoodieCopyOnWriteTable<T extends HoodieRecordPayload> extends Hoodi
     return stats;
   }
 
-  private List<RollbackRequest> generateRollbackRequests(HoodieInstant instantToRollback)
-      throws IOException {
+  private List<RollbackRequest> generateRollbackRequests(HoodieInstant instantToRollback) throws IOException {
     return FSUtils.getAllPartitionPaths(this.metaClient.getFs(), this.getMetaClient().getBasePath(),
         config.shouldAssumeDatePartitioning()).stream().map(partitionPath -> {
           return RollbackRequest.createRollbackRequestWithDeleteDataAndLogFilesAction(partitionPath, instantToRollback);
@@ -348,34 +406,6 @@ public class HoodieCopyOnWriteTable<T extends HoodieRecordPayload> extends Hoodi
     } else {
       logger.warn("Rollback finished without deleting inflight instant file. Instant=" + instantToBeDeleted);
     }
-  }
-
-  private List<HoodieCleanStat> cleanPartitionPaths(List<String> partitionsToClean, JavaSparkContext jsc) {
-    int cleanerParallelism = Math.min(partitionsToClean.size(), config.getCleanerParallelism());
-    logger.info("Using cleanerParallelism: " + cleanerParallelism);
-    List<Tuple2<String, PartitionCleanStat>> partitionCleanStats = jsc
-        .parallelize(partitionsToClean, cleanerParallelism).flatMapToPair(getFilesToDeleteFunc(this, config))
-        .repartition(cleanerParallelism) // repartition to remove skews
-        .mapPartitionsToPair(deleteFilesFunc(this)).reduceByKey(
-            // merge partition level clean stats below
-            (Function2<PartitionCleanStat, PartitionCleanStat, PartitionCleanStat>) (e1, e2) -> e1.merge(e2))
-        .collect();
-
-    Map<String, PartitionCleanStat> partitionCleanStatsMap =
-        partitionCleanStats.stream().collect(Collectors.toMap(Tuple2::_1, Tuple2::_2));
-
-    HoodieCleanHelper cleaner = new HoodieCleanHelper(this, config);
-    // Return PartitionCleanStat for each partition passed.
-    return partitionsToClean.stream().map(partitionPath -> {
-      PartitionCleanStat partitionCleanStat =
-          (partitionCleanStatsMap.containsKey(partitionPath)) ? partitionCleanStatsMap.get(partitionPath)
-              : new PartitionCleanStat(partitionPath);
-      return HoodieCleanStat.newBuilder().withPolicy(config.getCleanerPolicy()).withPartitionPath(partitionPath)
-          .withEarliestCommitRetained(cleaner.getEarliestCommitToRetain())
-          .withDeletePathPattern(partitionCleanStat.deletePathPatterns)
-          .withSuccessfulDeletes(partitionCleanStat.successDeleteFiles)
-          .withFailedDeletes(partitionCleanStat.failedDeleteFiles).build();
-    }).collect(Collectors.toList());
   }
 
   enum BucketType {

--- a/hudi-client/src/main/java/org/apache/hudi/table/HoodieMergeOnReadTable.java
+++ b/hudi-client/src/main/java/org/apache/hudi/table/HoodieMergeOnReadTable.java
@@ -185,12 +185,12 @@ public class HoodieMergeOnReadTable<T extends HoodieRecordPayload> extends Hoodi
     logger.info("Unpublished " + commit);
     Long startTime = System.currentTimeMillis();
     List<RollbackRequest> rollbackRequests = generateRollbackRequests(jsc, instantToRollback);
-    //TODO: We need to persist this as rollback workload and use it in case of partial failures
+    // TODO: We need to persist this as rollback workload and use it in case of partial failures
     List<HoodieRollbackStat> allRollbackStats =
         new RollbackExecutor(metaClient, config).performRollback(jsc, instantToRollback, rollbackRequests);
     // Delete Inflight instants if enabled
-    deleteInflightInstant(deleteInstants, this.getActiveTimeline(), new HoodieInstant(true, instantToRollback
-        .getAction(), instantToRollback.getTimestamp()));
+    deleteInflightInstant(deleteInstants, this.getActiveTimeline(),
+        new HoodieInstant(true, instantToRollback.getAction(), instantToRollback.getTimestamp()));
 
     logger.info("Time(in ms) taken to finish rollback " + (System.currentTimeMillis() - startTime));
 
@@ -200,6 +200,7 @@ public class HoodieMergeOnReadTable<T extends HoodieRecordPayload> extends Hoodi
   /**
    * Generate all rollback requests that we need to perform for rolling back this action without actually performing
    * rolling back
+   * 
    * @param jsc JavaSparkContext
    * @param instantToRollback Instant to Rollback
    * @return list of rollback requests
@@ -211,92 +212,92 @@ public class HoodieMergeOnReadTable<T extends HoodieRecordPayload> extends Hoodi
     List<String> partitions = FSUtils.getAllPartitionPaths(this.metaClient.getFs(), this.getMetaClient().getBasePath(),
         config.shouldAssumeDatePartitioning());
     int sparkPartitions = Math.max(Math.min(partitions.size(), config.getRollbackParallelism()), 1);
-    return jsc.parallelize(partitions, Math.min(partitions.size(), sparkPartitions))
-        .flatMap(partitionPath -> {
-          HoodieActiveTimeline activeTimeline = this.getActiveTimeline().reload();
-          List<RollbackRequest> partitionRollbackRequests = new ArrayList<>();
-          switch (instantToRollback.getAction()) {
-            case HoodieTimeline.COMMIT_ACTION:
-              logger.info("Rolling back commit action. There are higher delta commits. So only rolling back this "
-                  + "instant");
-              partitionRollbackRequests.add(RollbackRequest.createRollbackRequestWithDeleteDataAndLogFilesAction(
-                  partitionPath, instantToRollback));
-              break;
-            case HoodieTimeline.COMPACTION_ACTION:
-              // If there is no delta commit present after the current commit (if compaction), no action, else we
-              // need to make sure that a compaction commit rollback also deletes any log files written as part of the
-              // succeeding deltacommit.
-              boolean higherDeltaCommits = !activeTimeline.getDeltaCommitTimeline()
-                  .filterCompletedInstants().findInstantsAfter(commit, 1).empty();
-              if (higherDeltaCommits) {
-                // Rollback of a compaction action with no higher deltacommit means that the compaction is scheduled
-                // and has not yet finished. In this scenario we should delete only the newly created parquet files
-                // and not corresponding base commit log files created with this as baseCommit since updates would
-                // have been written to the log files.
-                logger.info("Rolling back compaction. There are higher delta commits. So only deleting data files");
-                partitionRollbackRequests.add(RollbackRequest.createRollbackRequestWithDeleteDataFilesOnlyAction(
-                    partitionPath, instantToRollback));
-              } else {
-                // No deltacommits present after this compaction commit (inflight or requested). In this case, we
-                // can also delete any log files that were created with this compaction commit as base
-                // commit.
-                logger.info("Rolling back compaction plan. There are NO higher delta commits. So deleting both data and"
-                    + " log files");
-                partitionRollbackRequests.add(
-                    RollbackRequest.createRollbackRequestWithDeleteDataAndLogFilesAction(partitionPath,
-                        instantToRollback));
-              }
-              break;
-            case HoodieTimeline.DELTA_COMMIT_ACTION:
-              // --------------------------------------------------------------------------------------------------
-              // (A) The following cases are possible if index.canIndexLogFiles and/or index.isGlobal
-              // --------------------------------------------------------------------------------------------------
-              // (A.1) Failed first commit - Inserts were written to log files and HoodieWriteStat has no entries. In
-              // this scenario we would want to delete these log files.
-              // (A.2) Failed recurring commit - Inserts/Updates written to log files. In this scenario,
-              // HoodieWriteStat will have the baseCommitTime for the first log file written, add rollback blocks.
-              // (A.3) Rollback triggered for first commit - Inserts were written to the log files but the commit is
-              // being reverted. In this scenario, HoodieWriteStat will be `null` for the attribute prevCommitTime and
-              // and hence will end up deleting these log files. This is done so there are no orphan log files
-              // lying around.
-              // (A.4) Rollback triggered for recurring commits - Inserts/Updates are being rolled back, the actions
-              // taken in this scenario is a combination of (A.2) and (A.3)
-              // ---------------------------------------------------------------------------------------------------
-              // (B) The following cases are possible if !index.canIndexLogFiles and/or !index.isGlobal
-              // ---------------------------------------------------------------------------------------------------
-              // (B.1) Failed first commit - Inserts were written to parquet files and HoodieWriteStat has no entries.
-              // In this scenario, we delete all the parquet files written for the failed commit.
-              // (B.2) Failed recurring commits - Inserts were written to parquet files and updates to log files. In
-              // this scenario, perform (A.1) and for updates written to log files, write rollback blocks.
-              // (B.3) Rollback triggered for first commit - Same as (B.1)
-              // (B.4) Rollback triggered for recurring commits - Same as (B.2) plus we need to delete the log files
-              // as well if the base parquet file gets deleted.
-              try {
-                HoodieCommitMetadata commitMetadata = HoodieCommitMetadata.fromBytes(
-                    metaClient.getCommitTimeline().getInstantDetails(
-                        new HoodieInstant(true, instantToRollback.getAction(), instantToRollback.getTimestamp()))
-                        .get(), HoodieCommitMetadata.class);
-
-                // In case all data was inserts and the commit failed, delete the file belonging to that commit
-                // We do not know fileIds for inserts (first inserts are either log files or parquet files),
-                // delete all files for the corresponding failed commit, if present (same as COW)
-                partitionRollbackRequests.add(RollbackRequest.createRollbackRequestWithDeleteDataAndLogFilesAction(
-                    partitionPath, instantToRollback));
-
-                // append rollback blocks for updates
-                if (commitMetadata.getPartitionToWriteStats().containsKey(partitionPath)) {
-                  partitionRollbackRequests
-                      .addAll(generateAppendRollbackBlocksAction(partitionPath, instantToRollback, commitMetadata));
-                }
-                break;
-              } catch (IOException io) {
-                throw new UncheckedIOException("Failed to collect rollback actions for commit " + commit, io);
-              }
-            default:
-              break;
+    return jsc.parallelize(partitions, Math.min(partitions.size(), sparkPartitions)).flatMap(partitionPath -> {
+      HoodieActiveTimeline activeTimeline = this.getActiveTimeline().reload();
+      List<RollbackRequest> partitionRollbackRequests = new ArrayList<>();
+      switch (instantToRollback.getAction()) {
+        case HoodieTimeline.COMMIT_ACTION:
+          logger.info(
+              "Rolling back commit action. There are higher delta commits. So only rolling back this " + "instant");
+          partitionRollbackRequests.add(
+              RollbackRequest.createRollbackRequestWithDeleteDataAndLogFilesAction(partitionPath, instantToRollback));
+          break;
+        case HoodieTimeline.COMPACTION_ACTION:
+          // If there is no delta commit present after the current commit (if compaction), no action, else we
+          // need to make sure that a compaction commit rollback also deletes any log files written as part of the
+          // succeeding deltacommit.
+          boolean higherDeltaCommits =
+              !activeTimeline.getDeltaCommitTimeline().filterCompletedInstants().findInstantsAfter(commit, 1).empty();
+          if (higherDeltaCommits) {
+            // Rollback of a compaction action with no higher deltacommit means that the compaction is scheduled
+            // and has not yet finished. In this scenario we should delete only the newly created parquet files
+            // and not corresponding base commit log files created with this as baseCommit since updates would
+            // have been written to the log files.
+            logger.info("Rolling back compaction. There are higher delta commits. So only deleting data files");
+            partitionRollbackRequests.add(
+                RollbackRequest.createRollbackRequestWithDeleteDataFilesOnlyAction(partitionPath, instantToRollback));
+          } else {
+            // No deltacommits present after this compaction commit (inflight or requested). In this case, we
+            // can also delete any log files that were created with this compaction commit as base
+            // commit.
+            logger.info("Rolling back compaction plan. There are NO higher delta commits. So deleting both data and"
+                + " log files");
+            partitionRollbackRequests.add(
+                RollbackRequest.createRollbackRequestWithDeleteDataAndLogFilesAction(partitionPath, instantToRollback));
           }
-          return partitionRollbackRequests.iterator();
-        }).filter(Objects::nonNull).collect();
+          break;
+        case HoodieTimeline.DELTA_COMMIT_ACTION:
+          // --------------------------------------------------------------------------------------------------
+          // (A) The following cases are possible if index.canIndexLogFiles and/or index.isGlobal
+          // --------------------------------------------------------------------------------------------------
+          // (A.1) Failed first commit - Inserts were written to log files and HoodieWriteStat has no entries. In
+          // this scenario we would want to delete these log files.
+          // (A.2) Failed recurring commit - Inserts/Updates written to log files. In this scenario,
+          // HoodieWriteStat will have the baseCommitTime for the first log file written, add rollback blocks.
+          // (A.3) Rollback triggered for first commit - Inserts were written to the log files but the commit is
+          // being reverted. In this scenario, HoodieWriteStat will be `null` for the attribute prevCommitTime and
+          // and hence will end up deleting these log files. This is done so there are no orphan log files
+          // lying around.
+          // (A.4) Rollback triggered for recurring commits - Inserts/Updates are being rolled back, the actions
+          // taken in this scenario is a combination of (A.2) and (A.3)
+          // ---------------------------------------------------------------------------------------------------
+          // (B) The following cases are possible if !index.canIndexLogFiles and/or !index.isGlobal
+          // ---------------------------------------------------------------------------------------------------
+          // (B.1) Failed first commit - Inserts were written to parquet files and HoodieWriteStat has no entries.
+          // In this scenario, we delete all the parquet files written for the failed commit.
+          // (B.2) Failed recurring commits - Inserts were written to parquet files and updates to log files. In
+          // this scenario, perform (A.1) and for updates written to log files, write rollback blocks.
+          // (B.3) Rollback triggered for first commit - Same as (B.1)
+          // (B.4) Rollback triggered for recurring commits - Same as (B.2) plus we need to delete the log files
+          // as well if the base parquet file gets deleted.
+          try {
+            HoodieCommitMetadata commitMetadata = HoodieCommitMetadata.fromBytes(
+                metaClient.getCommitTimeline()
+                    .getInstantDetails(
+                        new HoodieInstant(true, instantToRollback.getAction(), instantToRollback.getTimestamp()))
+                    .get(),
+                HoodieCommitMetadata.class);
+
+            // In case all data was inserts and the commit failed, delete the file belonging to that commit
+            // We do not know fileIds for inserts (first inserts are either log files or parquet files),
+            // delete all files for the corresponding failed commit, if present (same as COW)
+            partitionRollbackRequests.add(
+                RollbackRequest.createRollbackRequestWithDeleteDataAndLogFilesAction(partitionPath, instantToRollback));
+
+            // append rollback blocks for updates
+            if (commitMetadata.getPartitionToWriteStats().containsKey(partitionPath)) {
+              partitionRollbackRequests
+                  .addAll(generateAppendRollbackBlocksAction(partitionPath, instantToRollback, commitMetadata));
+            }
+            break;
+          } catch (IOException io) {
+            throw new UncheckedIOException("Failed to collect rollback actions for commit " + commit, io);
+          }
+        default:
+          break;
+      }
+      return partitionRollbackRequests.iterator();
+    }).filter(Objects::nonNull).collect();
   }
 
   @Override
@@ -428,27 +429,27 @@ public class HoodieMergeOnReadTable<T extends HoodieRecordPayload> extends Hoodi
     // baseCommit always by listing the file slice
     Map<String, String> fileIdToBaseCommitTimeForLogMap = this.getRTFileSystemView().getLatestFileSlices(partitionPath)
         .collect(Collectors.toMap(FileSlice::getFileId, FileSlice::getBaseInstantTime));
-    return commitMetadata.getPartitionToWriteStats().get(partitionPath).stream()
-        .filter(wStat -> {
+    return commitMetadata.getPartitionToWriteStats().get(partitionPath).stream().filter(wStat -> {
 
-          // Filter out stats without prevCommit since they are all inserts
-          boolean validForRollback = (wStat != null) && (wStat.getPrevCommit() != HoodieWriteStat.NULL_COMMIT)
-              && (wStat.getPrevCommit() != null) && fileIdToBaseCommitTimeForLogMap.containsKey(wStat.getFileId());
+      // Filter out stats without prevCommit since they are all inserts
+      boolean validForRollback = (wStat != null) && (wStat.getPrevCommit() != HoodieWriteStat.NULL_COMMIT)
+          && (wStat.getPrevCommit() != null) && fileIdToBaseCommitTimeForLogMap.containsKey(wStat.getFileId());
 
-          if (validForRollback) {
-            // For sanity, log instant time can never be less than base-commit on which we are rolling back
-            Preconditions.checkArgument(HoodieTimeline.compareTimestamps(fileIdToBaseCommitTimeForLogMap.get(
-                wStat.getFileId()), rollbackInstant.getTimestamp(), HoodieTimeline.LESSER_OR_EQUAL));
-          }
+      if (validForRollback) {
+        // For sanity, log instant time can never be less than base-commit on which we are rolling back
+        Preconditions
+            .checkArgument(HoodieTimeline.compareTimestamps(fileIdToBaseCommitTimeForLogMap.get(wStat.getFileId()),
+                rollbackInstant.getTimestamp(), HoodieTimeline.LESSER_OR_EQUAL));
+      }
 
-          return validForRollback  && HoodieTimeline.compareTimestamps(fileIdToBaseCommitTimeForLogMap.get(
-              // Base Ts should be strictly less. If equal (for inserts-to-logs), the caller employs another option
-              // to delete and we should not step on it
-              wStat.getFileId()), rollbackInstant.getTimestamp(), HoodieTimeline.LESSER);
-        }).map(wStat -> {
-          String baseCommitTime = fileIdToBaseCommitTimeForLogMap.get(wStat.getFileId());
-          return RollbackRequest.createRollbackRequestWithAppendRollbackBlockAction(partitionPath, wStat.getFileId(),
-              baseCommitTime, rollbackInstant);
-        }).collect(Collectors.toList());
+      return validForRollback && HoodieTimeline.compareTimestamps(fileIdToBaseCommitTimeForLogMap.get(
+          // Base Ts should be strictly less. If equal (for inserts-to-logs), the caller employs another option
+          // to delete and we should not step on it
+          wStat.getFileId()), rollbackInstant.getTimestamp(), HoodieTimeline.LESSER);
+    }).map(wStat -> {
+      String baseCommitTime = fileIdToBaseCommitTimeForLogMap.get(wStat.getFileId());
+      return RollbackRequest.createRollbackRequestWithAppendRollbackBlockAction(partitionPath, wStat.getFileId(),
+          baseCommitTime, rollbackInstant);
+    }).collect(Collectors.toList());
   }
 }

--- a/hudi-client/src/main/java/org/apache/hudi/table/RollbackExecutor.java
+++ b/hudi-client/src/main/java/org/apache/hudi/table/RollbackExecutor.java
@@ -65,8 +65,8 @@ public class RollbackExecutor implements Serializable {
   /**
    * Performs all rollback actions that we have collected in parallel.
    */
-  public List<HoodieRollbackStat> performRollback(JavaSparkContext jsc,
-      HoodieInstant instantToRollback, List<RollbackRequest> rollbackRequests) {
+  public List<HoodieRollbackStat> performRollback(JavaSparkContext jsc, HoodieInstant instantToRollback,
+      List<RollbackRequest> rollbackRequests) {
 
     SerializablePathFilter filter = (path) -> {
       if (path.toString().contains(".parquet")) {
@@ -101,11 +101,10 @@ public class RollbackExecutor implements Serializable {
           Writer writer = null;
           boolean success = false;
           try {
-            writer = HoodieLogFormat.newWriterBuilder().onParentPath(
-                FSUtils.getPartitionPath(metaClient.getBasePath(), rollbackRequest.getPartitionPath()))
+            writer = HoodieLogFormat.newWriterBuilder()
+                .onParentPath(FSUtils.getPartitionPath(metaClient.getBasePath(), rollbackRequest.getPartitionPath()))
                 .withFileId(rollbackRequest.getFileId().get())
-                .overBaseCommit(rollbackRequest.getLatestBaseInstant().get())
-                .withFs(metaClient.getFs())
+                .overBaseCommit(rollbackRequest.getLatestBaseInstant().get()).withFs(metaClient.getFs())
                 .withFileExtension(HoodieLogFile.DELTA_EXTENSION).build();
 
             // generate metadata
@@ -114,8 +113,7 @@ public class RollbackExecutor implements Serializable {
             writer = writer.appendBlock(new HoodieCommandBlock(header));
             success = true;
           } catch (IOException | InterruptedException io) {
-            throw new HoodieRollbackException(
-                "Failed to rollback for instant " + instantToRollback, io);
+            throw new HoodieRollbackException("Failed to rollback for instant " + instantToRollback, io);
           } finally {
             try {
               if (writer != null) {
@@ -130,8 +128,7 @@ public class RollbackExecutor implements Serializable {
           // getFileStatus would reflect correct stats and FileNotFoundException is not thrown in
           // cloud-storage : HUDI-168
           Map<FileStatus, Long> filesToNumBlocksRollback = new HashMap<>();
-          filesToNumBlocksRollback.put(metaClient.getFs()
-              .getFileStatus(writer.getLogFile().getPath()), 1L);
+          filesToNumBlocksRollback.put(metaClient.getFs().getFileStatus(writer.getLogFile().getPath()), 1L);
           return new Tuple2<String, HoodieRollbackStat>(rollbackRequest.getPartitionPath(),
               HoodieRollbackStat.newBuilder().withPartitionPath(rollbackRequest.getPartitionPath())
                   .withRollbackBlockAppendResults(filesToNumBlocksRollback).build());
@@ -180,8 +177,7 @@ public class RollbackExecutor implements Serializable {
    * Common method used for cleaning out parquet files under a partition path during rollback of a set of commits
    */
   private Map<FileStatus, Boolean> deleteCleanedFiles(HoodieTableMetaClient metaClient, HoodieWriteConfig config,
-      Map<FileStatus, Boolean> results, String partitionPath,
-      PathFilter filter) throws IOException {
+      Map<FileStatus, Boolean> results, String partitionPath, PathFilter filter) throws IOException {
     logger.info("Cleaning path " + partitionPath);
     FileSystem fs = metaClient.getFs();
     FileStatus[] toBeDeleted = fs.listStatus(FSUtils.getPartitionPath(config.getBasePath(), partitionPath), filter);

--- a/hudi-client/src/main/java/org/apache/hudi/table/RollbackRequest.java
+++ b/hudi-client/src/main/java/org/apache/hudi/table/RollbackRequest.java
@@ -30,9 +30,7 @@ public class RollbackRequest {
    * Rollback Action Types
    */
   public enum RollbackAction {
-    DELETE_DATA_FILES_ONLY,
-    DELETE_DATA_AND_LOG_FILES,
-    APPEND_ROLLBACK_BLOCK
+    DELETE_DATA_FILES_ONLY, DELETE_DATA_AND_LOG_FILES, APPEND_ROLLBACK_BLOCK
   }
 
   /**
@@ -60,8 +58,8 @@ public class RollbackRequest {
    */
   private final RollbackAction rollbackAction;
 
-  public RollbackRequest(String partitionPath, HoodieInstant rollbackInstant,
-      Option<String> fileId, Option<String> latestBaseInstant, RollbackAction rollbackAction) {
+  public RollbackRequest(String partitionPath, HoodieInstant rollbackInstant, Option<String> fileId,
+      Option<String> latestBaseInstant, RollbackAction rollbackAction) {
     this.partitionPath = partitionPath;
     this.rollbackInstant = rollbackInstant;
     this.fileId = fileId;

--- a/hudi-client/src/test/java/org/apache/hudi/HoodieClientTestHarness.java
+++ b/hudi-client/src/test/java/org/apache/hudi/HoodieClientTestHarness.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocalFileSystem;
@@ -52,6 +53,11 @@ public abstract class HoodieClientTestHarness extends HoodieCommonTestHarness im
   protected transient HoodieTestDataGenerator dataGen = null;
   protected transient ExecutorService executorService;
   protected transient HoodieTableMetaClient metaClient;
+  private static AtomicInteger instantGen = new AtomicInteger(1);
+
+  public String getNextInstant() {
+    return String.format("%09d", instantGen.getAndIncrement());
+  }
 
   // dfs
   protected String dfsBasePath;

--- a/hudi-client/src/test/java/org/apache/hudi/TestHoodieClientBase.java
+++ b/hudi-client/src/test/java/org/apache/hudi/TestHoodieClientBase.java
@@ -52,6 +52,7 @@ import org.apache.hudi.config.HoodieStorageConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.index.HoodieIndex;
 import org.apache.hudi.index.HoodieIndex.IndexType;
+import org.apache.hudi.metrics.HoodieMetrics;
 import org.apache.hudi.table.HoodieTable;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
@@ -75,6 +76,10 @@ public class TestHoodieClientBase extends HoodieClientTestHarness {
   @After
   public void tearDown() throws Exception {
     cleanupResources();
+  }
+
+  protected HoodieCleanClient getHoodieCleanClient(HoodieWriteConfig cfg) {
+    return new HoodieCleanClient(jsc, cfg, new HoodieMetrics(cfg, cfg.getTableName()));
   }
 
   protected HoodieWriteClient getHoodieWriteClient(HoodieWriteConfig cfg) {

--- a/hudi-common/src/main/avro/HoodieCleanerPlan.avsc
+++ b/hudi-common/src/main/avro/HoodieCleanerPlan.avsc
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+{
+  "namespace": "org.apache.hudi.avro.model",
+  "type": "record",
+  "name": "HoodieCleanerPlan",
+  "fields": [
+    {
+      "name": "earliestInstantToRetain",
+      "type":["null", {
+        "type": "record",
+        "name": "HoodieActionInstant",
+        "fields": [
+          {
+            "name": "timestamp",
+            "type": "string"
+          },
+          {
+            "name": "action",
+            "type": "string"
+          },
+          {
+            "name": "state",
+            "type": "string"
+          }
+        ]
+      }],
+      "default" : null
+    },
+    {
+      "name": "policy",
+      "type": "string"
+    },
+    {
+      "name": "filesToBeDeletedPerPartition",
+      "type": [
+        "null", {
+        "type":"map",
+        "values": {
+          "type":"array",
+          "items":{
+            "name":"filePath",
+            "type": "string"
+          }
+      }}],
+      "default" : null
+    },
+    {
+      "name":"version",
+      "type":["int", "null"],
+      "default": 1
+    }
+  ]
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/CompactionOperation.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/CompactionOperation.java
@@ -134,14 +134,9 @@ public class CompactionOperation implements Serializable {
 
   @Override
   public String toString() {
-    return "CompactionOperation{"
-        + "baseInstantTime='" + baseInstantTime + '\''
-        + ", dataFileCommitTime=" + dataFileCommitTime
-        + ", deltaFileNames=" + deltaFileNames
-        + ", dataFileName=" + dataFileName
-        + ", id='" + id + '\''
-        + ", metrics=" + metrics
-        + '}';
+    return "CompactionOperation{" + "baseInstantTime='" + baseInstantTime + '\'' + ", dataFileCommitTime="
+        + dataFileCommitTime + ", deltaFileNames=" + deltaFileNames + ", dataFileName=" + dataFileName + ", id='" + id
+        + '\'' + ", metrics=" + metrics + '}';
   }
 
   @Override
@@ -156,8 +151,7 @@ public class CompactionOperation implements Serializable {
     return Objects.equals(baseInstantTime, operation.baseInstantTime)
         && Objects.equals(dataFileCommitTime, operation.dataFileCommitTime)
         && Objects.equals(deltaFileNames, operation.deltaFileNames)
-        && Objects.equals(dataFileName, operation.dataFileName)
-        && Objects.equals(id, operation.id);
+        && Objects.equals(dataFileName, operation.dataFileName) && Objects.equals(id, operation.id);
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTimeline.java
@@ -63,6 +63,7 @@ public interface HoodieTimeline extends Serializable {
   String INFLIGHT_COMMIT_EXTENSION = INFLIGHT_EXTENSION;
   String INFLIGHT_DELTA_COMMIT_EXTENSION = "." + DELTA_COMMIT_ACTION + INFLIGHT_EXTENSION;
   String INFLIGHT_CLEAN_EXTENSION = "." + CLEAN_ACTION + INFLIGHT_EXTENSION;
+  String REQUESTED_CLEAN_EXTENSION = "." + CLEAN_ACTION + REQUESTED_EXTENSION;
   String INFLIGHT_ROLLBACK_EXTENSION = "." + ROLLBACK_ACTION + INFLIGHT_EXTENSION;
   String INFLIGHT_SAVEPOINT_EXTENSION = "." + SAVEPOINT_ACTION + INFLIGHT_EXTENSION;
   String REQUESTED_COMPACTION_SUFFIX = StringUtils.join(COMPACTION_ACTION, REQUESTED_EXTENSION);
@@ -79,6 +80,13 @@ public interface HoodieTimeline extends Serializable {
    * @return New instance of HoodieTimeline with just in-flights
    */
   HoodieTimeline filterInflights();
+
+  /**
+   * Filter this timeline to include requested and in-flights
+   *
+   * @return New instance of HoodieTimeline with just in-flights and requested instants
+   */
+  HoodieTimeline filterInflightsAndRequested();
 
   /**
    * Filter this timeline to just include the in-flights excluding compaction instants
@@ -219,7 +227,19 @@ public interface HoodieTimeline extends Serializable {
   }
 
   static HoodieInstant getCompletedInstant(final HoodieInstant instant) {
-    return new HoodieInstant(false, instant.getAction(), instant.getTimestamp());
+    return new HoodieInstant(State.COMPLETED, instant.getAction(), instant.getTimestamp());
+  }
+
+  static HoodieInstant getRequestedInstant(final HoodieInstant instant) {
+    return new HoodieInstant(State.REQUESTED, instant.getAction(), instant.getTimestamp());
+  }
+
+  static HoodieInstant getCleanRequestedInstant(final String timestamp) {
+    return new HoodieInstant(State.REQUESTED, CLEAN_ACTION, timestamp);
+  }
+
+  static HoodieInstant getCleanInflightInstant(final String timestamp) {
+    return new HoodieInstant(State.INFLIGHT, CLEAN_ACTION, timestamp);
   }
 
   static HoodieInstant getCompactionRequestedInstant(final String timestamp) {
@@ -244,6 +264,10 @@ public interface HoodieTimeline extends Serializable {
 
   static String makeCleanerFileName(String instant) {
     return StringUtils.join(instant, HoodieTimeline.CLEAN_EXTENSION);
+  }
+
+  static String makeRequestedCleanerFileName(String instant) {
+    return StringUtils.join(instant, HoodieTimeline.REQUESTED_CLEAN_EXTENSION);
   }
 
   static String makeInflightCleanerFileName(String instant) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieDefaultTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieDefaultTimeline.java
@@ -30,6 +30,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.hudi.common.table.HoodieTimeline;
+import org.apache.hudi.common.table.timeline.HoodieInstant.State;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.exception.HoodieException;
@@ -81,6 +82,13 @@ public class HoodieDefaultTimeline implements HoodieTimeline {
   @Override
   public HoodieTimeline filterInflights() {
     return new HoodieDefaultTimeline(instants.stream().filter(HoodieInstant::isInflight), details);
+  }
+
+  @Override
+  public HoodieTimeline filterInflightsAndRequested() {
+    return new HoodieDefaultTimeline(
+        instants.stream().filter(i -> i.getState().equals(State.REQUESTED) || i.getState().equals(State.INFLIGHT)),
+        details);
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieInstant.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieInstant.java
@@ -69,7 +69,7 @@ public class HoodieInstant implements Serializable {
     } else if (action.contains(HoodieTimeline.INFLIGHT_EXTENSION)) {
       state = State.INFLIGHT;
       action = action.replace(HoodieTimeline.INFLIGHT_EXTENSION, "");
-    } else if (action.equals(HoodieTimeline.REQUESTED_COMPACTION_SUFFIX)) {
+    } else if (action.contains(HoodieTimeline.REQUESTED_EXTENSION)) {
       state = State.REQUESTED;
       action = action.replace(HoodieTimeline.REQUESTED_EXTENSION, "");
     }
@@ -117,7 +117,8 @@ public class HoodieInstant implements Serializable {
           : HoodieTimeline.makeCommitFileName(timestamp);
     } else if (HoodieTimeline.CLEAN_ACTION.equals(action)) {
       return isInflight() ? HoodieTimeline.makeInflightCleanerFileName(timestamp)
-          : HoodieTimeline.makeCleanerFileName(timestamp);
+          : isRequested() ? HoodieTimeline.makeRequestedCleanerFileName(timestamp)
+              : HoodieTimeline.makeCleanerFileName(timestamp);
     } else if (HoodieTimeline.ROLLBACK_ACTION.equals(action)) {
       return isInflight() ? HoodieTimeline.makeInflightRollbackFileName(timestamp)
           : HoodieTimeline.makeRollbackFileName(timestamp);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/RocksDbBasedFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/RocksDbBasedFileSystemView.java
@@ -333,8 +333,10 @@ public class RocksDbBasedFileSystemView extends IncrementalTimelineSyncFileSyste
 
   @Override
   public void close() {
+    log.info("Closing Rocksdb !!");
     closed = true;
     rocksDB.close();
+    log.info("Closed Rocksdb !!");
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/AvroUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/AvroUtils.java
@@ -36,6 +36,7 @@ import org.apache.avro.specific.SpecificDatumWriter;
 import org.apache.avro.specific.SpecificRecordBase;
 import org.apache.hudi.avro.model.HoodieCleanMetadata;
 import org.apache.hudi.avro.model.HoodieCleanPartitionMetadata;
+import org.apache.hudi.avro.model.HoodieCleanerPlan;
 import org.apache.hudi.avro.model.HoodieCompactionPlan;
 import org.apache.hudi.avro.model.HoodieRestoreMetadata;
 import org.apache.hudi.avro.model.HoodieRollbackMetadata;
@@ -110,6 +111,11 @@ public class AvroUtils {
     return serializeAvroMetadata(compactionWorkload, HoodieCompactionPlan.class);
   }
 
+
+  public static Option<byte[]> serializeCleanerPlan(HoodieCleanerPlan cleanPlan) throws IOException {
+    return serializeAvroMetadata(cleanPlan, HoodieCleanerPlan.class);
+  }
+
   public static Option<byte[]> serializeCleanMetadata(HoodieCleanMetadata metadata) throws IOException {
     return serializeAvroMetadata(metadata, HoodieCleanMetadata.class);
   }
@@ -135,6 +141,10 @@ public class AvroUtils {
     fileWriter.append(metadata);
     fileWriter.flush();
     return Option.of(baos.toByteArray());
+  }
+
+  public static HoodieCleanerPlan deserializeCleanerPlan(byte[] bytes) throws IOException {
+    return deserializeAvroMetadata(bytes, HoodieCleanerPlan.class);
   }
 
   public static HoodieCompactionPlan deserializeCompactionPlan(byte[] bytes) throws IOException {

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ParquetUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ParquetUtils.java
@@ -141,10 +141,9 @@ public class ParquetUtils {
    * Read out the bloom filter from the parquet file meta data.
    */
   public static BloomFilter readBloomFilterFromParquetMetadata(Configuration configuration, Path parquetFilePath) {
-    Map<String, String> footerVals =
-        readParquetFooter(configuration, false, parquetFilePath,
-            HoodieAvroWriteSupport.HOODIE_AVRO_BLOOM_FILTER_METADATA_KEY,
-            HoodieAvroWriteSupport.OLD_HOODIE_AVRO_BLOOM_FILTER_METADATA_KEY);
+    Map<String, String> footerVals = readParquetFooter(configuration, false, parquetFilePath,
+        HoodieAvroWriteSupport.HOODIE_AVRO_BLOOM_FILTER_METADATA_KEY,
+        HoodieAvroWriteSupport.OLD_HOODIE_AVRO_BLOOM_FILTER_METADATA_KEY);
     String footerVal = footerVals.get(HoodieAvroWriteSupport.HOODIE_AVRO_BLOOM_FILTER_METADATA_KEY);
     if (null == footerVal) {
       // We use old style key "com.uber.hoodie.bloomfilter"

--- a/hudi-common/src/main/java/org/apache/hudi/common/versioning/MetadataMigrator.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/versioning/MetadataMigrator.java
@@ -27,6 +27,7 @@ import org.apache.hudi.common.util.collection.Pair;
 
 /**
  * Migrates a specific metadata type stored in .hoodie folder to latest version
+ * 
  * @param <T>
  */
 public class MetadataMigrator<T> {
@@ -36,15 +37,16 @@ public class MetadataMigrator<T> {
   private final Integer oldestVersion;
 
   public MetadataMigrator(HoodieTableMetaClient metaClient, List<VersionMigrator<T>> migratorList) {
-    migrators = migratorList.stream().map(m ->
-        Pair.of(m.getManagedVersion(), m)).collect(Collectors.toMap(Pair::getKey, Pair::getValue));
+    migrators = migratorList.stream().map(m -> Pair.of(m.getManagedVersion(), m))
+        .collect(Collectors.toMap(Pair::getKey, Pair::getValue));
     latestVersion = migrators.keySet().stream().reduce((x, y) -> x > y ? x : y).get();
     oldestVersion = migrators.keySet().stream().reduce((x, y) -> x < y ? x : y).get();
   }
 
   /**
    * Upgrade Metadata version to its latest
-   * @param metadata  Metadata
+   * 
+   * @param metadata Metadata
    * @param metadataVersion Current version of metadata
    * @return Metadata conforming to the latest version of this metadata
    */
@@ -64,9 +66,10 @@ public class MetadataMigrator<T> {
 
   /**
    * Migrate metadata to a specific version
-   * @param metadata         Hoodie Table Meta Client
-   * @param metadataVersion   Metadata Version
-   * @param targetVersion     Target Version
+   * 
+   * @param metadata Hoodie Table Meta Client
+   * @param metadataVersion Metadata Version
+   * @param targetVersion Target Version
    * @return Metadata conforming to the target version
    */
   public T migrateToVersion(T metadata, int metadataVersion, int targetVersion) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/versioning/VersionMigrator.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/versioning/VersionMigrator.java
@@ -22,18 +22,21 @@ import java.io.Serializable;
 
 /**
  * Responsible for upgrading and downgrading metadata versions for a specific metadata
+ * 
  * @param <T> Metadata Type
  */
 public interface VersionMigrator<T> extends Serializable {
 
   /**
    * Version of Metadata that this class will handle
+   * 
    * @return
    */
   Integer getManagedVersion();
 
   /**
    * Upgrades metadata of type T from previous version to this version
+   * 
    * @param input Metadata as of previous version.
    * @return Metadata compatible with the version managed by this class
    */
@@ -41,6 +44,7 @@ public interface VersionMigrator<T> extends Serializable {
 
   /**
    * Downgrades metadata of type T from next version to this version
+   * 
    * @param input Metadata as of next highest version
    * @return Metadata compatible with the version managed by this class
    */

--- a/hudi-common/src/main/java/org/apache/hudi/common/versioning/compaction/CompactionPlanMigrator.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/versioning/compaction/CompactionPlanMigrator.java
@@ -29,8 +29,7 @@ import org.apache.hudi.common.versioning.MetadataMigrator;
 public class CompactionPlanMigrator extends MetadataMigrator<HoodieCompactionPlan> {
 
   public CompactionPlanMigrator(HoodieTableMetaClient metaClient) {
-    super(metaClient, Arrays.asList(
-        new CompactionV1MigrationHandler(metaClient),
-        new CompactionV2MigrationHandler(metaClient)));
+    super(metaClient,
+        Arrays.asList(new CompactionV1MigrationHandler(metaClient), new CompactionV2MigrationHandler(metaClient)));
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/versioning/compaction/CompactionV1MigrationHandler.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/versioning/compaction/CompactionV1MigrationHandler.java
@@ -52,21 +52,17 @@ public class CompactionV1MigrationHandler extends AbstractMigratorBase<HoodieCom
 
   @Override
   public HoodieCompactionPlan downgradeFrom(HoodieCompactionPlan input) {
-    Preconditions.checkArgument(input.getVersion() == 2, "Input version is "
-        + input.getVersion() + ". Must be 2");
+    Preconditions.checkArgument(input.getVersion() == 2, "Input version is " + input.getVersion() + ". Must be 2");
     HoodieCompactionPlan compactionPlan = new HoodieCompactionPlan();
     final Path basePath = new Path(metaClient.getBasePath());
     List<HoodieCompactionOperation> v1CompactionOperationList = new ArrayList<>();
     if (null != input.getOperations()) {
       v1CompactionOperationList = input.getOperations().stream().map(inp -> {
-        return HoodieCompactionOperation.newBuilder()
-            .setBaseInstantTime(inp.getBaseInstantTime())
-            .setFileId(inp.getFileId())
-            .setPartitionPath(inp.getPartitionPath())
-            .setMetrics(inp.getMetrics())
+        return HoodieCompactionOperation.newBuilder().setBaseInstantTime(inp.getBaseInstantTime())
+            .setFileId(inp.getFileId()).setPartitionPath(inp.getPartitionPath()).setMetrics(inp.getMetrics())
             .setDataFilePath(convertToV1Path(basePath, inp.getPartitionPath(), inp.getDataFilePath()))
-            .setDeltaFilePaths(inp.getDeltaFilePaths().stream().map(s -> convertToV1Path(basePath,
-                inp.getPartitionPath(), s)).collect(Collectors.toList()))
+            .setDeltaFilePaths(inp.getDeltaFilePaths().stream()
+                .map(s -> convertToV1Path(basePath, inp.getPartitionPath(), s)).collect(Collectors.toList()))
             .build();
       }).collect(Collectors.toList());
     }

--- a/hudi-common/src/main/java/org/apache/hudi/common/versioning/compaction/CompactionV2MigrationHandler.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/versioning/compaction/CompactionV2MigrationHandler.java
@@ -46,20 +46,15 @@ public class CompactionV2MigrationHandler extends AbstractMigratorBase<HoodieCom
 
   @Override
   public HoodieCompactionPlan upgradeFrom(HoodieCompactionPlan input) {
-    Preconditions.checkArgument(input.getVersion() == 1, "Input version is "
-        + input.getVersion() + ". Must be 1");
+    Preconditions.checkArgument(input.getVersion() == 1, "Input version is " + input.getVersion() + ". Must be 1");
     HoodieCompactionPlan compactionPlan = new HoodieCompactionPlan();
     List<HoodieCompactionOperation> v2CompactionOperationList = new ArrayList<>();
     if (null != input.getOperations()) {
       v2CompactionOperationList = input.getOperations().stream().map(inp -> {
-        return HoodieCompactionOperation.newBuilder()
-            .setBaseInstantTime(inp.getBaseInstantTime())
-            .setFileId(inp.getFileId())
-            .setPartitionPath(inp.getPartitionPath())
-            .setMetrics(inp.getMetrics())
-            .setDataFilePath(new Path(inp.getDataFilePath()).getName())
-            .setDeltaFilePaths(inp.getDeltaFilePaths().stream().map(s -> new Path(s).getName())
-                .collect(Collectors.toList()))
+        return HoodieCompactionOperation.newBuilder().setBaseInstantTime(inp.getBaseInstantTime())
+            .setFileId(inp.getFileId()).setPartitionPath(inp.getPartitionPath()).setMetrics(inp.getMetrics())
+            .setDataFilePath(new Path(inp.getDataFilePath()).getName()).setDeltaFilePaths(
+                inp.getDeltaFilePaths().stream().map(s -> new Path(s).getName()).collect(Collectors.toList()))
             .build();
       }).collect(Collectors.toList());
     }

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestCompactionUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestCompactionUtils.java
@@ -114,8 +114,7 @@ public class TestCompactionUtils extends HoodieCommonTestHarness {
     fileSlice.addLogFile(
         new HoodieLogFile(new Path(FSUtils.makeLogFileName("noData1", ".log", "000", 2, TEST_WRITE_TOKEN))));
     op = CompactionUtils.buildFromFileSlice(DEFAULT_PARTITION_PATHS[0], fileSlice, Option.of(metricsCaptureFn));
-    testFileSliceCompactionOpEquality(fileSlice, op, DEFAULT_PARTITION_PATHS[0],
-        LATEST_COMPACTION_METADATA_VERSION);
+    testFileSliceCompactionOpEquality(fileSlice, op, DEFAULT_PARTITION_PATHS[0], LATEST_COMPACTION_METADATA_VERSION);
   }
 
   /**
@@ -126,17 +125,17 @@ public class TestCompactionUtils extends HoodieCommonTestHarness {
     FileSlice emptyFileSlice = new FileSlice(DEFAULT_PARTITION_PATHS[0], "000", "empty1");
     FileSlice fileSlice = new FileSlice(DEFAULT_PARTITION_PATHS[0], "000", "noData1");
     fileSlice.setDataFile(new TestHoodieDataFile(fullPartitionPath.toString() + "/data1_1_000.parquet"));
-    fileSlice.addLogFile(
-        new HoodieLogFile(new Path(fullPartitionPath, new Path(FSUtils.makeLogFileName("noData1", ".log", "000", 1, TEST_WRITE_TOKEN)))));
-    fileSlice.addLogFile(
-        new HoodieLogFile(new Path(fullPartitionPath, new Path(FSUtils.makeLogFileName("noData1", ".log", "000", 2, TEST_WRITE_TOKEN)))));
+    fileSlice.addLogFile(new HoodieLogFile(
+        new Path(fullPartitionPath, new Path(FSUtils.makeLogFileName("noData1", ".log", "000", 1, TEST_WRITE_TOKEN)))));
+    fileSlice.addLogFile(new HoodieLogFile(
+        new Path(fullPartitionPath, new Path(FSUtils.makeLogFileName("noData1", ".log", "000", 2, TEST_WRITE_TOKEN)))));
     FileSlice noLogFileSlice = new FileSlice(DEFAULT_PARTITION_PATHS[0], "000", "noLog1");
     noLogFileSlice.setDataFile(new TestHoodieDataFile(fullPartitionPath.toString() + "/noLog_1_000.parquet"));
     FileSlice noDataFileSlice = new FileSlice(DEFAULT_PARTITION_PATHS[0], "000", "noData1");
-    noDataFileSlice.addLogFile(
-        new HoodieLogFile(new Path(fullPartitionPath, new Path(FSUtils.makeLogFileName("noData1", ".log", "000", 1, TEST_WRITE_TOKEN)))));
-    noDataFileSlice.addLogFile(
-        new HoodieLogFile(new Path(fullPartitionPath, new Path(FSUtils.makeLogFileName("noData1", ".log", "000", 2, TEST_WRITE_TOKEN)))));
+    noDataFileSlice.addLogFile(new HoodieLogFile(
+        new Path(fullPartitionPath, new Path(FSUtils.makeLogFileName("noData1", ".log", "000", 1, TEST_WRITE_TOKEN)))));
+    noDataFileSlice.addLogFile(new HoodieLogFile(
+        new Path(fullPartitionPath, new Path(FSUtils.makeLogFileName("noData1", ".log", "000", 2, TEST_WRITE_TOKEN)))));
     List<FileSlice> fileSliceList = Arrays.asList(emptyFileSlice, noDataFileSlice, fileSlice, noLogFileSlice);
     List<Pair<String, FileSlice>> input =
         fileSliceList.stream().map(f -> Pair.of(DEFAULT_PARTITION_PATHS[0], f)).collect(Collectors.toList());
@@ -221,9 +220,8 @@ public class TestCompactionUtils extends HoodieCommonTestHarness {
    */
   private void testFileSlicesCompactionPlanEquality(List<Pair<String, FileSlice>> input, HoodieCompactionPlan plan) {
     Assert.assertEquals("All file-slices present", input.size(), plan.getOperations().size());
-    IntStream.range(0, input.size()).boxed().forEach(idx ->
-        testFileSliceCompactionOpEquality(input.get(idx).getValue(), plan.getOperations().get(idx),
-            input.get(idx).getKey(), plan.getVersion()));
+    IntStream.range(0, input.size()).boxed().forEach(idx -> testFileSliceCompactionOpEquality(input.get(idx).getValue(),
+        plan.getOperations().get(idx), input.get(idx).getKey(), plan.getVersion()));
   }
 
   /**
@@ -233,15 +231,15 @@ public class TestCompactionUtils extends HoodieCommonTestHarness {
    * @param op HoodieCompactionOperation
    * @param expPartitionPath Partition path
    */
-  private void testFileSliceCompactionOpEquality(FileSlice slice, HoodieCompactionOperation op,
-      String expPartitionPath, int version) {
+  private void testFileSliceCompactionOpEquality(FileSlice slice, HoodieCompactionOperation op, String expPartitionPath,
+      int version) {
     Assert.assertEquals("Partition path is correct", expPartitionPath, op.getPartitionPath());
     Assert.assertEquals("Same base-instant", slice.getBaseInstantTime(), op.getBaseInstantTime());
     Assert.assertEquals("Same file-id", slice.getFileId(), op.getFileId());
     if (slice.getDataFile().isPresent()) {
       HoodieDataFile df = slice.getDataFile().get();
-      Assert.assertEquals("Same data-file",
-          version == COMPACTION_METADATA_VERSION_1 ? df.getPath() : df.getFileName(), op.getDataFilePath());
+      Assert.assertEquals("Same data-file", version == COMPACTION_METADATA_VERSION_1 ? df.getPath() : df.getFileName(),
+          op.getDataFilePath());
     }
     List<String> paths = slice.getLogFiles().map(l -> l.getPath().toString()).collect(Collectors.toList());
     IntStream.range(0, paths.size()).boxed().forEach(idx -> {

--- a/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/TimelineService.java
+++ b/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/TimelineService.java
@@ -138,9 +138,11 @@ public class TimelineService {
   }
 
   public void close() {
+    log.info("Closing Timeline Service");
     this.app.stop();
     this.app = null;
     this.fsViewsManager.close();
+    log.info("Closed Timeline Service");
   }
 
   public Configuration getConf() {


### PR DESCRIPTION

Before this change, Cleaner performs cleaning of old file versions and then stores the deleted files in .clean files.
With this setup, we will not be able to track file deletions if a cleaner fails after deleting files but before writing .clean metadata.
This is fine for regular file-system view generation but Incremental timeline syncing relies on clean/commit/compaction metadata to keep a consistent file-system view.

Cleaner state transitions is now similar to that of compaction.

1. Requested : HoodieWriteClient.scheduleClean() selects the list of files that needs to be deleted and stores them in metadata
2. Inflight : HoodieWriteClient marks the state to be inflight before it starts deleting
3. Completed : HoodieWriteClient marks the state after completing the deletion according to the cleaner plan

There will be followup PRs after this :
1. HUDI-294 for making cleaner stats use relative paths.
2. HUDI-137 for similar handling for Rollback
3. HUDI-80  for incrementalize cleaning
