### PR TITLE
Fix Error: java.lang.IllegalArgumentException: Can not create a Path from an empty string

### DIFF
--- a/hudi-client/src/main/java/org/apache/hudi/table/HoodieCopyOnWriteTable.java
+++ b/hudi-client/src/main/java/org/apache/hudi/table/HoodieCopyOnWriteTable.java
@@ -109,7 +109,7 @@ public class HoodieCopyOnWriteTable<T extends HoodieRecordPayload> extends Hoodi
         Tuple2<String, String> partitionDelFileTuple = iter.next();
         String partitionPath = partitionDelFileTuple._1();
         String delFileName = partitionDelFileTuple._2();
-        Path deletePath = new Path(new Path(basePath, partitionPath), delFileName);
+        Path deletePath = FSUtils.getPartitionPath(FSUtils.getPartitionPath(basePath, partitionPath), delFileName);
         String deletePathStr = deletePath.toString();
         Boolean deletedFileResult = deleteFileAndGetResult(fs, deletePathStr);
         if (!partitionCleanStatMap.containsKey(partitionPath)) {


### PR DESCRIPTION
same link in https://github.com/apache/incubator-hudi/pull/771
this time is `deleteFilesFunc` method in `org.apache.hudi.table.HoodieCopyOnWrite.java`.

## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request
Fix Error: java.lang.IllegalArgumentException: Can not create a Path from an empty string, when upsert a hudi table with non-partition data.

## Brief change log
change `HoodieCopyOnWriteTable` in line 112 use `FSUtils.getPartitionPath(Path basePath, String partitionPath)`

## Verify this pull request
This pull request is already covered by existing tests, such as *org.apache.hudi.table.TestCopyOnWriteTable*.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [x] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.