### PR TITLE
[HUDI-364] Refactor hudi-hive based on new ImportOrder code style rule

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/collection/DiskBasedMap.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/collection/DiskBasedMap.java
@@ -26,7 +26,6 @@ import java.io.Serializable;
 import java.net.InetAddress;
 import java.util.AbstractMap;
 import java.util.Collection;
-import java.util.Date;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
@@ -213,7 +212,7 @@ public final class DiskBasedMap<T extends Serializable, R extends Serializable> 
     try {
       byte[] val = SerializationUtils.serialize(value);
       Integer valueSize = val.length;
-      Long timestamp = new Date().getTime();
+      Long timestamp = System.currentTimeMillis();
       this.valueMetadataMap.put(key,
           new DiskBasedMap.ValueMetadata(this.filePath, valueSize, filePosition.get(), timestamp));
       byte[] serializedKey = SerializationUtils.serialize(key);

--- a/hudi-hive/src/main/java/org/apache/hudi/hive/HiveSyncConfig.java
+++ b/hudi-hive/src/main/java/org/apache/hudi/hive/HiveSyncConfig.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.hive;
 
 import com.beust.jcommander.Parameter;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;

--- a/hudi-hive/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
+++ b/hudi-hive/src/main/java/org/apache/hudi/hive/HiveSyncTool.java
@@ -18,16 +18,6 @@
 
 package org.apache.hudi.hive;
 
-import com.beust.jcommander.JCommander;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.hive.conf.HiveConf;
-import org.apache.hadoop.hive.metastore.api.Partition;
-import org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat;
-import org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe;
 import org.apache.hudi.common.util.FSUtils;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.exception.InvalidDatasetException;
@@ -36,10 +26,21 @@ import org.apache.hudi.hadoop.realtime.HoodieParquetRealtimeInputFormat;
 import org.apache.hudi.hive.HoodieHiveClient.PartitionEvent;
 import org.apache.hudi.hive.HoodieHiveClient.PartitionEvent.PartitionEventType;
 import org.apache.hudi.hive.util.SchemaUtil;
+
+import com.beust.jcommander.JCommander;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.api.Partition;
+import org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat;
+import org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.apache.parquet.schema.MessageType;
 
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Tool to sync a hoodie HDFS dataset with a hive metastore table. Either use it as a api

--- a/hudi-hive/src/main/java/org/apache/hudi/hive/HoodieHiveClient.java
+++ b/hudi-hive/src/main/java/org/apache/hudi/hive/HoodieHiveClient.java
@@ -116,10 +116,10 @@ public class HoodieHiveClient {
 
     try {
       this.partitionValueExtractor =
-              (PartitionValueExtractor) Class.forName(cfg.partitionValueExtractorClass).newInstance();
+          (PartitionValueExtractor) Class.forName(cfg.partitionValueExtractorClass).newInstance();
     } catch (Exception e) {
       throw new HoodieHiveSyncException(
-              "Failed to initialize PartitionValueExtractor class " + cfg.partitionValueExtractorClass, e);
+          "Failed to initialize PartitionValueExtractor class " + cfg.partitionValueExtractorClass, e);
     }
 
     activeTimeline = metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants();
@@ -164,7 +164,7 @@ public class HoodieHiveClient {
       String partitionClause = getPartitionClause(partition);
       String fullPartitionPath = FSUtils.getPartitionPath(syncConfig.basePath, partition).toString();
       alterSQL.append("  PARTITION (").append(partitionClause).append(") LOCATION '").append(fullPartitionPath)
-              .append("' ");
+          .append("' ");
     }
     return alterSQL.toString();
   }
@@ -178,8 +178,8 @@ public class HoodieHiveClient {
   private String getPartitionClause(String partition) {
     List<String> partitionValues = partitionValueExtractor.extractPartitionValuesInPath(partition);
     Preconditions.checkArgument(syncConfig.partitionFields.size() == partitionValues.size(),
-            "Partition key parts " + syncConfig.partitionFields + " does not match with partition values " + partitionValues
-                    + ". Check partition strategy. ");
+        "Partition key parts " + syncConfig.partitionFields + " does not match with partition values " + partitionValues
+             + ". Check partition strategy. ");
     List<String> partBuilder = new ArrayList<>();
     for (int i = 0; i < syncConfig.partitionFields.size(); i++) {
       partBuilder.add("`" + syncConfig.partitionFields.get(i) + "`=" + "'" + partitionValues.get(i) + "'");
@@ -199,7 +199,7 @@ public class HoodieHiveClient {
       String fullPartitionPath = partitionPath.toUri().getScheme().equals(StorageSchemes.HDFS.getScheme())
               ? FSUtils.getDFSFullPartitionPath(fs, partitionPath) : partitionPath.toString();
       String changePartition =
-              alterTable + " PARTITION (" + partitionClause + ") SET LOCATION '" + fullPartitionPath + "'";
+          alterTable + " PARTITION (" + partitionClause + ") SET LOCATION '" + fullPartitionPath + "'";
       changePartitions.add(changePartition);
     }
     return changePartitions;
@@ -251,8 +251,8 @@ public class HoodieHiveClient {
       // Cascade clause should not be present for non-partitioned tables
       String cascadeClause = syncConfig.partitionFields.size() > 0 ? " cascade" : "";
       StringBuilder sqlBuilder = new StringBuilder("ALTER TABLE ").append("`").append(syncConfig.databaseName)
-              .append(".").append(syncConfig.tableName).append("`").append(" REPLACE COLUMNS(").append(newSchemaStr)
-              .append(" )").append(cascadeClause);
+          .append(".").append(syncConfig.tableName).append("`").append(" REPLACE COLUMNS(").append(newSchemaStr)
+          .append(" )").append(cascadeClause);
       LOG.info("Updating table definition with " + sqlBuilder);
       updateHiveSQL(sqlBuilder.toString());
     } catch (IOException e) {
@@ -263,7 +263,7 @@ public class HoodieHiveClient {
   void createTable(MessageType storageSchema, String inputFormatClass, String outputFormatClass, String serdeClass) {
     try {
       String createSQLQuery =
-              SchemaUtil.generateCreateDDL(storageSchema, syncConfig, inputFormatClass, outputFormatClass, serdeClass);
+          SchemaUtil.generateCreateDDL(storageSchema, syncConfig, inputFormatClass, outputFormatClass, serdeClass);
       LOG.info("Creating table with " + createSQLQuery);
       updateHiveSQL(createSQLQuery);
     } catch (IOException e) {
@@ -313,10 +313,10 @@ public class HoodieHiveClient {
       final long start = System.currentTimeMillis();
       Table table = this.client.getTable(syncConfig.databaseName, syncConfig.tableName);
       Map<String, String> partitionKeysMap =
-              table.getPartitionKeys().stream().collect(Collectors.toMap(f -> f.getName(), f -> f.getType().toUpperCase()));
+          table.getPartitionKeys().stream().collect(Collectors.toMap(f -> f.getName(), f -> f.getType().toUpperCase()));
 
       Map<String, String> columnsMap =
-              table.getSd().getCols().stream().collect(Collectors.toMap(f -> f.getName(), f -> f.getType().toUpperCase()));
+          table.getSd().getCols().stream().collect(Collectors.toMap(f -> f.getName(), f -> f.getType().toUpperCase()));
 
       Map<String, String> schema = new HashMap<>();
       schema.putAll(columnsMap);
@@ -343,13 +343,13 @@ public class HoodieHiveClient {
           // If this is COW, get the last commit and read the schema from a file written in the
           // last commit
           HoodieInstant lastCommit =
-                  activeTimeline.lastInstant().orElseThrow(() -> new InvalidDatasetException(syncConfig.basePath));
+              activeTimeline.lastInstant().orElseThrow(() -> new InvalidDatasetException(syncConfig.basePath));
           HoodieCommitMetadata commitMetadata = HoodieCommitMetadata
-                  .fromBytes(activeTimeline.getInstantDetails(lastCommit).get(), HoodieCommitMetadata.class);
+              .fromBytes(activeTimeline.getInstantDetails(lastCommit).get(), HoodieCommitMetadata.class);
           String filePath = commitMetadata.getFileIdAndFullPaths(metaClient.getBasePath()).values().stream().findAny()
-                  .orElseThrow(() -> new IllegalArgumentException("Could not find any data file written for commit "
-                          + lastCommit + ", could not get schema for dataset " + metaClient.getBasePath() + ", Metadata :"
-                          + commitMetadata));
+              .orElseThrow(() -> new IllegalArgumentException("Could not find any data file written for commit "
+                  + lastCommit + ", could not get schema for dataset " + metaClient.getBasePath() + ", Metadata :"
+                  + commitMetadata));
           return readSchemaFromDataFile(new Path(filePath));
         case MERGE_ON_READ:
           // If this is MOR, depending on whether the latest commit is a delta commit or
@@ -362,10 +362,10 @@ public class HoodieHiveClient {
           Option<HoodieInstant> lastDeltaCommit;
           if (lastCompactionCommit.isPresent()) {
             lastDeltaCommit = metaClient.getActiveTimeline().getDeltaCommitTimeline().filterCompletedInstants()
-                    .findInstantsAfter(lastCompactionCommit.get().getTimestamp(), Integer.MAX_VALUE).lastInstant();
+                .findInstantsAfter(lastCompactionCommit.get().getTimestamp(), Integer.MAX_VALUE).lastInstant();
           } else {
             lastDeltaCommit =
-                    metaClient.getActiveTimeline().getDeltaCommitTimeline().filterCompletedInstants().lastInstant();
+                metaClient.getActiveTimeline().getDeltaCommitTimeline().filterCompletedInstants().lastInstant();
           }
           LOG.info("Found the last delta commit " + lastDeltaCommit);
 
@@ -373,19 +373,19 @@ public class HoodieHiveClient {
             HoodieInstant lastDeltaInstant = lastDeltaCommit.get();
             // read from the log file wrote
             commitMetadata = HoodieCommitMetadata.fromBytes(activeTimeline.getInstantDetails(lastDeltaInstant).get(),
-                    HoodieCommitMetadata.class);
+                HoodieCommitMetadata.class);
             Pair<String, HoodieFileFormat> filePathWithFormat =
-                    commitMetadata.getFileIdAndFullPaths(metaClient.getBasePath()).values().stream()
-                            .filter(s -> s.contains(HoodieLogFile.DELTA_EXTENSION)).findAny()
-                            .map(f -> Pair.of(f, HoodieFileFormat.HOODIE_LOG)).orElseGet(() -> {
+                commitMetadata.getFileIdAndFullPaths(metaClient.getBasePath()).values().stream()
+                    .filter(s -> s.contains(HoodieLogFile.DELTA_EXTENSION)).findAny()
+                    .map(f -> Pair.of(f, HoodieFileFormat.HOODIE_LOG)).orElseGet(() -> {
                       // No Log files in Delta-Commit. Check if there are any parquet files
                       return commitMetadata.getFileIdAndFullPaths(metaClient.getBasePath()).values().stream()
-                              .filter(s -> s.contains((metaClient.getTableConfig().getROFileFormat().getFileExtension())))
-                              .findAny().map(f -> Pair.of(f, HoodieFileFormat.PARQUET)).orElseThrow(() -> {
-                                return new IllegalArgumentException("Could not find any data file written for commit "
-                                        + lastDeltaInstant + ", could not get schema for dataset " + metaClient.getBasePath()
-                                        + ", CommitMetadata :" + commitMetadata);
-                              });
+                          .filter(s -> s.contains((metaClient.getTableConfig().getROFileFormat().getFileExtension())))
+                          .findAny().map(f -> Pair.of(f, HoodieFileFormat.PARQUET)).orElseThrow(() -> {
+                            return new IllegalArgumentException("Could not find any data file written for commit "
+                                + lastDeltaInstant + ", could not get schema for dataset " + metaClient.getBasePath()
+                                + ", CommitMetadata :" + commitMetadata);
+                          });
                     });
             switch (filePathWithFormat.getRight()) {
               case HOODIE_LOG:
@@ -394,7 +394,7 @@ public class HoodieHiveClient {
                 return readSchemaFromDataFile(new Path(filePathWithFormat.getLeft()));
               default:
                 throw new IllegalArgumentException("Unknown file format :" + filePathWithFormat.getRight()
-                        + " for file " + filePathWithFormat.getLeft());
+                    + " for file " + filePathWithFormat.getLeft());
             }
           } else {
             return readSchemaFromLastCompaction(lastCompactionCommit);
@@ -414,14 +414,14 @@ public class HoodieHiveClient {
   @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
   private MessageType readSchemaFromLastCompaction(Option<HoodieInstant> lastCompactionCommitOpt) throws IOException {
     HoodieInstant lastCompactionCommit = lastCompactionCommitOpt.orElseThrow(() -> new HoodieHiveSyncException(
-            "Could not read schema from last compaction, no compaction commits found on path " + syncConfig.basePath));
+        "Could not read schema from last compaction, no compaction commits found on path " + syncConfig.basePath));
 
     // Read from the compacted file wrote
     HoodieCommitMetadata compactionMetadata = HoodieCommitMetadata
-            .fromBytes(activeTimeline.getInstantDetails(lastCompactionCommit).get(), HoodieCommitMetadata.class);
+        .fromBytes(activeTimeline.getInstantDetails(lastCompactionCommit).get(), HoodieCommitMetadata.class);
     String filePath = compactionMetadata.getFileIdAndFullPaths(metaClient.getBasePath()).values().stream().findAny()
-            .orElseThrow(() -> new IllegalArgumentException("Could not find any data file written for compaction "
-                    + lastCompactionCommit + ", could not get schema for dataset " + metaClient.getBasePath()));
+        .orElseThrow(() -> new IllegalArgumentException("Could not find any data file written for compaction "
+            + lastCompactionCommit + ", could not get schema for dataset " + metaClient.getBasePath()));
     return readSchemaFromDataFile(new Path(filePath));
   }
 
@@ -430,7 +430,7 @@ public class HoodieHiveClient {
    */
   @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
   private MessageType readSchemaFromLogFile(Option<HoodieInstant> lastCompactionCommitOpt, Path path)
-          throws IOException {
+      throws IOException {
     MessageType messageType = SchemaUtil.readSchemaFromLogFile(fs, path);
     // Fall back to read the schema from last compaction
     if (messageType == null) {
@@ -450,7 +450,7 @@ public class HoodieHiveClient {
               "Failed to read schema from data file " + parquetFilePath + ". File does not exist.");
     }
     ParquetMetadata fileFooter =
-            ParquetFileReader.readFooter(fs.getConf(), parquetFilePath, ParquetMetadataConverter.NO_FILTER);
+        ParquetFileReader.readFooter(fs.getConf(), parquetFilePath, ParquetMetadataConverter.NO_FILTER);
     return fileFooter.getFileMetaData().getSchema();
   }
 

--- a/hudi-hive/src/main/java/org/apache/hudi/hive/HoodieHiveClient.java
+++ b/hudi-hive/src/main/java/org/apache/hudi/hive/HoodieHiveClient.java
@@ -179,7 +179,7 @@ public class HoodieHiveClient {
     List<String> partitionValues = partitionValueExtractor.extractPartitionValuesInPath(partition);
     Preconditions.checkArgument(syncConfig.partitionFields.size() == partitionValues.size(),
         "Partition key parts " + syncConfig.partitionFields + " does not match with partition values " + partitionValues
-             + ". Check partition strategy. ");
+            + ". Check partition strategy. ");
     List<String> partBuilder = new ArrayList<>();
     for (int i = 0; i < syncConfig.partitionFields.size(); i++) {
       partBuilder.add("`" + syncConfig.partitionFields.get(i) + "`=" + "'" + partitionValues.get(i) + "'");
@@ -215,7 +215,7 @@ public class HoodieHiveClient {
       List<String> hivePartitionValues = tablePartition.getValues();
       Collections.sort(hivePartitionValues);
       String fullTablePartitionPath =
-              Path.getPathWithoutSchemeAndAuthority(new Path(tablePartition.getSd().getLocation())).toUri().getPath();
+          Path.getPathWithoutSchemeAndAuthority(new Path(tablePartition.getSd().getLocation())).toUri().getPath();
       paths.put(String.join(", ", hivePartitionValues), fullTablePartitionPath);
     }
 
@@ -278,7 +278,7 @@ public class HoodieHiveClient {
     if (syncConfig.useJdbc) {
       if (!doesTableExist()) {
         throw new IllegalArgumentException(
-                "Failed to get schema for table " + syncConfig.tableName + " does not exist");
+            "Failed to get schema for table " + syncConfig.tableName + " does not exist");
       }
       Map<String, String> schema = Maps.newHashMap();
       ResultSet result = null;
@@ -356,7 +356,7 @@ public class HoodieHiveClient {
           // compaction commit
           // Get a datafile written and get the schema from that file
           Option<HoodieInstant> lastCompactionCommit =
-                  metaClient.getActiveTimeline().getCommitTimeline().filterCompletedInstants().lastInstant();
+              metaClient.getActiveTimeline().getCommitTimeline().filterCompletedInstants().lastInstant();
           LOG.info("Found the last compaction commit as " + lastCompactionCommit);
 
           Option<HoodieInstant> lastDeltaCommit;
@@ -447,7 +447,7 @@ public class HoodieHiveClient {
     LOG.info("Reading schema from " + parquetFilePath);
     if (!fs.exists(parquetFilePath)) {
       throw new IllegalArgumentException(
-              "Failed to read schema from data file " + parquetFilePath + ". File does not exist.");
+          "Failed to read schema from data file " + parquetFilePath + ". File does not exist.");
     }
     ParquetMetadata fileFooter =
         ParquetFileReader.readFooter(fs.getConf(), parquetFilePath, ParquetMetadataConverter.NO_FILTER);

--- a/hudi-hive/src/main/java/org/apache/hudi/hive/MultiPartKeysValueExtractor.java
+++ b/hudi-hive/src/main/java/org/apache/hudi/hive/MultiPartKeysValueExtractor.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.hive;
 
 import com.google.common.base.Preconditions;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/hudi-hive/src/main/java/org/apache/hudi/hive/SchemaDifference.java
+++ b/hudi-hive/src/main/java/org/apache/hudi/hive/SchemaDifference.java
@@ -23,9 +23,10 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import org.apache.parquet.schema.MessageType;
+
 import java.util.List;
 import java.util.Map;
-import org.apache.parquet.schema.MessageType;
 
 /**
  * Represents the schema difference between the storage schema and hive table schema

--- a/hudi-hive/src/main/java/org/apache/hudi/hive/SlashEncodedDayPartitionValueExtractor.java
+++ b/hudi-hive/src/main/java/org/apache/hudi/hive/SlashEncodedDayPartitionValueExtractor.java
@@ -19,10 +19,11 @@
 package org.apache.hudi.hive;
 
 import com.beust.jcommander.internal.Lists;
-import java.util.List;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
+
+import java.util.List;
 
 /**
  * HDFS Path contain hive partition values for the keys it is partitioned on. This mapping is not straight forward and

--- a/hudi-hive/src/main/java/org/apache/hudi/hive/util/ColumnNameXLator.java
+++ b/hudi-hive/src/main/java/org/apache/hudi/hive/util/ColumnNameXLator.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.hive.util;
 
 import com.google.common.collect.Maps;
+
 import java.util.Iterator;
 import java.util.Map;
 

--- a/hudi-hive/src/main/java/org/apache/hudi/hive/util/SchemaUtil.java
+++ b/hudi-hive/src/main/java/org/apache/hudi/hive/util/SchemaUtil.java
@@ -18,16 +18,6 @@
 
 package org.apache.hudi.hive.util;
 
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
 import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.table.log.HoodieLogFormat;
 import org.apache.hudi.common.table.log.HoodieLogFormat.Reader;
@@ -36,6 +26,11 @@ import org.apache.hudi.common.table.log.block.HoodieLogBlock;
 import org.apache.hudi.hive.HiveSyncConfig;
 import org.apache.hudi.hive.HoodieHiveSyncException;
 import org.apache.hudi.hive.SchemaDifference;
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.apache.parquet.avro.AvroSchemaConverter;
@@ -45,6 +40,13 @@ import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.OriginalType;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Type;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Schema Utilities

--- a/hudi-hive/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
+++ b/hudi-hive/src/test/java/org/apache/hudi/hive/TestHiveSyncTool.java
@@ -18,22 +18,14 @@
 
 package org.apache.hudi.hive;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
-import com.google.common.collect.Lists;
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.common.util.SchemaTestUtil;
 import org.apache.hudi.hive.HoodieHiveClient.PartitionEvent;
 import org.apache.hudi.hive.HoodieHiveClient.PartitionEvent.PartitionEventType;
 import org.apache.hudi.hive.util.SchemaUtil;
+
+import com.google.common.collect.Lists;
+import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.OriginalType;
 import org.apache.parquet.schema.PrimitiveType;
@@ -44,6 +36,16 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 @SuppressWarnings("ConstantConditions")
 @RunWith(Parameterized.class)

--- a/hudi-hive/src/test/java/org/apache/hudi/hive/TestUtil.java
+++ b/hudi-hive/src/test/java/org/apache/hudi/hive/TestUtil.java
@@ -18,29 +18,6 @@
 
 package org.apache.hudi.hive;
 
-import static org.junit.Assert.fail;
-
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
-import java.io.File;
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.nio.charset.StandardCharsets;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.UUID;
-import org.apache.avro.Schema;
-import org.apache.avro.generic.IndexedRecord;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FSDataOutputStream;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hdfs.MiniDFSCluster;
-import org.apache.hadoop.hive.conf.HiveConf;
-import org.apache.hive.service.server.HiveServer2;
 import org.apache.hudi.avro.HoodieAvroWriteSupport;
 import org.apache.hudi.common.BloomFilter;
 import org.apache.hudi.common.minicluster.HdfsTestService;
@@ -63,6 +40,19 @@ import org.apache.hudi.common.util.FSUtils;
 import org.apache.hudi.common.util.FileIOUtils;
 import org.apache.hudi.common.util.SchemaTestUtil;
 import org.apache.hudi.hive.util.HiveTestService;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.IndexedRecord;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hive.service.server.HiveServer2;
 import org.apache.parquet.avro.AvroSchemaConverter;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
@@ -71,6 +61,18 @@ import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 import org.junit.runners.model.InitializationError;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.Assert.fail;
 
 @SuppressWarnings("SameParameterValue")
 public class TestUtil {

--- a/hudi-hive/src/test/java/org/apache/hudi/hive/util/HiveTestService.java
+++ b/hudi-hive/src/test/java/org/apache/hudi/hive/util/HiveTestService.java
@@ -18,16 +18,12 @@
 
 package org.apache.hudi.hive.util;
 
+import org.apache.hudi.common.model.HoodieTestUtils;
+import org.apache.hudi.common.util.FileIOUtils;
+
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import com.google.common.io.Files;
-import java.io.File;
-import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.net.SocketException;
-import java.util.Map;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -39,8 +35,6 @@ import org.apache.hadoop.hive.metastore.TUGIBasedProcessor;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.thrift.TUGIContainingTransport;
 import org.apache.hive.service.server.HiveServer2;
-import org.apache.hudi.common.model.HoodieTestUtils;
-import org.apache.hudi.common.util.FileIOUtils;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.apache.thrift.TProcessor;
@@ -54,6 +48,14 @@ import org.apache.thrift.transport.TSocket;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportException;
 import org.apache.thrift.transport.TTransportFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.SocketException;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 public class HiveTestService {
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/adhoc/UpgradePayloadFromUberToApache.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/adhoc/UpgradePayloadFromUberToApache.java
@@ -80,7 +80,7 @@ public class UpgradePayloadFromUberToApache implements Serializable {
               newPropsMap.put(HoodieCompactionConfig.PAYLOAD_CLASS_PROP, newPayloadClass);
               Properties props = new Properties();
               props.putAll(newPropsMap);
-              tableConfig.createHoodieProperties(metaClient.getFs(), new Path(metaPath), props);
+              HoodieTableConfig.createHoodieProperties(metaClient.getFs(), new Path(metaPath), props);
               logger.info("Finished upgrade for " + basePath);
             }
           }

--- a/style/checkstyle.xml
+++ b/style/checkstyle.xml
@@ -34,7 +34,7 @@
 <module name = "Checker">
     <property name="charset" value="UTF-8"/>
 
-    <property name="severity" value="warning"/>
+    <property name="severity" value="error"/>
 
     <property name="fileExtensions" value="java, properties, xml"/>
     <!-- Checks for whitespace                               -->


### PR DESCRIPTION
## What is the purpose of the pull request

Refactor hudi-hive based on new ImportOrder code style rule

## Brief change log

  - Refactor hudi-hive based on new ImportOrder code style rule.
  - Change severity of checkstyle.xml file to `error`.
  - Fix some other minor hotfixs.

## Verify this pull request

This pull request is a code cleanup without any test coverage.

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [x] CI is green

 - [x] Necessary doc changes done or have another open PR
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.