### PR TITLE
[WIP] [HUDI-375] Refactor the configure framework of hudi project

### DIFF
--- a/hudi-client/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -768,4 +768,113 @@ public class HoodieWriteConfig extends DefaultHoodieConfig {
       return config;
     }
   }
+
+  /**
+   * ConfigOption Part.
+   *
+   */
+  public void setString(ConfigOption<String> option, String value) {
+    Objects.requireNonNull(option);
+    Objects.requireNonNull(value);
+
+    setValueInternal(option.key(), value);
+  }
+
+  public void setInteger(ConfigOption<Integer> option, Integer value) {
+    Objects.requireNonNull(option);
+    Objects.requireNonNull(value);
+
+    setValueInternal(option.key(), value);
+  }
+
+  public void setBoolean(ConfigOption<Boolean> option, Boolean value) {
+    Objects.requireNonNull(option);
+    Objects.requireNonNull(value);
+
+    setValueInternal(option.key(), value);
+  }
+
+  private <T> void setValueInternal(String key, T value) {
+    synchronized (this.props) {
+      this.props.put(key, value);
+    }
+  }
+
+  public String getString(String key) {
+    Object rawValue = getRawValue(key);
+    return convertToString(rawValue, null);
+  }
+
+  public String getString(ConfigOption<String> configOption) {
+    Object rawValue = getRawValue(configOption.key());
+    return convertToString(rawValue, configOption.defaultValue());
+  }
+
+  public Integer getInteger(String key) {
+    Object rawValue = getRawValue(key);
+    return convertToInt(rawValue, null);
+  }
+
+  public Integer getInteger(ConfigOption<Integer> configOption) {
+    Object rawValue = getRawValue(configOption.key());
+    return convertToInt(rawValue, configOption.defaultValue());
+  }
+
+  public Integer getBoolean(String key) {
+    Object rawValue = getRawValue(key);
+    return convertToInt(rawValue, null);
+  }
+
+  public Boolean getBoolean(ConfigOption<Boolean> configOption) {
+    Object rawValue = getRawValue(configOption.key());
+    return convertToBoolean(rawValue, configOption.defaultValue());
+  }
+
+  private Object getRawValue(String key) {
+    if (key == null) {
+      throw new NullPointerException("Key must not be null.");
+    }
+
+    synchronized (this.props) {
+      return this.props.get(key);
+    }
+  }
+
+  // --------------------------------------------------------------------------------------------
+
+  private String convertToString(Object obj, String defaultValue) {
+    return obj != null ? obj.toString() : defaultValue;
+  }
+
+  private Integer convertToInt(Object obj, Integer defaultValue) {
+    if (obj == null) {
+      return defaultValue;
+    }
+
+    try {
+      return Integer.parseInt(obj.toString());
+    } catch (NumberFormatException e) {
+      return defaultValue;
+    }
+  }
+
+  private Boolean convertToBoolean(Object obj, Boolean defaultValue) {
+    if (obj == null) {
+      return defaultValue;
+    }
+
+    if (obj.getClass() == Boolean.class) {
+      return (Boolean) obj;
+    }
+
+    switch (obj.toString().trim().toUpperCase()) {
+      case "TRUE":
+        return true;
+      case "FALSE":
+        return false;
+      default:
+        return defaultValue;
+    }
+  }
+
 }

--- a/hudi-common/src/main/java/org/apache/hudi/config/ConfigOption.java
+++ b/hudi-common/src/main/java/org/apache/hudi/config/ConfigOption.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.config;
+
+import java.util.Objects;
+
+/**
+ * A ConfigOption contains the key and an optional default value.
+ *
+ * @param <T> The type of the default value.
+ */
+public class ConfigOption<T> {
+
+  private final String key;
+
+  private final T defaultValue;
+
+  ConfigOption(String key, T defaultValue) {
+    this.key = Objects.requireNonNull(key);
+    this.defaultValue = Objects.requireNonNull(defaultValue);
+  }
+
+  public String key() {
+    return key;
+  }
+
+  public T defaultValue() {
+    return defaultValue;
+  }
+
+  /**
+   * Create a OptionBuilder with key.
+   *
+   * @param key The key of the option
+   * @return Return a OptionBuilder.
+   */
+  public static ConfigOption.OptionBuilder key(String key) {
+    Objects.requireNonNull(key);
+    return new ConfigOption.OptionBuilder(key);
+  }
+
+  /**
+   * The OptionBuilder is used to build the ConfigOption.
+   */
+  public static final class OptionBuilder {
+
+    private final String key;
+
+    OptionBuilder(String key) {
+      this.key = key;
+    }
+
+    public <T> ConfigOption<T> defaultValue(T value) {
+      Objects.requireNonNull(value);
+      return new ConfigOption<>(key, value);
+    }
+  }
+}


### PR DESCRIPTION
## What is the purpose of the pull request

Currently, many configuration items and their default values are dispersed in the config file like HoodieWriteConfig. It’s very confused for developers, and it's easy for developers to use them in a wrong place especially when there are more and more configuration items. If we can solve this, developers will benefit from it and the code structure will be more concise. 

More details
[1] https://issues.apache.org/jira/projects/HUDI/issues/HUDI-375
[2] https://cwiki.apache.org/confluence/display/HUDI/RFC-11+%3A+Refactor+of+the+configuration+framework+of+hudi+project

## Brief change log

  - Add ConfigOption
  - Modify HoodieWriteConfig
  - Make graphite metrics reporter as a demo

## Verify this pull request

This pull request is code cleanup without any test coverage.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.