### PR TITLE
[HUDI-526] add parition meta file in HoodieAppendHandle

### DIFF
--- a/hudi-client/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
+++ b/hudi-client/src/main/java/org/apache/hudi/io/HoodieAppendHandle.java
@@ -23,6 +23,7 @@ import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieDeltaWriteStat;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieLogFile;
+import org.apache.hudi.common.model.HoodiePartitionMetadata;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordLocation;
 import org.apache.hudi.common.model.HoodieRecordPayload;
@@ -132,6 +133,10 @@ public class HoodieAppendHandle<T extends HoodieRecordPayload> extends HoodieWri
       writeStatus.getStat().setFileId(fileId);
       averageRecordSize = SizeEstimator.estimate(record);
       try {
+        //save hoodie partition meta in the partition path
+        HoodiePartitionMetadata partitionMetadata = new HoodiePartitionMetadata(fs, baseInstantTime,
+            new Path(config.getBasePath()), FSUtils.getPartitionPath(config.getBasePath(), partitionPath));
+        partitionMetadata.trySave(TaskContext.getPartitionId());
         this.writer = createLogWriter(fileSlice, baseInstantTime);
         this.currentLogFile = writer.getLogFile();
         ((HoodieDeltaWriteStat) writeStatus.getStat()).setLogVersion(currentLogFile.getLogVersion());


### PR DESCRIPTION
compact will retrieve the partition path which has partition meta file at that path

add partition meta file in the partition path
```
-rw-r--r--   1 liujianhui  wheel    2576  1 10 17:00 .5e8241a6-7844-4c8e-8428-966438424640-0_20200109181330.log.2_2-149-210
-rw-r--r--   1 liujianhui  wheel    2886  1 10 17:15 .5e8241a6-7844-4c8e-8428-966438424640-0_20200109181330.log.3_1-160-226
-rw-r--r--   1 liujianhui  wheel    2571  1 13 10:58 .5e8241a6-7844-4c8e-8428-966438424640-0_20200109181330.log.4_1-7-12
-rw-r--r--   1 liujianhui  wheel    2572  1 13 14:58 .5e8241a6-7844-4c8e-8428-966438424640-0_20200109181330.log.5_1-7-12
-rw-r--r--   1 liujianhui  wheel    2572  1 13 15:55 .5e8241a6-7844-4c8e-8428-966438424640-0_20200109181330.log.6_1-7-12
-rw-r--r--   1 liujianhui  wheel    2576  1 13 16:43 .5e8241a6-7844-4c8e-8428-966438424640-0_20200109181330.log.7_1-18-29
-rw-r--r--   1 liujianhui  wheel    2571  1 13 19:09 .5e8241a6-7844-4c8e-8428-966438424640-0_20200109181330.log.8_1-7-12
-rw-r--r--   1 liujianhui  wheel      93  1 13 19:09 .hoodie_partition_metadata
-rw-r--r--   1 liujianhui  wheel  439809  1 13 19:09 5e8241a6-7844-4c8e-8428-966438424640-0_0-12-20_20200113190955.parquet
```
