### PR TITLE
[HUDI-401]Remove unnecessary use of spark in savepoint timeline

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/SavepointsCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/SavepointsCommand.java
@@ -30,7 +30,7 @@ import org.apache.hudi.config.HoodieIndexConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.index.HoodieIndex;
 
-import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.launcher.SparkLauncher;
 import org.springframework.shell.core.CommandMarker;
 import org.springframework.shell.core.annotation.CliAvailabilityIndicator;
@@ -95,8 +95,7 @@ public class SavepointsCommand implements CommandMarker {
       return "Commit " + commitTime + " not found in Commits " + timeline;
     }
 
-    JavaSparkContext jsc = SparkUtil.initJavaSparkConf("Create Savepoint");
-    HoodieWriteClient client = createHoodieClient(jsc, HoodieCLI.tableMetadata.getBasePath());
+    HoodieWriteClient client = createHoodieClient(new Configuration(), HoodieCLI.tableMetadata.getBasePath());
     String result;
     if (client.savepoint(commitTime, user, comments)) {
       // Refresh the current
@@ -105,7 +104,6 @@ public class SavepointsCommand implements CommandMarker {
     } else {
       result = String.format("Failed: Could not savepoint commit \"%s\".", commitTime);
     }
-    jsc.close();
     return result;
   }
 
@@ -142,10 +140,10 @@ public class SavepointsCommand implements CommandMarker {
     return "Metadata for table " + HoodieCLI.tableMetadata.getTableConfig().getTableName() + " refreshed.";
   }
 
-  private static HoodieWriteClient createHoodieClient(JavaSparkContext jsc, String basePath) throws Exception {
+  private static HoodieWriteClient createHoodieClient(Configuration conf, String basePath) throws Exception {
     HoodieWriteConfig config = HoodieWriteConfig.newBuilder().withPath(basePath)
         .withIndexConfig(HoodieIndexConfig.newBuilder().withIndexType(HoodieIndex.IndexType.BLOOM).build()).build();
-    return new HoodieWriteClient(jsc, config, false);
+    return new HoodieWriteClient(conf, config, false);
   }
 
 }

--- a/hudi-client/src/main/java/org/apache/hudi/AbstractHoodieClient.java
+++ b/hudi-client/src/main/java/org/apache/hudi/AbstractHoodieClient.java
@@ -46,7 +46,7 @@ public abstract class AbstractHoodieClient implements Serializable, AutoCloseabl
   protected final transient JavaSparkContext jsc;
   protected final HoodieWriteConfig config;
   protected final String basePath;
-  protected Configuration hadoopConf = new Configuration();
+  protected transient Configuration hadoopConf = new Configuration();
 
   /**
    * Timeline Server has the same lifetime as that of Client. Any operations done on the same timeline service will be

--- a/hudi-client/src/main/java/org/apache/hudi/HoodieCleanClient.java
+++ b/hudi-client/src/main/java/org/apache/hudi/HoodieCleanClient.java
@@ -39,6 +39,7 @@ import org.apache.hudi.table.HoodieTable;
 import com.codahale.metrics.Timer;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.apache.spark.api.java.JavaSparkContext;
@@ -58,6 +59,12 @@ public class HoodieCleanClient<T extends HoodieRecordPayload> extends AbstractHo
   public HoodieCleanClient(JavaSparkContext jsc, HoodieWriteConfig clientConfig, HoodieMetrics metrics,
       Option<EmbeddedTimelineService> timelineService) {
     super(jsc, clientConfig, timelineService);
+    this.metrics = metrics;
+  }
+
+  public HoodieCleanClient(Configuration hadoopConf, HoodieWriteConfig clientConfig, HoodieMetrics metrics,
+                           Option<EmbeddedTimelineService> timelineService) {
+    super(hadoopConf, clientConfig, timelineService);
     this.metrics = metrics;
   }
 

--- a/hudi-client/src/main/java/org/apache/hudi/client/utils/ClientUtils.java
+++ b/hudi-client/src/main/java/org/apache/hudi/client/utils/ClientUtils.java
@@ -21,9 +21,23 @@ package org.apache.hudi.client.utils;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.config.HoodieWriteConfig;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.spark.api.java.JavaSparkContext;
 
 public class ClientUtils {
+
+  /**
+   * Create Consistency Aware MetaClient.
+   *
+   * @param hadoopConf Configuration
+   * @param config HoodieWriteConfig
+   * @param loadActiveTimelineOnLoad early loading of timeline
+   */
+  public static HoodieTableMetaClient createMetaClient(Configuration hadoopConf, HoodieWriteConfig config,
+                                                       boolean loadActiveTimelineOnLoad) {
+    return new HoodieTableMetaClient(hadoopConf, config.getBasePath(), loadActiveTimelineOnLoad,
+      config.getConsistencyGuardConfig());
+  }
 
   /**
    * Create Consistency Aware MetaClient.

--- a/hudi-client/src/main/java/org/apache/hudi/table/HoodieCopyOnWriteTable.java
+++ b/hudi-client/src/main/java/org/apache/hudi/table/HoodieCopyOnWriteTable.java
@@ -56,6 +56,7 @@ import org.apache.hudi.io.HoodieMergeHandle;
 import com.google.common.hash.Hashing;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.generic.IndexedRecord;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.log4j.LogManager;
@@ -96,6 +97,10 @@ public class HoodieCopyOnWriteTable<T extends HoodieRecordPayload> extends Hoodi
 
   public HoodieCopyOnWriteTable(HoodieWriteConfig config, JavaSparkContext jsc) {
     super(config, jsc);
+  }
+
+  public HoodieCopyOnWriteTable(HoodieWriteConfig config, Configuration hadoopConf) {
+    super(config, hadoopConf);
   }
 
   private static PairFlatMapFunction<Iterator<Tuple2<String, String>>, String, PartitionCleanStat> deleteFilesFunc(

--- a/hudi-client/src/main/java/org/apache/hudi/table/HoodieMergeOnReadTable.java
+++ b/hudi-client/src/main/java/org/apache/hudi/table/HoodieMergeOnReadTable.java
@@ -45,6 +45,7 @@ import org.apache.hudi.io.compact.HoodieRealtimeTableCompactor;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.apache.spark.Partitioner;
@@ -85,6 +86,10 @@ public class HoodieMergeOnReadTable<T extends HoodieRecordPayload> extends Hoodi
 
   public HoodieMergeOnReadTable(HoodieWriteConfig config, JavaSparkContext jsc) {
     super(config, jsc);
+  }
+
+  public HoodieMergeOnReadTable(HoodieWriteConfig config, Configuration hadoopConf) {
+    super(config, hadoopConf);
   }
 
   @Override


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

Currently, javasparkcontext was inited when savepoint create, but it is not necessary.  Javasparkcontext's whole work is provide hadoopconfig, but need time and resources to init it. 
So we can use hadoop config instead of jsc.

## Brief change log

*(for example:)*
  - *Use hadoop config instead jsc in savepoint timeline*

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.