### PR TITLE
[HUDI-362] Adds a check for the existence of field

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/HoodiePrintHelper.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/HoodiePrintHelper.java
@@ -59,6 +59,10 @@ public class HoodiePrintHelper {
       return HoodiePrintHelper.print(rowHeader);
     }
 
+    if (!sortByField.isEmpty() && !rowHeader.containsField(sortByField)) {
+      return String.format("Field[%s] is not in table, given columns[%s]", sortByField, rowHeader.getFieldNames());
+    }
+
     Table table =
         new Table(rowHeader, fieldNameToConverterMap, Option.ofNullable(sortByField.isEmpty() ? null : sortByField),
             Option.ofNullable(isDescending), Option.ofNullable(limit <= 0 ? null : limit)).addAllRows(rows).flip();

--- a/hudi-cli/src/main/java/org/apache/hudi/cli/TableHeader.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/TableHeader.java
@@ -68,4 +68,8 @@ public class TableHeader {
   public int getNumFields() {
     return fieldNames.size();
   }
+
+  public boolean containsField(String fieldName) {
+    return fieldNames.contains(fieldName);
+  }
 }


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

Use command

commits show --sortBy "Total Bytes Written" --desc true --limit 10
when  sortBy field not in columns, it throw 
```
Command failed java.lang.ArrayIndexOutOfBoundsException: -1
-1
java.lang.ArrayIndexOutOfBoundsException: -1
    at java.util.ArrayList.elementData(ArrayList.java:418)
    at java.util.ArrayList.get(ArrayList.java:431)
    at org.apache.hudi.cli.Table$1.compare(Table.java:125)
    at org.apache.hudi.cli.Table$1.compare(Table.java:122)
    at java.util.TimSort.countRunAndMakeAscending(TimSort.java:355)
```
It is better to give a friendly hint as:
```
Field[Total Bytes Writte] is not in table, given columns[[CommitTime, Total Bytes Written, Total Files Added, Total Files Updated, Total Partitions Written, Total Records Written, Total Update Records Written, Total Errors]]
```

## Brief change log

*(for example:)*
  - *Adds a check for the existence of field in hudi cli*

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [x] CI is green

 - [x] Necessary doc changes done or have another open PR
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.