### PR TITLE
[HUDI-327] Add null/empty checks to key generators

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/exception/HoodieKeyException.java
+++ b/hudi-common/src/main/java/org/apache/hudi/exception/HoodieKeyException.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.exception;
+
+/**
+ * <p>
+ * Exception thrown for Hoodie Key Generator related errors.
+ * </p>
+ */
+public class HoodieKeyException extends HoodieException {
+
+  public HoodieKeyException(String msg) {
+    super(msg);
+  }
+
+  public HoodieKeyException(String msg, Throwable e) {
+    super(msg, e);
+  }
+}

--- a/hudi-spark/src/main/java/org/apache/hudi/DataSourceUtils.java
+++ b/hudi-spark/src/main/java/org/apache/hudi/DataSourceUtils.java
@@ -52,6 +52,17 @@ import org.apache.spark.api.java.JavaSparkContext;
 public class DataSourceUtils {
 
   /**
+   * Obtain value of the provided nullable field as string, denoted by dot notation. e.g: a.b.c
+   */
+  public static String getNullableNestedFieldValAsString(GenericRecord record, String fieldName) {
+    try {
+      return getNestedFieldValAsString(record, fieldName);
+    } catch (HoodieException e) {
+      return null;
+    }
+  }
+
+  /**
    * Obtain value of the provided field as string, denoted by dot notation. e.g: a.b.c
    */
   public static String getNestedFieldValAsString(GenericRecord record, String fieldName) {

--- a/hudi-spark/src/main/java/org/apache/hudi/NonpartitionedKeyGenerator.java
+++ b/hudi-spark/src/main/java/org/apache/hudi/NonpartitionedKeyGenerator.java
@@ -21,6 +21,7 @@ package org.apache.hudi;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.util.TypedProperties;
+import org.apache.hudi.exception.HoodieKeyException;
 
 /**
  * Simple Key generator for unpartitioned Hive Tables
@@ -35,7 +36,10 @@ public class NonpartitionedKeyGenerator extends SimpleKeyGenerator {
 
   @Override
   public HoodieKey getKey(GenericRecord record) {
-    String recordKey = DataSourceUtils.getNestedFieldValAsString(record, recordKeyField);
+    String recordKey = DataSourceUtils.getNullableNestedFieldValAsString(record, recordKeyField);
+    if (recordKey == null || recordKey.isEmpty()) {
+      throw new HoodieKeyException("recordKey value: \"" + recordKey + "\" for field: \"" + recordKeyField + "\" cannot be null or empty.");
+    }
     return new HoodieKey(recordKey, EMPTY_PARTITION);
   }
 }

--- a/hudi-spark/src/test/scala/TestDataSourceDefaults.scala
+++ b/hudi-spark/src/test/scala/TestDataSourceDefaults.scala
@@ -19,7 +19,7 @@ import org.apache.avro.generic.GenericRecord
 import org.apache.hudi.common.model.EmptyHoodieRecordPayload
 import org.apache.hudi.common.util.{Option, SchemaTestUtil, TypedProperties}
 import org.apache.hudi.exception.{HoodieException, HoodieKeyException}
-import org.apache.hudi.{ComplexKeyGenerator, DataSourceWriteOptions, EmptyHoodieRecordPayload, OverwriteWithLatestAvroPayload, SimpleKeyGenerator}
+import org.apache.hudi.{ComplexKeyGenerator, DataSourceWriteOptions, OverwriteWithLatestAvroPayload, SimpleKeyGenerator}
 import org.junit.Assert._
 import org.junit.{Before, Test}
 import org.scalatest.junit.AssertionsForJUnit

--- a/hudi-spark/src/test/scala/TestDataSourceDefaults.scala
+++ b/hudi-spark/src/test/scala/TestDataSourceDefaults.scala
@@ -17,7 +17,7 @@
 
 import org.apache.avro.generic.GenericRecord
 import org.apache.hudi.common.util.{Option, SchemaTestUtil, TypedProperties}
-import org.apache.hudi.exception.HoodieException
+import org.apache.hudi.exception.{HoodieException, HoodieKeyException}
 import org.apache.hudi.{ComplexKeyGenerator, DataSourceWriteOptions, EmptyHoodieRecordPayload, OverwriteWithLatestAvroPayload, SimpleKeyGenerator}
 import org.junit.Assert._
 import org.junit.{Before, Test}
@@ -95,6 +95,44 @@ class TestDataSourceDefaults extends AssertionsForJUnit {
     val hk3 = new SimpleKeyGenerator(getKeyConfig("testNestedRecord.userId", "testNestedRecord.notThere"))
       .getKey(baseRecord);
     assertEquals("default", hk3.getPartitionPath)
+
+    // if partition is null, return default partition path
+    baseRecord.put("name", "")
+    val hk4 = new SimpleKeyGenerator(getKeyConfig("field1", "name"))
+      .getKey(baseRecord)
+    assertEquals("default", hk4.getPartitionPath)
+
+    // if partition is empty, return default partition path
+    baseRecord.put("name", null)
+    val hk5 = new SimpleKeyGenerator(getKeyConfig("field1", "name"))
+      .getKey(baseRecord)
+    assertEquals("default", hk5.getPartitionPath)
+
+    // if record key is empty, throw error
+    try {
+      baseRecord.put("field1", "")
+      val props = new TypedProperties()
+      props.setProperty(DataSourceWriteOptions.RECORDKEY_FIELD_OPT_KEY, "field1")
+      props.setProperty(DataSourceWriteOptions.PARTITIONPATH_FIELD_OPT_KEY, "name")
+      new SimpleKeyGenerator(props).getKey(baseRecord)
+      fail("Should have errored out")
+    } catch {
+      case e: HoodieKeyException =>
+        // do nothing
+    }
+
+    // if record key is null, throw error
+    try {
+      baseRecord.put("field1", null)
+      val props = new TypedProperties()
+      props.setProperty(DataSourceWriteOptions.RECORDKEY_FIELD_OPT_KEY, "field1")
+      props.setProperty(DataSourceWriteOptions.PARTITIONPATH_FIELD_OPT_KEY, "name")
+      new SimpleKeyGenerator(props).getKey(baseRecord)
+      fail("Should have errored out")
+    } catch {
+      case e: HoodieKeyException =>
+        // do nothing
+    }
   }
 
   @Test def testComplexKeyGenerator() = {
@@ -148,6 +186,32 @@ class TestDataSourceDefaults extends AssertionsForJUnit {
     val hk3 = new ComplexKeyGenerator(getKeyConfig("testNestedRecord.userId", "testNestedRecord.notThere"))
       .getKey(baseRecord);
     assertEquals("default", hk3.getPartitionPath)
+
+    // if one part of the record key is empty, replace with "__empty__"
+    baseRecord.put("name", "")
+    val hk4 = new ComplexKeyGenerator(getKeyConfig("field1,name", "field1,name")).getKey(baseRecord)
+    assertEquals("field1:field1,name:__empty__", hk4.getRecordKey)
+    assertEquals("field1/default", hk4.getPartitionPath)
+
+    // if one part of the record key is null, replace with "__null__"
+    baseRecord.put("name", null)
+    val hk5 = new ComplexKeyGenerator(getKeyConfig("field1,name", "field1,name")).getKey(baseRecord)
+    assertEquals("field1:field1,name:__null__", hk5.getRecordKey)
+    assertEquals("field1/default", hk5.getPartitionPath)
+
+    // if all parts of the composite record key are null/empty, throw error
+    try {
+      baseRecord.put("name", "")
+      baseRecord.put("field1", null)
+      val props = new TypedProperties()
+      props.setProperty(DataSourceWriteOptions.RECORDKEY_FIELD_OPT_KEY, "field1,name")
+      props.setProperty(DataSourceWriteOptions.PARTITIONPATH_FIELD_OPT_KEY, "field1,name")
+      new ComplexKeyGenerator(props).getKey(baseRecord)
+      fail("Should have errored out")
+    } catch {
+      case e: HoodieKeyException =>
+        // do nothing
+    }
   }
 
   @Test def testOverwriteWithLatestAvroPayload() = {


### PR DESCRIPTION
## Summary
Adds null and empty checks to all key generators. Also improves error
messaging for key generator issues.

Additionally gives support to complex key generator to accept null/empty fields within the composite key.

## What is the purpose of the pull request
Improve usability by improving null/empty key handling in key generators

## Brief change log
  - *Improve null/empty handling in key generators*

## Verify this pull request
This change added tests and can be verified as follows:
  - Old + New Unit tests pass successfully
