### PR TITLE
[minor] Fix few typos in the java docs

### DIFF
--- a/hudi-client/src/main/java/org/apache/hudi/HoodieWriteClient.java
+++ b/hudi-client/src/main/java/org/apache/hudi/HoodieWriteClient.java
@@ -89,7 +89,7 @@ import java.util.stream.IntStream;
 import scala.Tuple2;
 
 /**
- * Hoodie Write Client helps you build datasets on HDFS [insert()] and then perform efficient mutations on a HDFS
+ * Hoodie Write Client helps you build datasets on HDFS [insert()] and then perform efficient mutations on an HDFS
  * dataset [upsert()]
  * <p>
  * Note that, at any given time, there can only be one Spark job performing these operatons on a Hoodie dataset.

--- a/hudi-common/src/test/java/org/apache/hudi/common/bloom/filter/TestBloomFilter.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/bloom/filter/TestBloomFilter.java
@@ -39,7 +39,7 @@ public class TestBloomFilter {
 
   private final String versionToTest;
 
-  // name attribute is optional, provide an unique name for test
+  // name attribute is optional, provide a unique name for test
   // multiple parameters, uses Collection<Object[]>
   @Parameters()
   public static Collection<Object[]> data() {


### PR DESCRIPTION
fix typos(a hdfs, an unique), it's better to use "an hdfs", "a unique"