### PR TITLE
[HUDI-492] Fix show env all in hudi-cli

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/SparkEnvCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/SparkEnvCommand.java
@@ -46,7 +46,7 @@ public class SparkEnvCommand implements CommandMarker {
     env.put(map[0].trim(), map[1].trim());
   }
 
-  @CliCommand(value = "show env all", help = "Show spark launcher envs")
+  @CliCommand(value = "show envs all", help = "Show spark launcher envs")
   public String showAllEnv() {
     String[][] rows = new String[env.size()][2];
     int i = 0;


### PR DESCRIPTION
## What is the purpose of the pull request

Now, `show env all` command can't work correctly.  I found it is confused with `show env --conf` for spring-shell in latest code.
Can change it to `show envs all`, or maybe we can delete it because `show env` can show all also.

## Brief change log

  - *Fix show env all in hudi-cli*

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.