### PR TITLE
[HUDI-527] scalastyle-maven-plugin moved to pluginManagement

### DIFF
--- a/hudi-cli/pom.xml
+++ b/hudi-cli/pom.xml
@@ -110,6 +110,13 @@
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.scalastyle</groupId>
+        <artifactId>scalastyle-maven-plugin</artifactId>
+        <configuration>
+          <includeTestSourceDirectory>false</includeTestSourceDirectory>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/hudi-spark/pom.xml
+++ b/hudi-spark/pom.xml
@@ -140,6 +140,10 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.scalastyle</groupId>
+        <artifactId>scalastyle-maven-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -154,29 +154,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.scalastyle</groupId>
-        <artifactId>scalastyle-maven-plugin</artifactId>
-        <version>1.0.0</version>
-        <configuration>
-          <verbose>false</verbose>
-          <failOnViolation>true</failOnViolation>
-          <includeTestSourceDirectory>true</includeTestSourceDirectory>
-          <failOnWarning>false</failOnWarning>
-          <sourceDirectory>${project.basedir}/src/main/scala</sourceDirectory>
-          <testSourceDirectory>${project.basedir}/src/test/scala</testSourceDirectory>
-          <configLocation>${main.basedir}/style/scalastyle.xml</configLocation>
-          <outputEncoding>UTF-8</outputEncoding>
-        </configuration>
-        <executions>
-          <execution>
-            <phase>compile</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
 <!--
       See https://jira.apache.org/jira/browse/HUDI-304
       <plugin>
@@ -384,6 +361,29 @@
                 </outputDirectory>
                 <stringType>String</stringType>
               </configuration>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.scalastyle</groupId>
+          <artifactId>scalastyle-maven-plugin</artifactId>
+          <version>1.0.0</version>
+          <configuration>
+            <verbose>false</verbose>
+            <failOnViolation>true</failOnViolation>
+            <includeTestSourceDirectory>true</includeTestSourceDirectory>
+            <failOnWarning>false</failOnWarning>
+            <sourceDirectory>${project.basedir}/src/main/scala</sourceDirectory>
+            <testSourceDirectory>${project.basedir}/src/test/scala</testSourceDirectory>
+            <configLocation>${main.basedir}/style/scalastyle.xml</configLocation>
+            <outputEncoding>UTF-8</outputEncoding>
+          </configuration>
+          <executions>
+            <execution>
+              <phase>compile</phase>
+              <goals>
+                <goal>check</goal>
+              </goals>
             </execution>
           </executions>
         </plugin>


### PR DESCRIPTION
## What is the purpose of the pull request

This fixes scalastyle-maven-plugin warnings as well as unnecessary plugin invocation for most of the modules which do not have scala code.

## Brief change log
- Scala code is used in only hudi-cli and hudi-spark modules
- scalastyle-maven-plugin has been moved from pom.xml <plugin> to <pluginManagement>
- <plugin> entries have been added in hudi-cli/pom.xml and hudi-spark/pom.xml

This ensures that the scalastyle-maven-plugin will only be executed for the modules which have scala code.

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.

mvn clean package 

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [x] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.