### PR TITLE
[MINOR]: alter some wrong params which bring fatal exception

### DIFF
--- a/hudi-client/src/test/java/HoodieClientExample.java
+++ b/hudi-client/src/test/java/HoodieClientExample.java
@@ -95,7 +95,7 @@ public class HoodieClientExample {
     HoodieWriteConfig cfg = HoodieWriteConfig.newBuilder().withPath(tablePath)
         .withSchema(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA).withParallelism(2, 2).forTable(tableName)
         .withIndexConfig(HoodieIndexConfig.newBuilder().withIndexType(IndexType.BLOOM).build())
-        .withCompactionConfig(HoodieCompactionConfig.newBuilder().archiveCommitsWith(2, 3).build()).build();
+        .withCompactionConfig(HoodieCompactionConfig.newBuilder().archiveCommitsWith(20, 30).build()).build();
     HoodieWriteClient client = new HoodieWriteClient(jsc, cfg);
 
     List<HoodieRecord> recordsSoFar = new ArrayList<>();


### PR DESCRIPTION

## What is the purpose of the pull request

the `HoodieCompactionConfig.build()` method will check arguments to ensure MIN_COMMITS_TO_KEEP_PROP > CLEANER_COMMITS_RETAINED_PROP, and DEFAULT_CLEANER_COMMITS_RETAINED = "10", so we need to set MIN_COMMITS_TO_KEEP_PROP at least 11.

