### PR TITLE
[HUDI-470] Fix NPE when print result via hudi-cli

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/HoodieLogFileCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/HoodieLogFileCommand.java
@@ -227,7 +227,7 @@ public class HoodieLogFileCommand implements CommandMarker {
         }
       }
     }
-    String[][] rows = new String[allRecords.size() + 1][];
+    String[][] rows = new String[allRecords.size()][];
     int i = 0;
     for (IndexedRecord record : allRecords) {
       String[] data = new String[1];

--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/RepairsCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/RepairsCommand.java
@@ -77,7 +77,7 @@ public class RepairsCommand implements CommandMarker {
     List<String> partitionPaths =
         FSUtils.getAllPartitionFoldersThreeLevelsDown(HoodieCLI.fs, client.getBasePath());
     Path basePath = new Path(client.getBasePath());
-    String[][] rows = new String[partitionPaths.size() + 1][];
+    String[][] rows = new String[partitionPaths.size()][];
 
     int ind = 0;
     for (String partition : partitionPaths) {


### PR DESCRIPTION
## What is the purpose of the pull request

The size of `rows` is error, for example 
```
List<String> allRecords = Arrays.asList();

String[][] rows = new String[allRecords.size() + 1][];
int i = 0;
for (String record : allRecords) {
    String[] data = new String[1];
    data[0] = record;
    rows[i++] = data;
}

HoodiePrintHelper.print(new String[]{"Partition Path"}, rows);
```
Result is:
```
Exception in thread "main" java.lang.NullPointerException
	at com.jakewharton.fliptables.FlipTable.<init>(FlipTable.java:37)
	at com.jakewharton.fliptables.FlipTable.of(FlipTable.java:20)
	at org.apache.hudi.cli.HoodiePrintHelper.printTextTable(HoodiePrintHelper.java:110)
	at org.apache.hudi.cli.HoodiePrintHelper.print(HoodiePrintHelper.java:43)
	at org.apache.hudi.cli.commands.RepairsCommand.main(RepairsCommand.java:127)
```

## Brief change log

  - Fix NPE when print result via hudi-cli

## Verify this pull request

This pull request is a code cleanup without any test coverage.

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [x] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.