### PR TITLE
[HUDI-329] Presto Containers for integration test must allow newly built local jars to override

### DIFF
--- a/docker/compose/docker-compose_hadoop284_hive233_spark244.yml
+++ b/docker/compose/docker-compose_hadoop284_hive233_spark244.yml
@@ -195,7 +195,9 @@ services:
       - PRESTO_MEMORY_HEAP_HEADROOM_PER_NODE=100MB
       - TERM=xterm
     links:
-          - "hivemetastore"
+      - "hivemetastore"
+    volumes:
+      - ${HUDI_WS}:/var/hoodie/ws
     command: coordinator
 
   presto-worker-1:
@@ -215,6 +217,8 @@ services:
         - "hiveserver"
         - "hive-metastore-postgresql"
         - "namenode"
+      volumes:
+        - ${HUDI_WS}:/var/hoodie/ws
       command: worker
 
   adhoc-1:

--- a/docker/hoodie/hadoop/prestobase/bin/entrypoint.sh
+++ b/docker/hoodie/hadoop/prestobase/bin/entrypoint.sh
@@ -57,6 +57,9 @@ do
     cat ${conf_file}.mustache | mustache.sh > ${conf_file}
 done
 
+# Copy the presto bundle at run time so that locally built bundle overrides the one that is present in the image
+cp ${HUDI_PRESTO_BUNDLE} ${PRESTO_HOME}/plugin/hive-hadoop2/
+
 case "$1" in
     "coordinator" | "worker" )
         server_role="$1"


### PR DESCRIPTION
This was blocking #1009 . Pushed a new docker image for presto