### PR TITLE
[DOCS] Remove {#building-hudi} in reademe doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Hudi provides the ability to query via three types of views:
 
 Learn more about Hudi at [https://hudi.apache.org](https://hudi.apache.org)
 
-## Building Apache Hudi from source {#building-hudi}
+## Building Apache Hudi from source
 
 Prerequisites for building Apache Hudi:
 


### PR DESCRIPTION
## What is the purpose of the pull request

This a follow fix under #1058, remove `{#building-hudi}`

## Brief change log

  - Remove `{#building-hudi}`

## Verify this pull request

This pull request is code cleanup without any test coverage.

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [x] CI is green

 - [x] Necessary doc changes done or have another open PR
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.