### PR TITLE
[HUDI-469] Fix: HoodieCommitMetadata only show first commit insert rows.

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieCommitMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieCommitMetadata.java
@@ -175,7 +175,8 @@ public class HoodieCommitMetadata implements Serializable {
     long totalInsertRecordsWritten = 0;
     for (List<HoodieWriteStat> stats : partitionToWriteStats.values()) {
       for (HoodieWriteStat stat : stats) {
-        if (stat.getPrevCommit() != null && stat.getPrevCommit().equalsIgnoreCase("null")) {
+        // determine insert rows in every file
+        if (stat.getPrevCommit() != null) {
           totalInsertRecordsWritten += stat.getNumInserts();
         }
       }


### PR DESCRIPTION
When I run hudi cli to get insert rows, I found that hudi cli can not get insert rows if it is not in first commit time. I found that `HoodieCommitMetadata.fetchTotalInsertRecordsWritten()` method use ` stat.getPrevCommit().equalsIgnoreCase("null")` to filter first commit. So I think this check option should be removed.

JIRA link https://issues.apache.org/jira/projects/HUDI/issues/HUDI-469

## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request
It was only possible to determine the number of rows to insert for the first commit before. Currently, to fixe this problem.

## Brief change log

 hudi-common/src/main/java/org/apache/hudi/common/model/HoodieCommitMetadata.java | 4 +++-
 1 file changed, 3 insertions(+), 1 deletion(-)

## Verify this pull request

have run TestHoodieCommitMetadata.java to test.

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.