### PR TITLE
[HUDI-332]Add operation type (insert/upsert/bulkinsert/delete) to HoodieCommitMetadata

### DIFF
--- a/hudi-client/src/main/java/org/apache/hudi/table/HoodieCommitArchiveLog.java
+++ b/hudi-client/src/main/java/org/apache/hudi/table/HoodieCommitArchiveLog.java
@@ -331,7 +331,7 @@ public class HoodieCommitArchiveLog {
     return archivedMetaWrapper;
   }
 
-  private org.apache.hudi.avro.model.HoodieCommitMetadata commitMetadataConverter(
+  public org.apache.hudi.avro.model.HoodieCommitMetadata commitMetadataConverter(
       HoodieCommitMetadata hoodieCommitMetadata) {
     ObjectMapper mapper = new ObjectMapper();
     // Need this to ignore other public get() methods

--- a/hudi-client/src/test/java/org/apache/hudi/io/TestHoodieCommitArchiveLog.java
+++ b/hudi-client/src/test/java/org/apache/hudi/io/TestHoodieCommitArchiveLog.java
@@ -430,19 +430,7 @@ public class TestHoodieCommitArchiveLog extends HoodieClientTestHarness {
     metaClient = HoodieTableMetaClient.reload(metaClient);
     HoodieCommitArchiveLog archiveLog = new HoodieCommitArchiveLog(cfg, metaClient);
 
-    Class<?> clazz  = HoodieCommitArchiveLog.class;
-    try {
-      Method commitMetadataConverter = clazz.getDeclaredMethod("commitMetadataConverter", HoodieCommitMetadata.class);
-      commitMetadataConverter.setAccessible(true);
-      org.apache.hudi.avro.model.HoodieCommitMetadata expectedCommitMetadata =
-          (org.apache.hudi.avro.model.HoodieCommitMetadata) commitMetadataConverter.invoke(archiveLog, hoodieCommitMetadata);
-      assertEquals(expectedCommitMetadata.getOperationType(), WriteOperationType.INSERT.toString());
-    } catch (NoSuchMethodException e) {
-      assertTrue(e.getMessage(), false);
-    } catch (IllegalAccessException e) {
-      assertTrue(e.getMessage(), false);
-    } catch (InvocationTargetException e) {
-      assertTrue(e.getMessage(), false);
-    }
+    org.apache.hudi.avro.model.HoodieCommitMetadata expectedCommitMetadata = archiveLog.commitMetadataConverter(hoodieCommitMetadata);
+    assertEquals(expectedCommitMetadata.getOperationType(), WriteOperationType.INSERT.toString());
   }
 }

--- a/hudi-client/src/test/java/org/apache/hudi/io/TestHoodieCommitArchiveLog.java
+++ b/hudi-client/src/test/java/org/apache/hudi/io/TestHoodieCommitArchiveLog.java
@@ -45,7 +45,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;

--- a/hudi-client/src/test/java/org/apache/hudi/io/TestHoodieCommitArchiveLog.java
+++ b/hudi-client/src/test/java/org/apache/hudi/io/TestHoodieCommitArchiveLog.java
@@ -43,8 +43,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;

--- a/hudi-common/src/main/avro/HoodieCommitMetadata.avsc
+++ b/hudi-common/src/main/avro/HoodieCommitMetadata.avsc
@@ -133,6 +133,11 @@
          "name":"version",
          "type":["int", "null"],
          "default": 1
+      },
+      {
+         "name":"operationType",
+         "type": ["null","string"],
+         "default":null
       }
    ]
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieCommitMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieCommitMetadata.java
@@ -49,6 +49,8 @@ public class HoodieCommitMetadata implements Serializable {
 
   private Map<String, String> extraMetadata;
 
+  private WriteOperationType operationType = WriteOperationType.UNKNOWN;
+
   // for ser/deser
   public HoodieCommitMetadata() {
     this(false);
@@ -104,6 +106,14 @@ public class HoodieCommitMetadata implements Serializable {
       }
     }
     return filePaths;
+  }
+
+  public void setOperationType(WriteOperationType type) {
+    this.operationType = type;
+  }
+
+  public WriteOperationType getOperationType() {
+    return this.operationType;
   }
 
   public HashMap<String, String> getFileIdAndFullPaths(String basePath) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/WriteOperationType.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/WriteOperationType.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.model;
+
+import org.apache.hudi.exception.HoodieException;
+
+import java.util.Locale;
+
+/**
+ * The supported write operation types, used by commitMetadata.
+ */
+public enum WriteOperationType {
+  // directly insert
+  INSERT("insert"),
+  INSERT_PREPPED("insert_prepped"),
+  // update and insert
+  UPSERT("upsert"),
+  UPSERT_PREPPED("upsert_prepped"),
+  // bulk insert
+  BULK_INSERT("bulk_insert"),
+  BULK_INSERT_PREPPED("bulk_insert_prepped"),
+  // delete
+  DELETE("delete"),
+  // used for old version
+  UNKNOWN("unknown");
+
+  private final String value;
+
+  WriteOperationType(String value) {
+    this.value = value;
+  }
+
+  /**
+   * Convert string value to WriteOperationType.
+   */
+  public static WriteOperationType fromValue(String value) {
+    switch (value.toLowerCase(Locale.ROOT)) {
+      case "insert":
+        return INSERT;
+      case "insert_prepped":
+        return INSERT_PREPPED;
+      case "upsert":
+        return UPSERT;
+      case "upsert_prepped":
+        return UPSERT_PREPPED;
+      case "bulk_insert":
+        return BULK_INSERT;
+      case "bulk_insert_prepped":
+        return BULK_INSERT_PREPPED;
+      case "delete":
+        return DELETE;
+      default:
+        throw new HoodieException("Invalid value of Type.");
+    }
+  }
+}

--- a/hudi-common/src/test/resources/old-version.commit
+++ b/hudi-common/src/test/resources/old-version.commit
@@ -1,0 +1,20 @@
+{
+  "partitionToWriteStats" : {
+    "americas/brazil/sao_paulo" : []
+  },
+  "compacted" : false,
+  "extraMetadataMap" : {
+  },
+  "extraMetadata" : {
+  },
+  "fileIdAndRelativePaths" : {
+  },
+  "totalRecordsDeleted" : 0,
+  "totalLogRecordsCompacted" : 0,
+  "totalScanTime" : 0,
+  "totalCreateTime" : 4895,
+  "totalUpsertTime" : 0,
+  "totalCompactedRecordsUpdated" : 0,
+  "totalLogFilesCompacted" : 0,
+  "totalLogFilesSize" : 0
+}

--- a/pom.xml
+++ b/pom.xml
@@ -345,6 +345,7 @@
               <exclude>**/*LICENSE*</exclude>
               <exclude>**/dependency-reduced-pom.xml</exclude>
               <exclude>**/test/resources/*.data</exclude>
+              <exclude>**/test/resources/*.commit</exclude>
               <exclude>**/target/**</exclude>
               <exclude>**/generated-sources/**</exclude>
             </excludes>


### PR DESCRIPTION
## What is the purpose of the pull request

*Add operation type (insert/upsert/bulkinsert/delete) to HoodieCommitMetadata*

## Brief change log

  - *Add operation type (insert/upsert/bulkinsert/delete) to HoodieCommitMetadata*

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.