### PR TITLE
[HUDI-398]Add set env for spark launcher

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/SetSparkEnvCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/SetSparkEnvCommand.java
@@ -39,7 +39,7 @@ public class SetSparkEnvCommand implements CommandMarker {
       throws IllegalArgumentException {
     String[] map = confMap.split("=");
     if (map.length != 2) {
-      throw new IllegalArgumentException("Illegal set parameter, please use like [set SPARK_HOME=/usr/etc/spark]'");
+      throw new IllegalArgumentException("Illegal set parameter, please use like [set --conf SPARK_HOME=/usr/etc/spark]");
     }
     env.put(map[0].trim(), map[1].trim());
   }

--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/SetSparkEnvCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/SetSparkEnvCommand.java
@@ -18,6 +18,8 @@
 
 package org.apache.hudi.cli.commands;
 
+import org.apache.hudi.cli.HoodiePrintHelper;
+
 import org.springframework.shell.core.CommandMarker;
 import org.springframework.shell.core.annotation.CliCommand;
 import org.springframework.shell.core.annotation.CliOption;
@@ -32,7 +34,7 @@ import java.util.Map;
 @Component
 public class SetSparkEnvCommand implements CommandMarker {
 
-  public static Map env = new HashMap<String, String>();
+  public static Map<String, String> env = new HashMap<String, String>();
 
   @CliCommand(value = "set", help = "Set spark launcher env to cli")
   public void setEnv(@CliOption(key = {"conf"}, help = "Env config to be set") final String confMap)
@@ -42,5 +44,25 @@ public class SetSparkEnvCommand implements CommandMarker {
       throw new IllegalArgumentException("Illegal set parameter, please use like [set --conf SPARK_HOME=/usr/etc/spark]");
     }
     env.put(map[0].trim(), map[1].trim());
+  }
+
+  @CliCommand(value = "show env all", help = "Show spark launcher envs")
+  public String showAllEnv() {
+    String[][] rows = new String[env.size()][2];
+    int i = 0;
+    for (String key: env.keySet()) {
+      rows[i] = new String[]{key, env.get(key)};
+      i++;
+    }
+    return HoodiePrintHelper.print(new String[] {"key", "value"}, rows);
+  }
+
+  @CliCommand(value = "show env", help = "Show spark launcher env by key")
+  public String showEnvByKey(@CliOption(key = {"key"}, help = "Which env conf want to show") final String key) {
+    if (key == null || key.isEmpty()) {
+      return showAllEnv();
+    } else {
+      return HoodiePrintHelper.print(new String[] {"key", "value"}, new String[][]{new String[]{key, env.get(key)}});
+    }
   }
 }

--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/SetSparkEnvCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/SetSparkEnvCommand.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.cli.commands;
+
+import org.springframework.shell.core.CommandMarker;
+import org.springframework.shell.core.annotation.CliCommand;
+import org.springframework.shell.core.annotation.CliOption;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * CLI command to set env.
+ */
+@Component
+public class SetSparkEnvCommand implements CommandMarker {
+
+  public static Map env = new HashMap<String, String>();
+
+  @CliCommand(value = "set", help = "Set spark launcher env to cli")
+  public void setEnv(@CliOption(key = {"conf"}, help = "Env config to be set") final String confMap)
+      throws IllegalArgumentException {
+    String[] map = confMap.split("=");
+    if (map.length != 2) {
+      throw new IllegalArgumentException("Illegal set parameter, please use like [set SPARK_HOME=/usr/etc/spark]'");
+    }
+    env.put(map[0].trim(), map[1].trim());
+  }
+}

--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/SparkEnvCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/SparkEnvCommand.java
@@ -29,10 +29,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * CLI command to set env.
+ * CLI command to set and show spark launcher init env.
  */
 @Component
-public class SetSparkEnvCommand implements CommandMarker {
+public class SparkEnvCommand implements CommandMarker {
 
   public static Map<String, String> env = new HashMap<String, String>();
 

--- a/hudi-cli/src/main/java/org/apache/hudi/cli/utils/SparkUtil.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/utils/SparkUtil.java
@@ -19,7 +19,7 @@
 package org.apache.hudi.cli.utils;
 
 import org.apache.hudi.HoodieWriteClient;
-import org.apache.hudi.cli.commands.SetSparkEnvCommand;
+import org.apache.hudi.cli.commands.SparkEnvCommand;
 import org.apache.hudi.cli.commands.SparkMain;
 import org.apache.hudi.common.util.FSUtils;
 import org.apache.hudi.common.util.StringUtils;
@@ -47,7 +47,7 @@ public class SparkUtil {
   public static SparkLauncher initLauncher(String propertiesFile) throws URISyntaxException {
     String currentJar = new File(SparkUtil.class.getProtectionDomain().getCodeSource().getLocation().toURI().getPath())
         .getAbsolutePath();
-    Map<String, String> env = SetSparkEnvCommand.env;
+    Map<String, String> env = SparkEnvCommand.env;
     SparkLauncher sparkLauncher =
         new SparkLauncher(env).setAppResource(currentJar).setMainClass(SparkMain.class.getName());
 

--- a/hudi-cli/src/main/java/org/apache/hudi/cli/utils/SparkUtil.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/utils/SparkUtil.java
@@ -19,6 +19,7 @@
 package org.apache.hudi.cli.utils;
 
 import org.apache.hudi.HoodieWriteClient;
+import org.apache.hudi.cli.commands.SetSparkEnvCommand;
 import org.apache.hudi.cli.commands.SparkMain;
 import org.apache.hudi.common.util.FSUtils;
 import org.apache.hudi.common.util.StringUtils;
@@ -30,6 +31,7 @@ import org.apache.spark.launcher.SparkLauncher;
 
 import java.io.File;
 import java.net.URISyntaxException;
+import java.util.Map;
 
 /**
  * Utility functions dealing with Spark.
@@ -45,13 +47,13 @@ public class SparkUtil {
   public static SparkLauncher initLauncher(String propertiesFile) throws URISyntaxException {
     String currentJar = new File(SparkUtil.class.getProtectionDomain().getCodeSource().getLocation().toURI().getPath())
         .getAbsolutePath();
+    Map<String, String> env = SetSparkEnvCommand.env;
     SparkLauncher sparkLauncher =
-        new SparkLauncher().setAppResource(currentJar).setMainClass(SparkMain.class.getName());
+        new SparkLauncher(env).setAppResource(currentJar).setMainClass(SparkMain.class.getName());
 
     if (!StringUtils.isNullOrEmpty(propertiesFile)) {
       sparkLauncher.setPropertiesFile(propertiesFile);
     }
-
     File libDirectory = new File(new File(currentJar).getParent(), "lib");
     for (String library : libDirectory.list()) {
       sparkLauncher.addJar(new File(libDirectory, library).getAbsolutePath());


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

*It always throw exception `SPAR_HOEM not found` when SPARK_HOME is not set, so we need quit and set it.
```
hudi:hudi_cow_table->commit rollback --commit 20191210155859
Command failed java.lang.IllegalStateException: Spark home not found; set it explicitly or use the SPARK_HOME environment variable.
Listening for transport dt_socket at address: 5005
Spark home not found; set it explicitly or use the SPARK_HOME environment variable.
java.lang.IllegalStateException: Spark home not found; set it explicitly or use the SPARK_HOME environment variable.
    at org.apache.spark.launcher.CommandBuilderUtils.checkState(CommandBuilderUtils.java:248)
    at org.apache.spark.launcher.AbstractCommandBuilder.getSparkHome(AbstractCommandBuilder.java:248)
```
After add this function for cli, we can type SPARK_HOEM and other conf on hudi-CLI:
`[hudi->set --conf SPARK_HOME=/usr/bch/3.0.1/spark`
*

## Brief change log

*(for example:)*
  - *add a new cli command to set conf for spark launcher*

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.