### PR TITLE
[HUDI-372] Support the shortName for Hudi DataSource

### DIFF
--- a/hudi-spark/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
+++ b/hudi-spark/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
@@ -1,1 +1,19 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
 org.apache.hudi.DefaultSource

--- a/hudi-spark/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
+++ b/hudi-spark/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
@@ -15,5 +15,4 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-
 org.apache.hudi.DefaultSource

--- a/hudi-spark/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
+++ b/hudi-spark/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
@@ -15,4 +15,6 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+
+
 org.apache.hudi.DefaultSource

--- a/hudi-spark/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
+++ b/hudi-spark/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
@@ -1,0 +1,1 @@
+org.apache.hudi.DefaultSource

--- a/hudi-spark/src/main/scala/org/apache/hudi/DefaultSource.scala
+++ b/hudi-spark/src/main/scala/org/apache/hudi/DefaultSource.scala
@@ -104,5 +104,5 @@ class DefaultSource extends RelationProvider
       outputMode)
   }
 
-  override def shortName(): String = "hoodie"
+  override def shortName(): String = "hudi"
 }

--- a/hudi-spark/src/test/scala/TestDataSource.scala
+++ b/hudi-spark/src/test/scala/TestDataSource.scala
@@ -73,8 +73,6 @@ class TestDataSource extends AssertionsForJUnit {
       .mode(SaveMode.Overwrite)
       .save(basePath)
 
-    println(basePath)
-
     assertTrue(HoodieDataSourceHelpers.hasNewCommits(fs, basePath, "000"))
   }
 

--- a/hudi-spark/src/test/scala/TestDataSource.scala
+++ b/hudi-spark/src/test/scala/TestDataSource.scala
@@ -63,6 +63,21 @@ class TestDataSource extends AssertionsForJUnit {
     fs = FSUtils.getFs(basePath, spark.sparkContext.hadoopConfiguration)
   }
 
+  @Test def testShotNameStorage() {
+    // Insert Operation
+    val records = DataSourceTestUtils.convertToStringList(dataGen.generateInserts("000", 100)).toList
+    val inputDF: Dataset[Row] = spark.read.json(spark.sparkContext.parallelize(records, 2))
+    inputDF.write.format("hudi")
+      .options(commonOpts)
+      .option(DataSourceWriteOptions.OPERATION_OPT_KEY, DataSourceWriteOptions.INSERT_OPERATION_OPT_VAL)
+      .mode(SaveMode.Overwrite)
+      .save(basePath)
+
+    println(basePath)
+
+    assertTrue(HoodieDataSourceHelpers.hasNewCommits(fs, basePath, "000"))
+  }
+
   @Test def testCopyOnWriteStorage() {
     // Insert Operation
     val records1 = DataSourceTestUtils.convertToStringList(dataGen.generateInserts("000", 100)).toList

--- a/hudi-spark/src/test/scala/TestDataSource.scala
+++ b/hudi-spark/src/test/scala/TestDataSource.scala
@@ -63,7 +63,7 @@ class TestDataSource extends AssertionsForJUnit {
     fs = FSUtils.getFs(basePath, spark.sparkContext.hadoopConfiguration)
   }
 
-  @Test def testShotNameStorage() {
+  @Test def testShortNameStorage() {
     // Insert Operation
     val records = DataSourceTestUtils.convertToStringList(dataGen.generateInserts("000", 100)).toList
     val inputDF: Dataset[Row] = spark.read.json(spark.sparkContext.parallelize(records, 2))


### PR DESCRIPTION
## What is the purpose of the pull request

Support the shortName for Hudi DataSouce, we can use shortName like

```
${SPARK_HOME}/bin/spark-shell \
--jars `ls packaging/hudi-spark-bundle/target/hudi-spark-bundle-*.*.*-SNAPSHOT.jar` \
--conf 'spark.serializer=org.apache.spark.serializer.KryoSerializer'

import scala.collection.JavaConversions._
import org.apache.spark.sql.SaveMode._
import org.apache.hudi.DataSourceReadOptions._
import org.apache.hudi.DataSourceWriteOptions._
import org.apache.hudi.config.HoodieWriteConfig._

val tableName = "tmp"
val basePath = "file:///tmp/tmp"

var datas = List("{ \"data\": \"aaaaa\", \"time\": 1574297893836 }");
val df = spark.read.json(spark.sparkContext.parallelize(datas, 2))
df.write.format("hudi").
    option(RECORDKEY_FIELD_OPT_KEY, "data").
    option(PRECOMBINE_FIELD_OPT_KEY, "time").
    option(TABLE_NAME, "tmp").
    mode(Append).
    save(basePath);

spark.read.format("hudi").
    load(basePath + "/*").
    registerTempTable("hudi_ro_table")

spark.sql("select * from hudi_ro_table").show()
```

## Brief change log

  - Add org.apache.spark.sql.sources.DataSourceRegister to META-INF/services
  - Add test

## Verify this pull request

This pull request is already covered by existing tests, such as `TestDataSource#testShotNameStorage`.

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [x] CI is green

 - [x] Necessary doc changes done or have another open PR
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.