### PR TITLE
[HUDI-464] : Use Hive Exec Core

### DIFF
--- a/hudi-client/pom.xml
+++ b/hudi-client/pom.xml
@@ -231,6 +231,13 @@
       <artifactId>hive-exec</artifactId>
       <version>${hive.version}</version>
       <scope>test</scope>
+      <classifier>${hive.exec.classifier}</classifier>
+    </dependency>
+    <dependency>
+      <groupId>${hive.groupid}</groupId>
+      <artifactId>hive-metastore</artifactId>
+      <version>${hive.version}</version>
+      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/hudi-hadoop-mr/pom.xml
+++ b/hudi-hadoop-mr/pom.xml
@@ -79,6 +79,7 @@
     <dependency>
       <groupId>${hive.groupid}</groupId>
       <artifactId>hive-exec</artifactId>
+      <classifier>${hive.exec.classifier}</classifier>
     </dependency>
 
     <!-- Hoodie - Test -->

--- a/hudi-utilities/pom.xml
+++ b/hudi-utilities/pom.xml
@@ -329,6 +329,7 @@
       <artifactId>hive-exec</artifactId>
       <version>${hive.version}</version>
       <scope>test</scope>
+      <classifier>${hive.exec.classifier}</classifier>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,7 @@
     <hadoop.version>2.7.3</hadoop.version>
     <hive.groupid>org.apache.hive</hive.groupid>
     <hive.version>2.3.1</hive.version>
+    <hive.exec.classifier>core</hive.exec.classifier>
     <metrics.version>4.1.1</metrics.version>
     <spark.version>2.1.0</spark.version>
     <avro.version>1.7.7</avro.version>
@@ -783,6 +784,7 @@
         <artifactId>hive-exec</artifactId>
         <version>${hive.version}</version>
         <scope>provided</scope>
+        <classifier>${hive.exec.classifier}</classifier>
         <exclusions>
           <exclusion>
             <groupId>javax.mail</groupId>


### PR DESCRIPTION
## What is the purpose of the pull request

HUDI depends on `hive-exec` which contains a number of dependencies which have version conflicts with the dependencies required by Spark. Specifically, we are going to upgrade HUDI to `spark 2.4.4` which depends on `avro 1.8.2`, whereas `hive-exec` brings in `avro 1.7.7`. 

We have run into many issues arising form the way that `hive-exec` packages its dependencies. To address these issues, we are choosing to move to `hive-exec:core` which does not include these dependencies. 

## Brief change log

Change poms to use hive exec with the `core` classifier. 

## Verify this pull request

Verified by ensuring spark and hive queries in https://hudi.apache.org/docker_demo.html#step-4-a-run-hive-queries continue to work as expected. 

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [x] CI is green

 - [x] Necessary doc changes done or have another open PR
       
 - [x] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.