### PR TITLE
[HUDI-361] Implement CSV metrics reporter

### DIFF
--- a/hudi-client/src/main/java/org/apache/hudi/config/HoodieMetricsConfig.java
+++ b/hudi-client/src/main/java/org/apache/hudi/config/HoodieMetricsConfig.java
@@ -42,6 +42,14 @@ public class HoodieMetricsConfig extends DefaultHoodieConfig {
   public static final String GRAPHITE_SERVER_HOST = GRAPHITE_PREFIX + ".host";
   public static final String DEFAULT_GRAPHITE_SERVER_HOST = "localhost";
 
+  // Csv
+  public static final String CSV_KEY_PERIOD = "period";
+  public static final String CSV_KEY_UNIT = "unit";
+  public static final String CSV_KEY_DIR = "directory";
+  public static final int CSV_DEFAULT_PERIOD = 10;
+  public static final String CSV_DEFAULT_UNIT = "SECONDS";
+  public static final String CSV_DEFAULT_DIR = "/tmp/";
+
   public static final String GRAPHITE_SERVER_PORT = GRAPHITE_PREFIX + ".port";
   public static final int DEFAULT_GRAPHITE_SERVER_PORT = 4756;
 

--- a/hudi-client/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -32,6 +32,7 @@ import org.apache.hudi.common.model.HoodieCleaningPolicy;
 import org.apache.hudi.common.table.view.FileSystemViewStorageConfig;
 import org.apache.hudi.common.util.ConsistencyGuardConfig;
 import org.apache.hudi.common.util.ReflectionUtils;
+import org.apache.hudi.common.util.StringUtils;
 import org.apache.hudi.index.HoodieIndex;
 import org.apache.hudi.io.compact.strategy.CompactionStrategy;
 import org.apache.hudi.metrics.MetricsReporterType;
@@ -455,6 +456,21 @@ public class HoodieWriteConfig extends DefaultHoodieConfig {
 
   public String getGraphiteMetricPrefix() {
     return props.getProperty(HoodieMetricsConfig.GRAPHITE_METRIC_PREFIX);
+  }
+
+  public int getCsvKeyPeriod() {
+    String pollPeriod = props.getProperty(HoodieMetricsConfig.CSV_KEY_PERIOD);
+    return StringUtils.isNullOrEmpty(pollPeriod) ? HoodieMetricsConfig.CSV_DEFAULT_PERIOD : Integer.parseInt(pollPeriod);
+  }
+
+  public String getCsvKeyUnit() {
+    String pollUnit = props.getProperty(HoodieMetricsConfig.CSV_KEY_UNIT);
+    return StringUtils.isNullOrEmpty(pollUnit) ? HoodieMetricsConfig.CSV_DEFAULT_UNIT : pollUnit;
+  }
+
+  public String getCsvKeyDir() {
+    String pollDir = props.getProperty(HoodieMetricsConfig.CSV_KEY_DIR);
+    return StringUtils.isNullOrEmpty(pollDir) ? HoodieMetricsConfig.CSV_DEFAULT_DIR : pollDir;
   }
 
   /**

--- a/hudi-client/src/main/java/org/apache/hudi/metrics/CsvMetricsReporter.java
+++ b/hudi-client/src/main/java/org/apache/hudi/metrics/CsvMetricsReporter.java
@@ -59,7 +59,7 @@ public class CsvMetricsReporter extends MetricsReporter {
     if (csvReporter != null) {
       csvReporter.start(pollPeriod, pollUnit);
     } else {
-      logger.error("Cannot start as the graphiteReporter is null.");
+      logger.error("Cannot start as the csvReporter is null.");
     }
   }
 
@@ -68,7 +68,7 @@ public class CsvMetricsReporter extends MetricsReporter {
     if (csvReporter != null) {
       csvReporter.report();
     } else {
-      logger.error("Cannot report metrics as the graphiteReporter is null.");
+      logger.error("Cannot report metrics as the csvReporter is null.");
     }
   }
 

--- a/hudi-client/src/main/java/org/apache/hudi/metrics/CsvMetricsReporter.java
+++ b/hudi-client/src/main/java/org/apache/hudi/metrics/CsvMetricsReporter.java
@@ -18,10 +18,6 @@
 
 package org.apache.hudi.metrics;
 
-import org.apache.hudi.config.HoodieWriteConfig;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
-
 import com.codahale.metrics.CsvReporter;
 import com.codahale.metrics.MetricRegistry;
 
@@ -29,6 +25,12 @@ import java.io.Closeable;
 import java.io.File;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
+
+import org.apache.hudi.config.HoodieWriteConfig;
+
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+
 
 /**
  * Implementation of CSV reporter, which save metrics to CSV files.

--- a/hudi-client/src/main/java/org/apache/hudi/metrics/CsvMetricsReporter.java
+++ b/hudi-client/src/main/java/org/apache/hudi/metrics/CsvMetricsReporter.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.metrics;
+
+import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+
+import com.codahale.metrics.CsvReporter;
+import com.codahale.metrics.MetricRegistry;
+
+import java.io.Closeable;
+import java.io.File;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Implementation of CSV reporter, which save metrics to CSV files.
+ */
+public class CsvMetricsReporter extends MetricsReporter {
+
+  private static Logger logger = LogManager.getLogger(CsvMetricsReporter.class);
+  private final MetricRegistry registry;
+  private final CsvReporter csvReporter;
+
+  private int pollPeriod;
+  private TimeUnit pollUnit;
+  private String pollDir;
+
+  public CsvMetricsReporter(HoodieWriteConfig config, MetricRegistry registry) {
+    this.registry = registry;
+
+    this.pollPeriod = config.getCsvKeyPeriod();
+    this.pollUnit = TimeUnit.valueOf(config.getCsvKeyUnit().toUpperCase(Locale.ROOT));
+    this.pollDir = config.getCsvKeyDir();
+    this.csvReporter = createCsvReport();
+  }
+
+  @Override
+  public void start() {
+    if (csvReporter != null) {
+      csvReporter.start(pollPeriod, pollUnit);
+    } else {
+      logger.error("Cannot start as the graphiteReporter is null.");
+    }
+  }
+
+  @Override
+  public void report() {
+    if (csvReporter != null) {
+      csvReporter.report();
+    } else {
+      logger.error("Cannot report metrics as the graphiteReporter is null.");
+    }
+  }
+
+  @Override
+  public Closeable getReporter() {
+    return csvReporter;
+  }
+
+  private CsvReporter createCsvReport() {
+    return CsvReporter.forRegistry(registry)
+        .formatFor(Locale.US)
+        .convertDurationsTo(TimeUnit.MILLISECONDS)
+        .convertRatesTo(TimeUnit.SECONDS)
+        .build(new File(pollDir));
+  }
+}

--- a/hudi-client/src/main/java/org/apache/hudi/metrics/MetricsReporterFactory.java
+++ b/hudi-client/src/main/java/org/apache/hudi/metrics/MetricsReporterFactory.java
@@ -40,6 +40,9 @@ public class MetricsReporterFactory {
       case INMEMORY:
         reporter = new InMemoryMetricsReporter();
         break;
+      case CSV:
+        reporter = new CsvMetricsReporter(config, registry);
+        break;
       default:
         logger.error("Reporter type[" + type + "] is not supported.");
         break;

--- a/hudi-client/src/main/java/org/apache/hudi/metrics/MetricsReporterType.java
+++ b/hudi-client/src/main/java/org/apache/hudi/metrics/MetricsReporterType.java
@@ -22,5 +22,5 @@ package org.apache.hudi.metrics;
  * Types of the reporter. Right now we only support Graphite. We can include JMX and CSV in the future.
  */
 public enum MetricsReporterType {
-  GRAPHITE, INMEMORY
+  GRAPHITE, INMEMORY, CSV
 }

--- a/hudi-client/src/test/java/org/apache/hudi/metrics/TestHoodieCsvMetrics.java
+++ b/hudi-client/src/test/java/org/apache/hudi/metrics/TestHoodieCsvMetrics.java
@@ -18,8 +18,6 @@
 
 package org.apache.hudi.metrics;
 
-import static org.apache.hudi.metrics.Metrics.registerGauge;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -27,11 +25,11 @@ import org.apache.hudi.config.HoodieMetricsConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 
 import org.junit.Before;
-import org.junit.Test;
 
+/**
+ * Test for the Csv metrics report.
+ */
 public class TestHoodieCsvMetrics extends TestHoodieMetrics {
-
-  private HoodieMetrics metrics = null;
 
   @Before
   public void start() {
@@ -41,12 +39,6 @@ public class TestHoodieCsvMetrics extends TestHoodieMetrics {
     when(config.getCsvKeyPeriod()).thenReturn(HoodieMetricsConfig.CSV_DEFAULT_PERIOD);
     when(config.getCsvKeyUnit()).thenReturn(HoodieMetricsConfig.CSV_DEFAULT_UNIT);
     when(config.getCsvKeyDir()).thenReturn(HoodieMetricsConfig.CSV_DEFAULT_DIR);
-    metrics = new HoodieMetrics(config, "raw_table");
-  }
-
-  @Test
-  public void testRegisterGauge() {
-    registerGauge("metric1", 123L);
-    assertTrue(Metrics.getInstance().getRegistry().getGauges().get("metric1").getValue().toString().equals("123"));
+    new HoodieMetrics(config, "raw_table");
   }
 }

--- a/hudi-client/src/test/java/org/apache/hudi/metrics/TestHoodieCsvMetrics.java
+++ b/hudi-client/src/test/java/org/apache/hudi/metrics/TestHoodieCsvMetrics.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.metrics;
+
+import org.apache.hudi.config.HoodieMetricsConfig;
+import org.apache.hudi.config.HoodieWriteConfig;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.apache.hudi.metrics.Metrics.registerGauge;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TestHoodieCsvMetrics extends TestHoodieMetrics {
+
+  private HoodieMetrics metrics = null;
+
+  @Before
+  public void start() {
+    HoodieWriteConfig config = mock(HoodieWriteConfig.class);
+    when(config.isMetricsOn()).thenReturn(true);
+    when(config.getMetricsReporterType()).thenReturn(MetricsReporterType.CSV);
+    when(config.getCsvKeyPeriod()).thenReturn(HoodieMetricsConfig.CSV_DEFAULT_PERIOD);
+    when(config.getCsvKeyUnit()).thenReturn(HoodieMetricsConfig.CSV_DEFAULT_UNIT);
+    when(config.getCsvKeyDir()).thenReturn(HoodieMetricsConfig.CSV_DEFAULT_DIR);
+    metrics = new HoodieMetrics(config, "raw_table");
+  }
+
+  @Test
+  public void testRegisterGauge() {
+    registerGauge("metric1", 123L);
+    assertTrue(Metrics.getInstance().getRegistry().getGauges().get("metric1").getValue().toString().equals("123"));
+  }
+}

--- a/hudi-client/src/test/java/org/apache/hudi/metrics/TestHoodieCsvMetrics.java
+++ b/hudi-client/src/test/java/org/apache/hudi/metrics/TestHoodieCsvMetrics.java
@@ -18,17 +18,16 @@
 
 package org.apache.hudi.metrics;
 
+import static org.apache.hudi.metrics.Metrics.registerGauge;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import org.apache.hudi.config.HoodieMetricsConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.apache.hudi.metrics.Metrics.registerGauge;
-
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class TestHoodieCsvMetrics extends TestHoodieMetrics {
 

--- a/hudi-client/src/test/java/org/apache/hudi/metrics/TestHoodieMetrics.java
+++ b/hudi-client/src/test/java/org/apache/hudi/metrics/TestHoodieMetrics.java
@@ -29,14 +29,12 @@ import org.junit.Test;
 
 public class TestHoodieMetrics {
 
-  private HoodieMetrics metrics = null;
-
   @Before
   public void start() {
     HoodieWriteConfig config = mock(HoodieWriteConfig.class);
     when(config.isMetricsOn()).thenReturn(true);
     when(config.getMetricsReporterType()).thenReturn(MetricsReporterType.INMEMORY);
-    metrics = new HoodieMetrics(config, "raw_table");
+    new HoodieMetrics(config, "raw_table");
   }
 
   @Test


### PR DESCRIPTION
Currently, there are only two reporters MetricsGraphiteReporter and InMemoryMetricsReporter. InMemoryMetricsReporter is used for testing. So actually we only have one metrics reporter.  propose to provide a CSV metrics reporter.