### PR TITLE
[HOTFIX] Fix error configuration item of dockerfile-maven-plugin

### DIFF
--- a/docker/hoodie/hadoop/base/pom.xml
+++ b/docker/hoodie/hadoop/base/pom.xml
@@ -68,7 +68,7 @@
               <skip>${docker.build.skip}</skip>
               <pullNewerImage>false</pullNewerImage>
               <repository>apachehudi/hudi-hadoop_${docker.hadoop.version}-base</repository>
-              <forceTags>true</forceTags>
+              <force>true</force>
               <tag>latest</tag>
             </configuration>
           </execution>
@@ -84,7 +84,7 @@
               <skip>${docker.build.skip}</skip>
               <pullNewerImage>false</pullNewerImage>
               <repository>apachehudi/hudi-hadoop_${docker.hadoop.version}-base</repository>
-              <forceTags>true</forceTags>
+              <force>true</force>
               <tag>${project.version}</tag>
             </configuration>
           </execution>

--- a/docker/hoodie/hadoop/datanode/pom.xml
+++ b/docker/hoodie/hadoop/datanode/pom.xml
@@ -65,7 +65,7 @@
               <skip>${docker.build.skip}</skip>
               <pullNewerImage>false</pullNewerImage>
               <repository>apachehudi/hudi-hadoop_${docker.hadoop.version}-datanode</repository>
-              <forceTags>true</forceTags>
+              <force>true</force>
               <tag>latest</tag>
             </configuration>
           </execution>
@@ -81,7 +81,7 @@
               <skip>${docker.build.skip}</skip>
               <pullNewerImage>false</pullNewerImage>
               <repository>apachehudi/hudi-hadoop_${docker.hadoop.version}-datanode</repository>
-              <forceTags>true</forceTags>
+              <force>true</force>
               <tag>${project.version}</tag>
             </configuration>
           </execution>

--- a/docker/hoodie/hadoop/historyserver/pom.xml
+++ b/docker/hoodie/hadoop/historyserver/pom.xml
@@ -65,7 +65,7 @@
               <skip>${docker.build.skip}</skip>
               <pullNewerImage>false</pullNewerImage>
               <repository>apachehudi/hudi-hadoop_${docker.hadoop.version}-history</repository>
-              <forceTags>true</forceTags>
+              <force>true</force>
               <tag>latest</tag>
             </configuration>
           </execution>
@@ -81,7 +81,7 @@
               <skip>${docker.build.skip}</skip>
               <pullNewerImage>false</pullNewerImage>
               <repository>apachehudi/hudi-hadoop_${docker.hadoop.version}-history</repository>
-              <forceTags>true</forceTags>
+              <force>true</force>
               <tag>${project.version}</tag>
             </configuration>
           </execution>

--- a/docker/hoodie/hadoop/hive_base/pom.xml
+++ b/docker/hoodie/hadoop/hive_base/pom.xml
@@ -87,7 +87,7 @@
               <skip>${docker.build.skip}</skip>
               <pullNewerImage>false</pullNewerImage>
               <repository>apachehudi/hudi-hadoop_${docker.hadoop.version}-hive_${docker.hive.version}</repository>
-              <forceTags>true</forceTags>
+              <force>true</force>
               <tag>latest</tag>
             </configuration>
           </execution>
@@ -103,7 +103,7 @@
               <skip>${docker.build.skip}</skip>
               <pullNewerImage>false</pullNewerImage>
               <repository>apachehudi/hudi-hadoop_${docker.hadoop.version}-hive_${docker.hive.version}</repository>
-              <forceTags>true</forceTags>
+              <force>true</force>
               <tag>${project.version}</tag>
             </configuration>
           </execution>

--- a/docker/hoodie/hadoop/namenode/pom.xml
+++ b/docker/hoodie/hadoop/namenode/pom.xml
@@ -65,7 +65,7 @@
               <skip>${docker.build.skip}</skip>
               <pullNewerImage>false</pullNewerImage>
               <repository>apachehudi/hudi-hadoop_${docker.hadoop.version}-namenode</repository>
-              <forceTags>true</forceTags>
+              <force>true</force>
               <tag>latest</tag>
             </configuration>
           </execution>
@@ -81,7 +81,7 @@
               <skip>${docker.build.skip}</skip>
               <pullNewerImage>false</pullNewerImage>
               <repository>apachehudi/hudi-hadoop_${docker.hadoop.version}-namenode</repository>
-              <forceTags>true</forceTags>
+              <force>true</force>
               <tag>${project.version}</tag>
             </configuration>
           </execution>

--- a/docker/hoodie/hadoop/prestobase/pom.xml
+++ b/docker/hoodie/hadoop/prestobase/pom.xml
@@ -83,7 +83,7 @@
               <skip>${docker.build.skip}</skip>
               <pullNewerImage>false</pullNewerImage>
               <repository>apachehudi/hudi-hadoop_${docker.hadoop.version}-prestobase_${docker.presto.version}</repository>
-              <forceTags>true</forceTags>
+              <force>true</force>
               <tag>latest</tag>
             </configuration>
           </execution>
@@ -99,7 +99,7 @@
               <skip>${docker.build.skip}</skip>
               <pullNewerImage>false</pullNewerImage>
               <repository>apachehudi/hudi-hadoop_${docker.hadoop.version}-prestobase_${docker.presto.version}</repository>
-              <forceTags>true</forceTags>
+              <force>true</force>
               <tag>${project.version}</tag>
             </configuration>
           </execution>

--- a/docker/hoodie/hadoop/spark_base/pom.xml
+++ b/docker/hoodie/hadoop/spark_base/pom.xml
@@ -65,7 +65,7 @@
               <skip>${docker.build.skip}</skip>
               <pullNewerImage>false</pullNewerImage>
               <repository>apachehudi/hudi-hadoop_${docker.hadoop.version}-hive_${docker.hive.version}-sparkbase_${docker.spark.version}</repository>
-              <forceTags>true</forceTags>
+              <force>true</force>
               <tag>latest</tag>
             </configuration>
           </execution>
@@ -81,7 +81,7 @@
               <skip>${docker.build.skip}</skip>
               <pullNewerImage>false</pullNewerImage>
               <repository>apachehudi/hudi-hadoop_${docker.hadoop.version}-hive_${docker.hive.version}-sparkbase_${docker.spark.version}</repository>
-              <forceTags>true</forceTags>
+              <force>true</force>
               <tag>${project.version}</tag>
             </configuration>
           </execution>

--- a/docker/hoodie/hadoop/sparkadhoc/pom.xml
+++ b/docker/hoodie/hadoop/sparkadhoc/pom.xml
@@ -65,7 +65,7 @@
               <skip>${docker.build.skip}</skip>
               <pullNewerImage>false</pullNewerImage>
               <repository>apachehudi/hudi-hadoop_${docker.hadoop.version}-hive_${docker.hive.version}-sparkadhoc_${docker.spark.version}</repository>
-              <forceTags>true</forceTags>
+              <force>true</force>
               <tag>latest</tag>
             </configuration>
           </execution>
@@ -81,7 +81,7 @@
               <skip>${docker.build.skip}</skip>
               <pullNewerImage>false</pullNewerImage>
               <repository>apachehudi/hudi-hadoop_${docker.hadoop.version}-hive_${docker.hive.version}-sparkadhoc_${docker.spark.version}</repository>
-              <forceTags>true</forceTags>
+              <force>true</force>
               <tag>${project.version}</tag>
             </configuration>
           </execution>

--- a/docker/hoodie/hadoop/sparkmaster/pom.xml
+++ b/docker/hoodie/hadoop/sparkmaster/pom.xml
@@ -65,7 +65,7 @@
               <skip>${docker.build.skip}</skip>
               <pullNewerImage>false</pullNewerImage>
               <repository>apachehudi/hudi-hadoop_${docker.hadoop.version}-hive_${docker.hive.version}-sparkmaster_${docker.spark.version}</repository>
-              <forceTags>true</forceTags>
+              <force>true</force>
               <tag>latest</tag>
             </configuration>
           </execution>
@@ -81,7 +81,7 @@
               <skip>${docker.build.skip}</skip>
               <pullNewerImage>false</pullNewerImage>
               <repository>apachehudi/hudi-hadoop_${docker.hadoop.version}-hive_${docker.hive.version}-sparkmaster_${docker.spark.version}</repository>
-              <forceTags>true</forceTags>
+              <force>true</force>
               <tag>${project.version}</tag>
             </configuration>
           </execution>

--- a/docker/hoodie/hadoop/sparkworker/pom.xml
+++ b/docker/hoodie/hadoop/sparkworker/pom.xml
@@ -65,7 +65,7 @@
               <skip>${docker.build.skip}</skip>
               <pullNewerImage>false</pullNewerImage>
               <repository>apachehudi/hudi-hadoop_${docker.hadoop.version}-hive_${docker.hive.version}-sparkworker_${docker.spark.version}</repository>
-              <forceTags>true</forceTags>
+              <force>true</force>
               <tag>latest</tag>
             </configuration>
           </execution>
@@ -81,7 +81,7 @@
               <skip>${docker.build.skip}</skip>
               <pullNewerImage>false</pullNewerImage>
               <repository>apachehudi/hudi-hadoop_${docker.hadoop.version}-hive_${docker.hive.version}-sparkworker_${docker.spark.version}</repository>
-              <forceTags>true</forceTags>
+              <force>true</force>
               <tag>${project.version}</tag>
             </configuration>
           </execution>


### PR DESCRIPTION
## What is the purpose of the pull request

Fix error configuration item of dockerfile-maven-plugin, chang `forceTags` to `force`.

From dockerfile-maven-plugin(v1.4.3) souce code, we can find out that the paramter is `force`.

please check [dockerfile-maven-plugin source](https://github.com/spotify/dockerfile-maven/blob/v1.4.3/plugin/src/main/java/com/spotify/plugin/dockerfile/TagMojo.java).

```java
/**
 * The repository to put the built image into, for example <tt>spotify/foo</tt>.  You should also
 * set the <tt>tag</tt> parameter, otherwise the tag <tt>latest</tt> is used by default.
 */
@Parameter(property = "dockerfile.repository", required = true)
private String repository;

/**
 * The tag to apply to the built image.
 */
@Parameter(property = "dockerfile.tag", defaultValue = "latest", required = true)
private String tag;

/**
 * Whether to force re-assignment of an already assigned tag.
 */
@Parameter(property = "dockerfile.force", defaultValue = "true", required = true)
private boolean force;

/**
 * Disables the tag goal; it becomes a no-op.
 */
@Parameter(property = "dockerfile.tag.skip", defaultValue = "false")
private boolean skipTag;
```



## Verify this pull request

This pull request without any test coverage.
