### PR TITLE
[HUDI-302]: simplified countInstants() method in HoodieDefaultTimeline

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieDefaultTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieDefaultTimeline.java
@@ -141,7 +141,7 @@ public class HoodieDefaultTimeline implements HoodieTimeline {
 
   @Override
   public int countInstants() {
-    return new Long(instants.stream().count()).intValue();
+    return instants.size();
   }
 
   @Override


### PR DESCRIPTION
countInstants() method was having unnecessary casting. We can directly use Collections.size() method. 