### PR TITLE
[HUDI-484] Fix NPE when reading IncrementalPull.sqltemplate in HiveIncrementalPuller

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HiveIncrementalPuller.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HiveIncrementalPuller.java
@@ -112,7 +112,7 @@ public class HiveIncrementalPuller {
     this.config = config;
     validateConfig(config);
     String templateContent =
-        FileIOUtils.readAsUTFString(this.getClass().getResourceAsStream("IncrementalPull.sqltemplate"));
+        FileIOUtils.readAsUTFString(this.getClass().getResourceAsStream("/IncrementalPull.sqltemplate"));
     incrementalPullSQLtemplate = new ST(templateContent);
   }
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHiveIncrementalPuller.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHiveIncrementalPuller.java
@@ -1,0 +1,24 @@
+package org.apache.hudi.utilities;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestHiveIncrementalPuller {
+
+  private HiveIncrementalPuller.Config config;
+
+  @Before
+  public void init() {
+    config = new HiveIncrementalPuller.Config();
+  }
+
+  @Test
+  public void testInitHiveIncrementalPuller() throws Exception {
+
+    HiveIncrementalPuller puller = new HiveIncrementalPuller(config);
+    Assert.assertNotNull(puller);
+
+  }
+
+}

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHiveIncrementalPuller.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHiveIncrementalPuller.java
@@ -9,15 +9,18 @@ public class TestHiveIncrementalPuller {
   private HiveIncrementalPuller.Config config;
 
   @Before
-  public void init() {
+  public void setup() {
     config = new HiveIncrementalPuller.Config();
   }
 
   @Test
   public void testInitHiveIncrementalPuller() throws Exception {
 
-    HiveIncrementalPuller puller = new HiveIncrementalPuller(config);
-    Assert.assertNotNull(puller);
+    try {
+      new HiveIncrementalPuller(config);
+    } catch (Exception e) {
+      Assert.fail("Unexpected exception while init HiveIncrementalPuller, msg: " + e.getMessage());
+    }
 
   }
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHiveIncrementalPuller.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHiveIncrementalPuller.java
@@ -19,7 +19,7 @@ public class TestHiveIncrementalPuller {
     try {
       new HiveIncrementalPuller(config);
     } catch (Exception e) {
-      Assert.fail("Unexpected exception while init HiveIncrementalPuller, msg: " + e.getMessage());
+      Assert.fail("Unexpected exception while initing HiveIncrementalPuller, msg: " + e.getMessage());
     }
 
   }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHiveIncrementalPuller.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHiveIncrementalPuller.java
@@ -14,7 +14,7 @@ public class TestHiveIncrementalPuller {
   }
 
   @Test
-  public void testInitHiveIncrementalPuller() throws Exception {
+  public void testInitHiveIncrementalPuller() {
 
     try {
       new HiveIncrementalPuller(config);


### PR DESCRIPTION

## What is the purpose of the pull request

When using `class.getResourceAsStream` method, the resource name should begins with a '/'.

More detail, please visit https://lists.apache.org/thread.html/9c7ab9b8cf63d8f1f7fd72a0aba870976e81d9c50ed53db80f082284%40%3Cdev.hudi.apache.org%3E

## Brief change log

  - Change "IncrementalPull.sqltemplate" to "/IncrementalPull.sqltemplate".

## Verify this pull request

This pull request is code cleanup without any test coverage.

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.