### PR TITLE
[HUDI-482] Fix missing @Override annotation on methods

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/HoodieHistoryFileNameProvider.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/HoodieHistoryFileNameProvider.java
@@ -30,6 +30,7 @@ import org.springframework.stereotype.Component;
 @Order(Ordered.HIGHEST_PRECEDENCE)
 public class HoodieHistoryFileNameProvider extends DefaultHistoryFileNameProvider {
 
+  @Override
   public String getHistoryFileName() {
     return "hoodie-cmd.log";
   }

--- a/hudi-cli/src/main/java/org/apache/hudi/cli/HoodieSplashScreen.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/HoodieSplashScreen.java
@@ -50,14 +50,17 @@ public class HoodieSplashScreen extends DefaultBannerProvider {
       + "*                                                                 *" + OsUtils.LINE_SEPARATOR
       + "===================================================================" + OsUtils.LINE_SEPARATOR;
 
+  @Override
   public String getBanner() {
     return screen;
   }
 
+  @Override
   public String getVersion() {
     return "1.0";
   }
 
+  @Override
   public String getWelcomeMessage() {
     return "Welcome to Apache Hudi CLI. Please type help if you are looking for help. ";
   }

--- a/hudi-client/src/main/java/org/apache/hudi/AbstractHoodieClient.java
+++ b/hudi-client/src/main/java/org/apache/hudi/AbstractHoodieClient.java
@@ -72,6 +72,7 @@ public abstract class AbstractHoodieClient implements Serializable, AutoCloseabl
   /**
    * Releases any resources used by the client.
    */
+  @Override
   public void close() {
     stopEmbeddedServerView(true);
   }

--- a/hudi-client/src/main/java/org/apache/hudi/HoodieWriteClient.java
+++ b/hudi-client/src/main/java/org/apache/hudi/HoodieWriteClient.java
@@ -973,6 +973,7 @@ public class HoodieWriteClient<T extends HoodieRecordPayload> extends AbstractHo
   /**
    * Releases any resources used by the client.
    */
+  @Override
   public void close() {
     // Stop timeline-server if running
     super.close();

--- a/hudi-client/src/main/java/org/apache/hudi/func/SparkBoundedInMemoryExecutor.java
+++ b/hudi-client/src/main/java/org/apache/hudi/func/SparkBoundedInMemoryExecutor.java
@@ -48,6 +48,7 @@ public class SparkBoundedInMemoryExecutor<I, O, E> extends BoundedInMemoryExecut
     this.sparkThreadTaskContext = TaskContext.get();
   }
 
+  @Override
   public void preExecute() {
     // Passing parent thread's TaskContext to newly launched thread for it to access original TaskContext properties.
     TaskContext$.MODULE$.setTaskContext(sparkThreadTaskContext);

--- a/hudi-client/src/main/java/org/apache/hudi/index/bloom/BloomIndexFileInfo.java
+++ b/hudi-client/src/main/java/org/apache/hudi/index/bloom/BloomIndexFileInfo.java
@@ -88,6 +88,7 @@ public class BloomIndexFileInfo implements Serializable {
     return Objects.hashCode(fileId, minRecordKey, maxRecordKey);
   }
 
+  @Override
   public String toString() {
     final StringBuilder sb = new StringBuilder("BloomIndexFileInfo {");
     sb.append(" fileId=").append(fileId);

--- a/hudi-client/src/main/java/org/apache/hudi/index/hbase/HBaseIndex.java
+++ b/hudi-client/src/main/java/org/apache/hudi/index/hbase/HBaseIndex.java
@@ -154,6 +154,7 @@ public class HBaseIndex<T extends HoodieRecordPayload> extends HoodieIndex<T> {
    */
   private void addShutDownHook() {
     Runtime.getRuntime().addShutdownHook(new Thread() {
+      @Override
       public void run() {
         try {
           hbaseConnection.close();
@@ -167,6 +168,7 @@ public class HBaseIndex<T extends HoodieRecordPayload> extends HoodieIndex<T> {
   /**
    * Ensure that any resources used for indexing are released here.
    */
+  @Override
   public void close() {
     this.hBaseIndexQPSResourceAllocator.releaseQPSResources();
   }

--- a/hudi-client/src/main/java/org/apache/hudi/io/HoodieCreateHandle.java
+++ b/hudi-client/src/main/java/org/apache/hudi/io/HoodieCreateHandle.java
@@ -94,6 +94,7 @@ public class HoodieCreateHandle<T extends HoodieRecordPayload> extends HoodieWri
   /**
    * Perform the actual writing of the given record into the backing file.
    */
+  @Override
   public void write(HoodieRecord record, Option<IndexedRecord> avroRecord) {
     Option recordMetadata = record.getData().getMetadata();
     try {

--- a/hudi-client/src/main/java/org/apache/hudi/io/HoodieMergeHandle.java
+++ b/hudi-client/src/main/java/org/apache/hudi/io/HoodieMergeHandle.java
@@ -92,6 +92,7 @@ public class HoodieMergeHandle<T extends HoodieRecordPayload> extends HoodieWrit
     return HoodieAvroUtils.addMetadataFields(originalSchema);
   }
 
+  @Override
   public Path makeNewPath(String partitionPath) {
     Path path = FSUtils.getPartitionPath(config.getBasePath(), partitionPath);
     try {
@@ -103,6 +104,7 @@ public class HoodieMergeHandle<T extends HoodieRecordPayload> extends HoodieWrit
     return new Path(path.toString(), FSUtils.makeDataFileName(instantTime, writeToken, fileId));
   }
 
+  @Override
   public Schema getWriterSchema() {
     return writerSchema;
   }
@@ -113,6 +115,7 @@ public class HoodieMergeHandle<T extends HoodieRecordPayload> extends HoodieWrit
    * - Whether it belongs to the same partitionPath as existing records - Whether the current file written bytes lt max
    * file size
    */
+  @Override
   public boolean canWrite(HoodieRecord record) {
     return false;
   }
@@ -120,6 +123,7 @@ public class HoodieMergeHandle<T extends HoodieRecordPayload> extends HoodieWrit
   /**
    * Perform the actual writing of the given record into the backing file.
    */
+  @Override
   public void write(HoodieRecord record, Option<IndexedRecord> insertValue) {
     // NO_OP
   }
@@ -127,6 +131,7 @@ public class HoodieMergeHandle<T extends HoodieRecordPayload> extends HoodieWrit
   /**
    * Perform the actual writing of the given record into the backing file.
    */
+  @Override
   public void write(HoodieRecord record, Option<IndexedRecord> avroRecord, Option<Exception> exception) {
     Option recordMetadata = record.getData().getMetadata();
     if (exception.isPresent() && exception.get() instanceof Throwable) {
@@ -141,6 +146,7 @@ public class HoodieMergeHandle<T extends HoodieRecordPayload> extends HoodieWrit
   /**
    * Rewrite the GenericRecord with the Schema containing the Hoodie Metadata fields.
    */
+  @Override
   protected GenericRecord rewriteRecord(GenericRecord record) {
     return HoodieAvroUtils.rewriteRecord(record, writerSchema);
   }

--- a/hudi-client/src/main/java/org/apache/hudi/io/storage/HoodieParquetWriter.java
+++ b/hudi-client/src/main/java/org/apache/hudi/io/storage/HoodieParquetWriter.java
@@ -93,6 +93,7 @@ public class HoodieParquetWriter<T extends HoodieRecordPayload, R extends Indexe
     writeSupport.add(record.getRecordKey());
   }
 
+  @Override
   public boolean canWrite() {
     return fs.getBytesWritten(file) < maxFileSize;
   }

--- a/hudi-client/src/main/java/org/apache/hudi/table/HoodieCopyOnWriteTable.java
+++ b/hudi-client/src/main/java/org/apache/hudi/table/HoodieCopyOnWriteTable.java
@@ -279,6 +279,7 @@ public class HoodieCopyOnWriteTable<T extends HoodieRecordPayload> extends Hoodi
    * @param jsc JavaSparkContext
    * @return Cleaner Plan
    */
+  @Override
   public HoodieCleanerPlan scheduleClean(JavaSparkContext jsc) {
     try {
       HoodieCleanHelper cleaner = new HoodieCleanHelper(this, config);

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFileReader.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFileReader.java
@@ -108,6 +108,7 @@ class HoodieLogFileReader implements HoodieLogFormat.Reader {
    */
   private void addShutDownHook() {
     Runtime.getRuntime().addShutdownHook(new Thread() {
+      @Override
       public void run() {
         try {
           close();

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFormatWriter.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFormatWriter.java
@@ -107,6 +107,7 @@ public class HoodieLogFormatWriter implements HoodieLogFormat.Writer {
     return fs;
   }
 
+  @Override
   public HoodieLogFile getLogFile() {
     return logFile;
   }
@@ -212,6 +213,7 @@ public class HoodieLogFormatWriter implements HoodieLogFormat.Writer {
     output.hsync();
   }
 
+  @Override
   public long getCurrentSize() throws IOException {
     if (output == null) {
       throw new IllegalStateException("Cannot get current size as the underlying stream has been closed already");

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieActiveTimeline.java
@@ -145,6 +145,7 @@ public class HoodieActiveTimeline extends HoodieDefaultTimeline {
    * timeline * With Async compaction a requested/inflight compaction-instant is a valid baseInstant for a file-slice as
    * there could be delta-commits with that baseInstant.
    */
+  @Override
   public HoodieTimeline getCommitsAndCompactionTimeline() {
     return getTimelineOfActions(Sets.newHashSet(COMMIT_ACTION, DELTA_COMMIT_ACTION, COMPACTION_ACTION));
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/AbstractTableFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/AbstractTableFileSystemView.java
@@ -182,6 +182,7 @@ public abstract class AbstractTableFileSystemView implements SyncableFileSystemV
   /**
    * Clears the partition Map and reset view states.
    */
+  @Override
   public final void reset() {
     try {
       writeLock.lock();
@@ -380,6 +381,7 @@ public abstract class AbstractTableFileSystemView implements SyncableFileSystemV
   /**
    * Get Latest data file for a partition and file-Id.
    */
+  @Override
   public final Option<HoodieDataFile> getLatestDataFile(String partitionStr, String fileId) {
     try {
       readLock.lock();
@@ -434,6 +436,7 @@ public abstract class AbstractTableFileSystemView implements SyncableFileSystemV
   /**
    * Get Latest File Slice for a given fileId in a given partition.
    */
+  @Override
   public final Option<FileSlice> getLatestFileSlice(String partitionStr, String fileId) {
     try {
       readLock.lock();

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/HoodieTableFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/HoodieTableFileSystemView.java
@@ -205,6 +205,7 @@ public class HoodieTableFileSystemView extends IncrementalTimelineSyncFileSystem
     });
   }
 
+  @Override
   public void close() {
     closed = true;
     super.reset();
@@ -212,6 +213,7 @@ public class HoodieTableFileSystemView extends IncrementalTimelineSyncFileSystem
     fgIdToPendingCompaction = null;
   }
 
+  @Override
   public boolean isClosed() {
     return closed;
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/view/SpillableMapBasedFileSystemView.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/view/SpillableMapBasedFileSystemView.java
@@ -76,6 +76,7 @@ public class SpillableMapBasedFileSystemView extends HoodieTableFileSystemView {
     }
   }
 
+  @Override
   protected Map<HoodieFileGroupId, Pair<String, CompactionOperation>> createFileIdToPendingCompactionMap(
       Map<HoodieFileGroupId, Pair<String, CompactionOperation>> fgIdToPendingCompaction) {
     try {
@@ -91,6 +92,7 @@ public class SpillableMapBasedFileSystemView extends HoodieTableFileSystemView {
     }
   }
 
+  @Override
   public Stream<HoodieFileGroup> getAllFileGroups() {
     return ((ExternalSpillableMap) partitionToFileGroupsMap).valueStream()
         .flatMap(fg -> ((List<HoodieFileGroup>) fg).stream());

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/ObjectSizeCalculator.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/ObjectSizeCalculator.java
@@ -124,6 +124,7 @@ public class ObjectSizeCalculator {
 
   private final LoadingCache<Class<?>, ClassSizeInfo> classSizeInfos =
       CacheBuilder.newBuilder().build(new CacheLoader<Class<?>, ClassSizeInfo>() {
+        @Override
         public ClassSizeInfo load(Class<?> clazz) {
           return new ClassSizeInfo(clazz);
         }

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/collection/DiskBasedMap.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/collection/DiskBasedMap.java
@@ -125,6 +125,7 @@ public final class DiskBasedMap<T extends Serializable, R extends Serializable> 
    */
   private void addShutDownHook() {
     Runtime.getRuntime().addShutdownHook(new Thread() {
+      @Override
       public void run() {
         try {
           if (writeOnlyFileHandle != null) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/collection/LazyFileIterable.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/collection/LazyFileIterable.java
@@ -115,6 +115,7 @@ public class LazyFileIterable<T, R> implements Iterable<R> {
 
     private void addShutdownHook() {
       Runtime.getRuntime().addShutdownHook(new Thread() {
+        @Override
         public void run() {
           close();
         }

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieParquetInputFormat.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieParquetInputFormat.java
@@ -173,10 +173,12 @@ public class HoodieParquetInputFormat extends MapredParquetInputFormat implement
     return grouped;
   }
 
+  @Override
   public void setConf(Configuration conf) {
     this.conf = conf;
   }
 
+  @Override
   public Configuration getConf() {
     return conf;
   }

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/hive/HoodieCombineHiveInputFormat.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/hive/HoodieCombineHiveInputFormat.java
@@ -890,7 +890,7 @@ public class HoodieCombineHiveInputFormat<K extends WritableComparable, V extend
 
     @Override
     public RecordReader getRecordReader(JobConf job, CombineFileSplit split, Reporter reporter,
-                                        Class<RecordReader<K, V>> rrClass) throws IOException {
+        Class<RecordReader<K, V>> rrClass) throws IOException {
       return new HadoopShimsSecure.CombineFileRecordReader(job, split, reporter, rrClass);
     }
 

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/hive/HoodieCombineHiveInputFormat.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/hive/HoodieCombineHiveInputFormat.java
@@ -805,6 +805,7 @@ public class HoodieCombineHiveInputFormat<K extends WritableComparable, V extend
 
     public HoodieCombineFileInputFormatShim() {}
 
+    @Override
     public Path[] getInputPathsShim(JobConf conf) {
       try {
         return FileInputFormat.getInputPaths(conf);
@@ -813,6 +814,7 @@ public class HoodieCombineHiveInputFormat<K extends WritableComparable, V extend
       }
     }
 
+    @Override
     public void createPool(JobConf conf, PathFilter... filters) {
       super.createPool(conf, filters);
     }
@@ -822,6 +824,7 @@ public class HoodieCombineHiveInputFormat<K extends WritableComparable, V extend
       throw new IOException("CombineFileInputFormat.getRecordReader not needed.");
     }
 
+    @Override
     protected List<FileStatus> listStatus(JobContext job) throws IOException {
       LOG.info("Listing status in HoodieCombineHiveInputFormat.HoodieCombineFileInputFormatShim");
       List<FileStatus> result;
@@ -851,6 +854,7 @@ public class HoodieCombineHiveInputFormat<K extends WritableComparable, V extend
       return result;
     }
 
+    @Override
     public CombineFileSplit[] getSplits(JobConf job, int numSplits) throws IOException {
       long minSize = job.getLong(org.apache.hadoop.mapreduce.lib.input.FileInputFormat.SPLIT_MINSIZE, 0L);
       if (job.getLong("mapreduce.input.fileinputformat.split.minsize.per.node", 0L) == 0L) {
@@ -879,12 +883,14 @@ public class HoodieCombineHiveInputFormat<K extends WritableComparable, V extend
       return (CombineFileSplit[]) inputSplitShims.toArray(new HadoopShimsSecure.InputSplitShim[inputSplitShims.size()]);
     }
 
+    @Override
     public HadoopShimsSecure.InputSplitShim getInputSplitShim() throws IOException {
       return new HadoopShimsSecure.InputSplitShim();
     }
 
+    @Override
     public RecordReader getRecordReader(JobConf job, CombineFileSplit split, Reporter reporter,
-        Class<RecordReader<K, V>> rrClass) throws IOException {
+                                        Class<RecordReader<K, V>> rrClass) throws IOException {
       return new HadoopShimsSecure.CombineFileRecordReader(job, split, reporter, rrClass);
     }
 

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamer.java
@@ -554,6 +554,7 @@ public class HoodieDeltaStreamer implements Serializable {
     /**
      * Start Compaction Service.
      */
+    @Override
     protected Pair<CompletableFuture, ExecutorService> startService() {
       ExecutorService executor = Executors.newFixedThreadPool(maxConcurrentCompaction);
       List<CompletableFuture<Boolean>> compactionFutures =


### PR DESCRIPTION
## What is the purpose of the pull request

An overridden method from an interface or abstract class should be marked with @Override annotation.

Once the method signature in the abstract class is changed, the implementation class will report a compile error immediately.

## Brief change log

  - Fix missing @Override annotation on method

## Verify this pull request

This pull request is code cleanup without any test coverage.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.