### PR TITLE
[MINOR] Move all repository declarations to parent pom

### DIFF
--- a/hudi-cli/pom.xml
+++ b/hudi-cli/pom.xml
@@ -32,17 +32,6 @@
     <main.basedir>${project.parent.basedir}</main.basedir>
   </properties>
 
-  <repositories>
-    <repository>
-      <id>libs-milestone</id>
-      <url>https://repo.spring.io/libs-milestone/</url>
-    </repository>
-    <repository>
-      <id>libs-release</id>
-      <url>https://repo.spring.io/libs-release/</url>
-    </repository>
-  </repositories>
-
   <build>
     <resources>
       <resource>

--- a/packaging/hudi-utilities-bundle/pom.xml
+++ b/packaging/hudi-utilities-bundle/pom.xml
@@ -175,13 +175,6 @@
     </resources>
   </build>
 
-  <repositories>
-    <repository>
-      <id>confluent</id>
-      <url>https://packages.confluent.io/maven/</url>
-    </repository>
-  </repositories>
-
   <dependencies>
     <!-- Hoodie -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -844,6 +844,14 @@
       <id>confluent</id>
       <url>https://packages.confluent.io/maven/</url>
     </repository>
+    <repository>
+      <id>libs-milestone</id>
+      <url>https://repo.spring.io/libs-milestone/</url>
+    </repository>
+    <repository>
+      <id>libs-release</id>
+      <url>https://repo.spring.io/libs-release/</url>
+    </repository>
   </repositories>
 
   <profiles>


### PR DESCRIPTION
Removed the redundant repository declarations in individual modules and move all to the parent pom