### PR TITLE
[HUDI-390] Add backtick character in hive queries to support hive identiter as tablename

### DIFF
--- a/hudi-hive/src/main/java/org/apache/hudi/hive/util/SchemaUtil.java
+++ b/hudi-hive/src/main/java/org/apache/hudi/hive/util/SchemaUtil.java
@@ -54,6 +54,7 @@ import java.util.stream.Collectors;
 public class SchemaUtil {
 
   private static final Logger LOG = LogManager.getLogger(SchemaUtil.class);
+  public static final String HIVE_ESCAPE_CHARACTER = "`";
 
   /**
    * Get the schema difference between the storage schema and hive table schema.
@@ -402,7 +403,8 @@ public class SchemaUtil {
 
     String partitionsStr = partitionFields.stream().collect(Collectors.joining(","));
     StringBuilder sb = new StringBuilder("CREATE EXTERNAL TABLE  IF NOT EXISTS ");
-    sb = sb.append(config.databaseName).append(".").append(config.tableName);
+    sb = sb.append(HIVE_ESCAPE_CHARACTER).append(config.databaseName).append(HIVE_ESCAPE_CHARACTER)
+            .append(".").append(HIVE_ESCAPE_CHARACTER).append(config.tableName).append(HIVE_ESCAPE_CHARACTER);
     sb = sb.append("( ").append(columns).append(")");
     if (!config.partitionFields.isEmpty()) {
       sb = sb.append(" PARTITIONED BY (").append(partitionsStr).append(")");


### PR DESCRIPTION
## What is the purpose of the pull request
This pull request adds support for keyword as tablename in hive sync 

## Brief change log
 - Add back tick character to escape keywords in hive queries

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [x] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.