### PR TITLE
[HUDI-358] Add Java-doc and importOrder checkstyle rule

### DIFF
--- a/style/checkstyle.xml
+++ b/style/checkstyle.xml
@@ -294,8 +294,7 @@
 
         <!-- Checks for redundant imports. -->
         <module name="RedundantImport">
-            <message key="import.redundancy"
-                     value="Redundant import {0}."/>
+            <message key="import.redundancy" value="Redundant import {0}."/>
         </module>
 
         <!-- Checks for star import. -->

--- a/style/checkstyle.xml
+++ b/style/checkstyle.xml
@@ -206,11 +206,6 @@
             <property name="allowedDistance" value="5"/>
         </module>
         -->
-        <module name="CustomImportOrder">
-            <property name="sortImportsInGroupAlphabetically" value="true"/>
-            <property name="separateLineBetweenGroups" value="true"/>
-            <property name="customImportOrderRules" value="STATIC###THIRD_PARTY_PACKAGE"/>
-        </module>
         <module name="UnusedImports"/>
         <module name="RedundantImport"/>
 
@@ -274,5 +269,37 @@
         </module>
 
         <module name="EmptyStatement" />
+
+        <!-- Checks for Java Docs. -->
+        <module name="JavadocStyle">
+            <property name="severity" value="info"/>
+        </module>
+        <module name="JavadocType">
+            <property name="severity" value="info"/>
+            <property name="scope" value="protected"/>
+            <property name="allowMissingParamTags" value="true"/>
+        </module>
+
+        <!-- Checks for out of order import statements. -->
+        <module name="ImportOrder">
+            <property name="severity" value="info"/>
+            <property name="groups" value="org.apache.hudi,*,javax,java,scala"/>
+            <property name="separated" value="true"/>
+            <property name="sortStaticImportsAlphabetically" value="true"/>
+            <property name="option" value="bottom"/>
+            <property name="tokens" value="STATIC_IMPORT, IMPORT"/>
+            <message key="import.ordering"
+                     value="Import {0} appears after other imports that it should precede"/>
+        </module>
+
+        <!-- Checks for redundant imports. -->
+        <module name="RedundantImport">
+            <message key="import.redundancy"
+                     value="Redundant import {0}."/>
+        </module>
+
+        <!-- Checks for star import. -->
+        <module name="AvoidStarImport" />
+
     </module>
 </module>

--- a/style/checkstyle.xml
+++ b/style/checkstyle.xml
@@ -292,11 +292,6 @@
                      value="Import {0} appears after other imports that it should precede"/>
         </module>
 
-        <!-- Checks for redundant imports. -->
-        <module name="RedundantImport">
-            <message key="import.redundancy" value="Redundant import {0}."/>
-        </module>
-
         <!-- Checks for star import. -->
         <module name="AvoidStarImport" />
 


### PR DESCRIPTION
## What is the purpose of the pull request

Add checkstyle rule to enhance code quality and the java doc.

#### new import rule

- import groups are separated by one blank line
- `org.apache.hudi.* ` at the top location

#### Old import order rule
```
import static org.junit.Assert.assertEquals;

import java.io.IOException;
import org.apache.hadoop.conf.Configuration;
import org.apache.hadoop.fs.FileSystem;
import org.apache.hudi.common.table.HoodieTableMetaClient;
import org.apache.hudi.common.util.ConsistencyGuardConfig;
import org.apache.hudi.common.util.FSUtils;
```

#### New import order rule
```
import org.apache.hudi.common.table.HoodieTableMetaClient;
import org.apache.hudi.common.util.ConsistencyGuardConfig;
import org.apache.hudi.common.util.FSUtils;

import org.apache.hadoop.conf.Configuration;
import org.apache.hadoop.fs.FileSystem;

import java.io.IOException;

import static org.junit.Assert.assertEquals;
```

## Brief change log

  - Add Java-doc and importOrder checkstyle rule
  - Set severity `info` level

## Verify this pull request

This pull request is a code cleanup without any test coverage.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.