### PR TITLE
[HUDI-387] Fix NPE when create savepoint via hudi-cli

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/utils/SparkUtil.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/utils/SparkUtil.java
@@ -61,10 +61,14 @@ public class SparkUtil {
 
   public static JavaSparkContext initJavaSparkConf(String name) {
     SparkConf sparkConf = new SparkConf().setAppName(name);
-    String defMasterFromEnv = sparkConf.get("spark.master");
+
+    String defMasterFromEnv = sparkConf.getenv("SPARK_MASTER");
     if ((null == defMasterFromEnv) || (defMasterFromEnv.isEmpty())) {
       sparkConf.setMaster(DEFUALT_SPARK_MASTER);
+    } else {
+      sparkConf.setMaster(defMasterFromEnv);
     }
+
     sparkConf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer");
     sparkConf.set("spark.driver.maxResultSize", "2g");
     sparkConf.set("spark.eventLog.overwrite", "true");


### PR DESCRIPTION
## What is the purpose of the pull request

Fix NPE when create savepoint via hudi-cli

```
java.lang.NullPointerException
    at org.apache.hudi.AbstractHoodieClient.<init>(AbstractHoodieClient.java:68)
    at org.apache.hudi.HoodieWriteClient.<init>(HoodieWriteClient.java:133)
    at org.apache.hudi.HoodieWriteClient.<init>(HoodieWriteClient.java:128)
    at org.apache.hudi.HoodieWriteClient.<init>(HoodieWriteClient.java:123)
    at org.apache.hudi.cli.commands.SavepointsCommand.createHoodieClient(SavepointsCommand.java:143)
    at org.apache.hudi.cli.commands.SavepointsCommand.savepoint(SavepointsCommand.java:98)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    at org.springframework.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:216)
    at org.springframework.shell.core.SimpleExecutionStrategy.invoke(SimpleExecutionStrategy.java:68)
    at org.springframework.shell.core.SimpleExecutionStrategy.execute(SimpleExecutionStrategy.java:59)
    at org.springframework.shell.core.AbstractShell.executeCommand(AbstractShell.java:134)
    at org.springframework.shell.core.JLineShell.promptLoop(JLineShell.java:533)
    at org.springframework.shell.core.JLineShell.run(JLineShell.java:179)
    at java.lang.Thread.run(Thread.java:748)
```

```
Command failed java.util.NoSuchElementException: spark.master
spark.master
java.util.NoSuchElementException: spark.master
    at org.apache.spark.SparkConf$$anonfun$get$1.apply(SparkConf.scala:243)
    at org.apache.spark.SparkConf$$anonfun$get$1.apply(SparkConf.scala:243)
    at scala.Option.getOrElse(Option.scala:121)
    at org.apache.spark.SparkConf.get(SparkConf.scala:243)
    at org.apache.hudi.cli.utils.SparkUtil.initJavaSparkConf(SparkUtil.java:64)
    at org.apache.hudi.cli.commands.SavepointsCommand.savepoint(SavepointsCommand.java:98)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    at org.springframework.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:216)
    at org.springframework.shell.core.SimpleExecutionStrategy.invoke(SimpleExecutionStrategy.java:68)
    at org.springframework.shell.core.SimpleExecutionStrategy.execute(SimpleExecutionStrategy.java:59)
    at org.springframework.shell.core.AbstractShell.executeCommand(AbstractShell.java:134)
    at org.springframework.shell.core.JLineShell.promptLoop(JLineShell.java:533)
    at org.springframework.shell.core.JLineShell.run(JLineShell.java:179)
    at java.lang.Thread.run(Thread.java:748)
```

## Brief change log

  - init JavaSparkContext by SparkUtil

## Verify this pull request

Verify by follow steps by hudi-cli

```
export SPARK_MASTER=local

connect --path file:///tmp/hudi_cow_table

savepoint create --commit "20191207003200" 
```

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.