### PR TITLE
[HUDI-356][chinese] Sync translation and code in quickstart.cn and admin_guide.cn pages

### DIFF
--- a/docs/admin_guide.cn.md
+++ b/docs/admin_guide.cn.md
@@ -42,7 +42,7 @@ hudi->create --path /user/hive/warehouse/table1 --tableName hoodie_table_1 --tab
 18/09/06 15:57:15 INFO table.HoodieTableMetaClient: Finished Loading Table of type COPY_ON_WRITE from ...
 ```
 
-To see the description of hudi table, use the command:
+使用desc命令可以查看hudi表的描述信息:
 
 ```Java
 hoodie:hoodie_table_1->desc

--- a/docs/quickstart.cn.md
+++ b/docs/quickstart.cn.md
@@ -108,6 +108,13 @@ Hudi还提供了获取给定提交时间戳以来已更改的记录流的功能�
 如果我们需要给定提交之后的所有更改(这是常见的情况)，则无需指定结束时间。
 
 ```Java
+// reload data
+spark.
+    read.
+    format("org.apache.hudi").
+    load(basePath + "/*/*/*/*").
+    createOrReplaceTempView("hudi_ro_table")
+
 val commits = spark.sql("select distinct(_hoodie_commit_time) as commitTime from  hudi_ro_table order by commitTime").map(k => k.getString(0)).take(50)
 val beginTime = commits(commits.length - 2) // commit time we are interested in
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -75,7 +75,7 @@ val roViewDF = spark.
     read.
     format("org.apache.hudi").
     load(basePath + "/*/*/*/*")
-roViewDF.registerTempTable("hudi_ro_table")
+roViewDF.createOrReplaceTempView("hudi_ro_table")
 spark.sql("select fare, begin_lon, begin_lat, ts from  hudi_ro_table where fare > 20.0").show()
 spark.sql("select _hoodie_commit_time, _hoodie_record_key, _hoodie_partition_path, rider, driver, fare from  hudi_ro_table").show()
 ```
@@ -111,6 +111,13 @@ This can be achieved using Hudi's incremental view and providing a begin time fr
 We do not need to specify endTime, if we want all changes after the given commit (as is the common case). 
 
 ```Scala
+// reload data
+spark.
+    read.
+    format("org.apache.hudi").
+    load(basePath + "/*/*/*/*").
+    createOrReplaceTempView("hudi_ro_table")
+
 val commits = spark.sql("select distinct(_hoodie_commit_time) as commitTime from  hudi_ro_table order by commitTime").map(k => k.getString(0)).take(50)
 val beginTime = commits(commits.length - 2) // commit time we are interested in
 


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

Sync translation and code in quickstart.cn and admin_guide.cn pages

## Brief change log

*(for example:)*
  - *translation a line in admin_guide.cn*
  - *sync reload code in quickstart.cn*

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [x] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.