### PR TITLE
[HUDI-502] provide a custom time zone definition for TimestampBasedKeyGenerator

### DIFF
--- a/hudi-common/src/test/java/org/apache/hudi/common/util/SchemaTestUtil.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/SchemaTestUtil.java
@@ -169,6 +169,10 @@ public class SchemaTestUtil {
     return new Schema.Parser().parse(SchemaTestUtil.class.getResourceAsStream("/complex-test-evolved.avsc"));
   }
 
+  public static Schema getTimestampEvolvedSchema() throws IOException {
+    return new Schema.Parser().parse(SchemaTestUtil.class.getResourceAsStream("/timestamp-test-evolved.avsc"));
+  }
+
   public static GenericRecord generateAvroRecordFromJson(Schema schema, int recordNumber, String commitTime,
       String fileId) throws IOException {
     TestRecord record = new TestRecord(commitTime, recordNumber, fileId);

--- a/hudi-common/src/test/resources/timestamp-test-evolved.avsc
+++ b/hudi-common/src/test/resources/timestamp-test-evolved.avsc
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+{
+  "namespace": "example.avro",
+  "type": "record",
+  "name": "User",
+  "fields": [
+    {"name": "field1", "type": ["null", "string"], "default": null},
+    {"name": "field2", "type": ["null", "string"], "default": null},
+    {"name": "createTime", "type": ["null", "string"], "default": null},
+    {"name": "name", "type": ["null", "string"], "default": null},
+    {"name": "favoriteIntNumber",  "type": ["null", "int"], "default": null},
+    {"name": "favoriteNumber",  "type": ["null", "long"], "default": null},
+    {"name": "favoriteFloatNumber",  "type": ["null", "float"], "default": null},
+    {"name": "favoriteDoubleNumber",  "type": ["null", "double"], "default": null},
+    {"name": "tags", "type": ["null", {"values": ["null", {"fields": [{"default": null, "type": ["null", "string"], "name": "item1"}, {"default": null, "type": ["null", "string"], "name": "item2"} ], "type": "record", "name": "tagsMapItems"} ], "type": "map"} ], "default": null},
+    {"default": null, "name": "testNestedRecord", "type": ["null", {"fields": [{"default": null, "name": "isAdmin", "type": ["null", "boolean"] }, {"default": null, "name": "userId", "type": ["null", "string"] } ], "name": "notes", "type": "record"}]},
+    {"default": null, "name": "stringArray", "type": ["null", {"items": "string", "type": "array"}]}
+  ]
+}

--- a/hudi-common/src/test/resources/timestamp-test-evolved.avsc
+++ b/hudi-common/src/test/resources/timestamp-test-evolved.avsc
@@ -21,15 +21,6 @@
   "name": "User",
   "fields": [
     {"name": "field1", "type": ["null", "string"], "default": null},
-    {"name": "field2", "type": ["null", "string"], "default": null},
-    {"name": "createTime", "type": ["null", "string"], "default": null},
-    {"name": "name", "type": ["null", "string"], "default": null},
-    {"name": "favoriteIntNumber",  "type": ["null", "int"], "default": null},
-    {"name": "favoriteNumber",  "type": ["null", "long"], "default": null},
-    {"name": "favoriteFloatNumber",  "type": ["null", "float"], "default": null},
-    {"name": "favoriteDoubleNumber",  "type": ["null", "double"], "default": null},
-    {"name": "tags", "type": ["null", {"values": ["null", {"fields": [{"default": null, "type": ["null", "string"], "name": "item1"}, {"default": null, "type": ["null", "string"], "name": "item2"} ], "type": "record", "name": "tagsMapItems"} ], "type": "map"} ], "default": null},
-    {"default": null, "name": "testNestedRecord", "type": ["null", {"fields": [{"default": null, "name": "isAdmin", "type": ["null", "boolean"] }, {"default": null, "name": "userId", "type": ["null", "string"] } ], "name": "notes", "type": "record"}]},
-    {"default": null, "name": "stringArray", "type": ["null", {"items": "string", "type": "array"}]}
+    {"name": "createTime", "type": ["null", "string"], "default": null}
   ]
 }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/keygen/TimestampBasedKeyGenerator.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/keygen/TimestampBasedKeyGenerator.java
@@ -74,6 +74,7 @@ public class TimestampBasedKeyGenerator extends SimpleKeyGenerator {
         Arrays.asList(Config.TIMESTAMP_TYPE_FIELD_PROP, Config.TIMESTAMP_OUTPUT_DATE_FORMAT_PROP));
     this.timestampType = TimestampType.valueOf(config.getString(Config.TIMESTAMP_TYPE_FIELD_PROP));
     this.outputDateFormat = config.getString(Config.TIMESTAMP_OUTPUT_DATE_FORMAT_PROP);
+    this.timeZone = TimeZone.getTimeZone(config.getString(Config.TIMESTAMP_TIMEZONE_FORMAT_PROP, "GMT"));
 
     if (timestampType == TimestampType.DATE_STRING || timestampType == TimestampType.MIXED) {
       DataSourceUtils.checkRequiredProperties(config,

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/keygen/TimestampBasedKeyGenerator.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/keygen/TimestampBasedKeyGenerator.java
@@ -51,6 +51,8 @@ public class TimestampBasedKeyGenerator extends SimpleKeyGenerator {
 
   private final String outputDateFormat;
 
+  private TimeZone timeZone;
+
   /**
    * Supported configs.
    */
@@ -62,6 +64,8 @@ public class TimestampBasedKeyGenerator extends SimpleKeyGenerator {
         "hoodie.deltastreamer.keygen.timebased.input.dateformat";
     private static final String TIMESTAMP_OUTPUT_DATE_FORMAT_PROP =
         "hoodie.deltastreamer.keygen.timebased.output.dateformat";
+    private static final String TIMESTAMP_TIMEZONE_FORMAT_PROP =
+            "hoodie.deltastreamer.keygen.timebased.timezone";
   }
 
   public TimestampBasedKeyGenerator(TypedProperties config) {
@@ -75,7 +79,8 @@ public class TimestampBasedKeyGenerator extends SimpleKeyGenerator {
       DataSourceUtils.checkRequiredProperties(config,
           Collections.singletonList(Config.TIMESTAMP_INPUT_DATE_FORMAT_PROP));
       this.inputDateFormat = new SimpleDateFormat(config.getString(Config.TIMESTAMP_INPUT_DATE_FORMAT_PROP));
-      this.inputDateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
+      this.timeZone = TimeZone.getTimeZone(config.getString(Config.TIMESTAMP_TIMEZONE_FORMAT_PROP, "GMT"));
+      this.inputDateFormat.setTimeZone(timeZone);
     }
   }
 
@@ -83,7 +88,7 @@ public class TimestampBasedKeyGenerator extends SimpleKeyGenerator {
   public HoodieKey getKey(GenericRecord record) {
     Object partitionVal = DataSourceUtils.getNestedFieldVal(record, partitionPathField);
     SimpleDateFormat partitionPathFormat = new SimpleDateFormat(outputDateFormat);
-    partitionPathFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
+    partitionPathFormat.setTimeZone(timeZone);
 
     try {
       long unixTime;

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/keygen/TimestampBasedKeyGenerator.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/keygen/TimestampBasedKeyGenerator.java
@@ -51,6 +51,8 @@ public class TimestampBasedKeyGenerator extends SimpleKeyGenerator {
 
   private final String outputDateFormat;
 
+  // TimeZone detailed settings reference
+  // https://docs.oracle.com/javase/8/docs/api/java/util/TimeZone.html
   private final TimeZone timeZone;
 
   /**

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/keygen/TimestampBasedKeyGenerator.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/keygen/TimestampBasedKeyGenerator.java
@@ -51,7 +51,7 @@ public class TimestampBasedKeyGenerator extends SimpleKeyGenerator {
 
   private final String outputDateFormat;
 
-  private TimeZone timeZone;
+  private final TimeZone timeZone;
 
   /**
    * Supported configs.
@@ -80,7 +80,6 @@ public class TimestampBasedKeyGenerator extends SimpleKeyGenerator {
       DataSourceUtils.checkRequiredProperties(config,
           Collections.singletonList(Config.TIMESTAMP_INPUT_DATE_FORMAT_PROP));
       this.inputDateFormat = new SimpleDateFormat(config.getString(Config.TIMESTAMP_INPUT_DATE_FORMAT_PROP));
-      this.timeZone = TimeZone.getTimeZone(config.getString(Config.TIMESTAMP_TIMEZONE_FORMAT_PROP, "GMT"));
       this.inputDateFormat.setTimeZone(timeZone);
     }
   }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestTimestampBasedKeyGenerator.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestTimestampBasedKeyGenerator.java
@@ -15,60 +15,57 @@ import java.io.IOException;
 import static org.junit.Assert.assertEquals;
 
 public class TestTimestampBasedKeyGenerator {
-    private Schema schema = SchemaTestUtil.getTimestampEvolvedSchema();
-    private GenericRecord baseRecord = null;
+  private Schema schema = SchemaTestUtil.getTimestampEvolvedSchema();
+  private GenericRecord baseRecord = null;
 
-    public TestTimestampBasedKeyGenerator() throws IOException {
-    }
+  public TestTimestampBasedKeyGenerator() throws IOException {
+  }
 
-    @Before
-    public void initialize() throws IOException {
-        baseRecord = SchemaTestUtil
-                .generateAvroRecordFromJson(schema, 1, "001", "f1");
-    }
+  @Before
+  public void initialize() throws IOException {
+    baseRecord = SchemaTestUtil
+        .generateAvroRecordFromJson(schema, 1, "001", "f1");
+  }
 
-    private TypedProperties getKeyConfig(String recordKeyFieldName, String partitionPathField, String hiveStylePartitioning) {
-        TypedProperties props = new TypedProperties();
-        props.setProperty(DataSourceWriteOptions.RECORDKEY_FIELD_OPT_KEY(), recordKeyFieldName);
-        props.setProperty(DataSourceWriteOptions.PARTITIONPATH_FIELD_OPT_KEY(), partitionPathField);
-        props.setProperty(DataSourceWriteOptions.HIVE_STYLE_PARTITIONING_OPT_KEY(), hiveStylePartitioning);
-        props.setProperty("hoodie.deltastreamer.keygen.timebased.timestamp.type", "EPOCHMILLISECONDS");
-        props.setProperty("hoodie.deltastreamer.keygen.timebased.output.dateformat", "yyyy-MM-dd hh");
-        props.setProperty("hoodie.deltastreamer.keygen.timebased.timezone", "GMT+8:00");
-        return props;
-    }
+  private TypedProperties getKeyConfig(String recordKeyFieldName, String partitionPathField, String hiveStylePartitioning) {
+    TypedProperties props = new TypedProperties();
+    props.setProperty(DataSourceWriteOptions.RECORDKEY_FIELD_OPT_KEY(), recordKeyFieldName);
+    props.setProperty(DataSourceWriteOptions.PARTITIONPATH_FIELD_OPT_KEY(), partitionPathField);
+    props.setProperty(DataSourceWriteOptions.HIVE_STYLE_PARTITIONING_OPT_KEY(), hiveStylePartitioning);
+    props.setProperty("hoodie.deltastreamer.keygen.timebased.timestamp.type", "EPOCHMILLISECONDS");
+    props.setProperty("hoodie.deltastreamer.keygen.timebased.output.dateformat", "yyyy-MM-dd hh");
+    props.setProperty("hoodie.deltastreamer.keygen.timebased.timezone", "GMT+8:00");
+    return props;
+  }
 
-    private TypedProperties getKeyConfig2(String recordKeyFieldName, String partitionPathField, String hiveStylePartitioning) {
-        TypedProperties props = getKeyConfig(recordKeyFieldName, partitionPathField, hiveStylePartitioning);
-        props.setProperty("hoodie.deltastreamer.keygen.timebased.timezone", "GMT");
-        return props;
-    }
+  private TypedProperties getKeyConfig2(String recordKeyFieldName, String partitionPathField, String hiveStylePartitioning) {
+    TypedProperties props = getKeyConfig(recordKeyFieldName, partitionPathField, hiveStylePartitioning);
+    props.setProperty("hoodie.deltastreamer.keygen.timebased.timezone", "GMT");
+    return props;
+  }
 
-    private TypedProperties getKeyConfig3(String recordKeyFieldName, String partitionPathField, String hiveStylePartitioning) {
-        TypedProperties props = getKeyConfig(recordKeyFieldName, partitionPathField, hiveStylePartitioning);
-        props.setProperty("hoodie.deltastreamer.keygen.timebased.timestamp.type", "DATE_STRING");
-        props.setProperty("hoodie.deltastreamer.keygen.timebased.input.dateformat", "yyyy-MM-dd hh:mm:ss");
-        props.setProperty("hoodie.deltastreamer.keygen.timebased.timezone", "GMT+8:00");
-        return props;
-    }
+  private TypedProperties getKeyConfig3(String recordKeyFieldName, String partitionPathField, String hiveStylePartitioning) {
+    TypedProperties props = getKeyConfig(recordKeyFieldName, partitionPathField, hiveStylePartitioning);
+    props.setProperty("hoodie.deltastreamer.keygen.timebased.timestamp.type", "DATE_STRING");
+    props.setProperty("hoodie.deltastreamer.keygen.timebased.input.dateformat", "yyyy-MM-dd hh:mm:ss");
+    props.setProperty("hoodie.deltastreamer.keygen.timebased.timezone", "GMT+8:00");
+    return props;
+  }
 
+  @Test
+  public void testTimestampBasedKeyGenerator() {
+    // if timezone is GMT+8:00
+    baseRecord.put("createTime", 1578283932000L);
+    HoodieKey hk1 = new TimestampBasedKeyGenerator(getKeyConfig("field1", "createTime", "false")).getKey(baseRecord);
+    assertEquals(hk1.getPartitionPath(), "2020-01-06 12");
 
-    @Test
-    public void testTimestampBasedKeyGenerator() {
-        // if timezone is GMT+8:00
-        baseRecord.put("createTime",1578283932000L);
-        HoodieKey hk1 = new TimestampBasedKeyGenerator(getKeyConfig("field1", "createTime", "false")).getKey(baseRecord);
-        assertEquals(hk1.getPartitionPath(), "2020-01-06 12");
+    // if timezone is GMT
+    HoodieKey hk2 = new TimestampBasedKeyGenerator(getKeyConfig2("field1", "createTime", "false")).getKey(baseRecord);
+    assertEquals(hk2.getPartitionPath(), "2020-01-06 04");
 
-        // if timezone is GMT
-        HoodieKey hk2 = new TimestampBasedKeyGenerator(getKeyConfig2("field1", "createTime", "false")).getKey(baseRecord);
-        assertEquals(hk2.getPartitionPath(), "2020-01-06 04");
-
-        // if timestamp is DATE_STRING
-        baseRecord.put("createTime","2020-01-06 12:12:12");
-        HoodieKey hk3 = new TimestampBasedKeyGenerator(getKeyConfig3("field1", "createTime", "false")).getKey(baseRecord);
-        assertEquals(hk3.getPartitionPath(), "2020-01-06 12");
-    }
-
-
+    // if timestamp is DATE_STRING
+    baseRecord.put("createTime", "2020-01-06 12:12:12");
+    HoodieKey hk3 = new TimestampBasedKeyGenerator(getKeyConfig3("field1", "createTime", "false")).getKey(baseRecord);
+    assertEquals(hk3.getPartitionPath(), "2020-01-06 12");
+  }
 }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestTimestampBasedKeyGenerator.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestTimestampBasedKeyGenerator.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hudi.utilities;
 
 import org.apache.avro.Schema;

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestTimestampBasedKeyGenerator.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestTimestampBasedKeyGenerator.java
@@ -1,0 +1,74 @@
+package org.apache.hudi.utilities;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.hudi.DataSourceWriteOptions;
+import org.apache.hudi.common.model.HoodieKey;
+import org.apache.hudi.common.util.SchemaTestUtil;
+import org.apache.hudi.common.util.TypedProperties;
+import org.apache.hudi.utilities.keygen.TimestampBasedKeyGenerator;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestTimestampBasedKeyGenerator {
+    private Schema schema = SchemaTestUtil.getTimestampEvolvedSchema();
+    private GenericRecord baseRecord = null;
+
+    public TestTimestampBasedKeyGenerator() throws IOException {
+    }
+
+    @Before
+    public void initialize() throws IOException {
+        baseRecord = SchemaTestUtil
+                .generateAvroRecordFromJson(schema, 1, "001", "f1");
+    }
+
+    private TypedProperties getKeyConfig(String recordKeyFieldName, String partitionPathField, String hiveStylePartitioning) {
+        TypedProperties props = new TypedProperties();
+        props.setProperty(DataSourceWriteOptions.RECORDKEY_FIELD_OPT_KEY(), recordKeyFieldName);
+        props.setProperty(DataSourceWriteOptions.PARTITIONPATH_FIELD_OPT_KEY(), partitionPathField);
+        props.setProperty(DataSourceWriteOptions.HIVE_STYLE_PARTITIONING_OPT_KEY(), hiveStylePartitioning);
+        props.setProperty("hoodie.deltastreamer.keygen.timebased.timestamp.type", "EPOCHMILLISECONDS");
+        props.setProperty("hoodie.deltastreamer.keygen.timebased.output.dateformat", "yyyy-MM-dd hh");
+        props.setProperty("hoodie.deltastreamer.keygen.timebased.timezone", "GMT+8:00");
+        return props;
+    }
+
+    private TypedProperties getKeyConfig2(String recordKeyFieldName, String partitionPathField, String hiveStylePartitioning) {
+        TypedProperties props = getKeyConfig(recordKeyFieldName, partitionPathField, hiveStylePartitioning);
+        props.setProperty("hoodie.deltastreamer.keygen.timebased.timezone", "GMT");
+        return props;
+    }
+
+    private TypedProperties getKeyConfig3(String recordKeyFieldName, String partitionPathField, String hiveStylePartitioning) {
+        TypedProperties props = getKeyConfig(recordKeyFieldName, partitionPathField, hiveStylePartitioning);
+        props.setProperty("hoodie.deltastreamer.keygen.timebased.timestamp.type", "DATE_STRING");
+        props.setProperty("hoodie.deltastreamer.keygen.timebased.input.dateformat", "yyyy-MM-dd hh:mm:ss");
+        props.setProperty("hoodie.deltastreamer.keygen.timebased.timezone", "GMT+8:00");
+        return props;
+    }
+
+
+    @Test
+    public void testTimestampBasedKeyGenerator() {
+        // if timezone is GMT+8:00
+        baseRecord.put("createTime",1578283932000L);
+        HoodieKey hk1 = new TimestampBasedKeyGenerator(getKeyConfig("field1", "createTime", "false")).getKey(baseRecord);
+        assertEquals(hk1.getPartitionPath(), "2020-01-06 12");
+
+        // if timezone is GMT
+        HoodieKey hk2 = new TimestampBasedKeyGenerator(getKeyConfig2("field1", "createTime", "false")).getKey(baseRecord);
+        assertEquals(hk2.getPartitionPath(), "2020-01-06 04");
+
+        // if timestamp is DATE_STRING
+        baseRecord.put("createTime","2020-01-06 12:12:12");
+        HoodieKey hk3 = new TimestampBasedKeyGenerator(getKeyConfig3("field1", "createTime", "false")).getKey(baseRecord);
+        assertEquals(hk3.getPartitionPath(), "2020-01-06 12");
+    }
+
+
+}


### PR DESCRIPTION
## What is the purpose of the pull request
provide a custom time zone definition, such as GMT+8:00 **Instead of default "GMT"**

## Verify this pull request

alrealy exists test units

#JIRA
https://issues.apache.org/jira/browse/HUDI-502

TimestampBasedKeyGenerator defualt TimeZone is GMT, but it's not cover all everthing. example, i push chinese time zone GMT+8:00 style timestamp data to hudi, but keygenerator create GMT time zone data, it's wrong! so i submit this pr.