### PR TITLE
[HUDI-530] Fix conversion of Spark struct type to Avro schema

### DIFF
--- a/hudi-client/src/test/java/org/apache/hudi/common/HoodieTestDataGenerator.java
+++ b/hudi-client/src/test/java/org/apache/hudi/common/HoodieTestDataGenerator.java
@@ -79,10 +79,12 @@ public class HoodieTestDataGenerator {
       + "{\"name\": \"rider\", \"type\": \"string\"}," + "{\"name\": \"driver\", \"type\": \"string\"},"
       + "{\"name\": \"begin_lat\", \"type\": \"double\"}," + "{\"name\": \"begin_lon\", \"type\": \"double\"},"
       + "{\"name\": \"end_lat\", \"type\": \"double\"}," + "{\"name\": \"end_lon\", \"type\": \"double\"},"
-      + "{\"name\":\"fare\",\"type\": \"double\"},"
+      + "{\"name\": \"fare\",\"type\": {\"type\":\"record\", \"name\":\"fare\",\"fields\": ["
+      + "{\"name\": \"amount\",\"type\": \"double\"},{\"name\": \"currency\", \"type\": \"string\"}]}},"
       + "{\"name\": \"_hoodie_is_deleted\", \"type\": \"boolean\", \"default\": false} ]}";
   public static String NULL_SCHEMA = Schema.create(Schema.Type.NULL).toString();
-  public static String TRIP_HIVE_COLUMN_TYPES = "double,string,string,string,double,double,double,double,double,boolean";
+  public static String TRIP_HIVE_COLUMN_TYPES = "double,string,string,string,double,double,double,double,"
+                                                  + "struct<amount:double,currency:string>,boolean";
   public static Schema avroSchema = new Schema.Parser().parse(TRIP_EXAMPLE_SCHEMA);
   public static Schema avroSchemaWithMetadataFields = HoodieAvroUtils.addMetadataFields(avroSchema);
 
@@ -152,7 +154,12 @@ public class HoodieTestDataGenerator {
     rec.put("begin_lon", rand.nextDouble());
     rec.put("end_lat", rand.nextDouble());
     rec.put("end_lon", rand.nextDouble());
-    rec.put("fare", rand.nextDouble() * 100);
+
+    GenericRecord fareRecord = new GenericData.Record(avroSchema.getField("fare").schema());
+    fareRecord.put("amount", rand.nextDouble() * 100);
+    fareRecord.put("currency", "USD");
+    rec.put("fare", fareRecord);
+
     if (isDeleteRecord) {
       rec.put("_hoodie_is_deleted", true);
     } else {

--- a/hudi-spark/src/main/scala/org/apache/hudi/AvroConversionHelper.scala
+++ b/hudi-spark/src/main/scala/org/apache/hudi/AvroConversionHelper.scala
@@ -343,7 +343,7 @@ object AvroConversionHelper {
             avroSchema,
             field.dataType,
             field.name,
-            getNewRecordNamespace(field.dataType, recordNamespace, field.name)))
+            getNewRecordNamespace(field.dataType, recordNamespace, structName)))
         (item: Any) => {
           if (item == null) {
             null

--- a/hudi-spark/src/test/java/DataSourceTestUtils.java
+++ b/hudi-spark/src/test/java/DataSourceTestUtils.java
@@ -34,7 +34,9 @@ public class DataSourceTestUtils {
     try {
       String str = ((TestRawTripPayload) record.getData()).getJsonData();
       str = "{" + str.substring(str.indexOf("\"timestamp\":"));
-      return Option.of(str.replaceAll("}", ", \"partition\": \"" + record.getPartitionPath() + "\"}"));
+      // Remove the last } bracket
+      str = str.substring(0, str.length() - 1);
+      return Option.of(str + ", \"partition\": \"" + record.getPartitionPath() + "\"}");
     } catch (IOException e) {
       return Option.empty();
     }

--- a/hudi-spark/src/test/java/HoodieJavaApp.java
+++ b/hudi-spark/src/test/java/HoodieJavaApp.java
@@ -212,8 +212,8 @@ public class HoodieJavaApp {
         .load(tablePath + (nonPartitionedTable ? "/*" : "/*/*/*/*"));
     hoodieROViewDF.registerTempTable("hoodie_ro");
     spark.sql("describe hoodie_ro").show();
-    // all trips whose fare was greater than 2.
-    spark.sql("select fare, begin_lon, begin_lat, timestamp from hoodie_ro where fare > 2.0").show();
+    // all trips whose fare amount was greater than 2.
+    spark.sql("select fare.amount, begin_lon, begin_lat, timestamp from hoodie_ro where fare.amount > 2.0").show();
 
     if (tableType.equals(HoodieTableType.COPY_ON_WRITE.name())) {
       /**

--- a/hudi-spark/src/test/java/HoodieJavaStreamingApp.java
+++ b/hudi-spark/src/test/java/HoodieJavaStreamingApp.java
@@ -195,8 +195,8 @@ public class HoodieJavaStreamingApp {
         .load(tablePath + "/*/*/*/*");
     hoodieROViewDF.registerTempTable("hoodie_ro");
     spark.sql("describe hoodie_ro").show();
-    // all trips whose fare was greater than 2.
-    spark.sql("select fare, begin_lon, begin_lat, timestamp from hoodie_ro where fare > 2.0").show();
+    // all trips whose fare amount was greater than 2.
+    spark.sql("select fare.amount, begin_lon, begin_lat, timestamp from hoodie_ro where fare.amount > 2.0").show();
 
     if (tableType.equals(HoodieTableType.COPY_ON_WRITE.name())) {
       /**

--- a/hudi-utilities/src/test/resources/delta-streamer-config/source.avsc
+++ b/hudi-utilities/src/test/resources/delta-streamer-config/source.avsc
@@ -46,7 +46,20 @@
   },
   {
     "name" : "fare",
-    "type" : "double"
+    "type" : {
+      "type" : "record",
+      "name" : "fare",
+      "fields" : [
+        {
+         "name" : "amount",
+         "type" : "double"
+        },
+        {
+         "name" : "currency",
+         "type" : "string"
+        }
+      ]
+    }
   },
   {
     "name" : "_hoodie_is_deleted",

--- a/hudi-utilities/src/test/resources/delta-streamer-config/target.avsc
+++ b/hudi-utilities/src/test/resources/delta-streamer-config/target.avsc
@@ -45,7 +45,20 @@
     "type" : "double"
   }, {
     "name" : "fare",
-    "type" : "double"
+    "type" : {
+      "type" : "record",
+      "name" : "fare",
+       "fields" : [
+        {
+         "name" : "amount",
+         "type" : "double"
+        },
+        {
+         "name" : "currency",
+         "type" : "string"
+        }
+       ]
+    }
   },
   {
      "name" : "_hoodie_is_deleted",


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

With migration of Hudi to `spark 2.4.4` and to using `native spark-avro`, there is an issue with conversion of struct fields because of the way spark-avro handles avro schema conversion vs databricks-avro. This has been reported earlier for EMR in https://github.com/apache/incubator-hudi/issues/1034 and now exists in Hudi master as well.

The issue is `spark-avro` has a different way of naming `Avro namespace` than `databricks-avro`, while converting the schema to avro schema. For example suppose the data is:

```
List("{ \"deviceId\": \"aaaaa\", \"eventType\": \"uditevent1\", \"eventTimeMilli\": 1574297893836, \"location\": { \"latitude\": 2.5, \"longitude\": 3.5 }}");
```

`databricks-avro` used to convert it to avro schema, such that namespace of `location` struct field has field name in it:
```
{
  "type" : "record",
  "name" : "hudi_issue_1034_dec30_01_record",
  "namespace" : "hoodie.hudi_issue_1034_dec30_01",
  "fields" : [ {
    "name" : "deviceId",
    "type" : [ "string", "null" ]
  }, {
    "name" : "eventTimeMilli",
    "type" : [ "long", "null" ]
  }, {
    "name" : "location",
    "type" : [ {
      "type" : "record",
      "name" : "location",
      "namespace" : "hoodie.hudi_issue_1034_dec30_01.location",
      "fields" : [ {
        "name" : "latitude",
        "type" : [ "double", "null" ]
      }, {
        "name" : "longitude",
        "type" : [ "double", "null" ]
      } ]
    }, "null" ]
  } ]
}
```
`spark-avro` now converts the same to the following, and uses the `record name` in the schema instead:
```
{        
  "type" : "record",
  "name" : "hudi_issue_1034_dec31_01_record",
  "namespace" : "hoodie.hudi_issue_1034_dec31_01",
  "fields" : [ {
    "name" : "deviceId",
    "type" : [ "string", "null" ]
  }, {
    "name" : "eventTimeMilli",
    "type" : [ "long", "null" ]
  }, {
    "name" : "location",
    "type" : [ {
      "type" : "record",
      "name" : "location",
      "namespace" : "hoodie.hudi_issue_1034_dec31_01.hudi_issue_1034_dec31_01_record",
      "fields" : [ {
        "name" : "latitude",
        "type" : [ "double", "null" ]
      }, {
        "name" : "longitude",
        "type" : [ "double", "null" ]
      } ]
    }, "null" ]
  } ]
}
```

This PR fixes the above issue as we have now migrated to spark-avro.

## Brief change log

- Fix conversion of Spark struct type to Avro schema
- Modify the schema of data used in unit tests and integration tests to have struct type data as well, so that any issue with struct type can be caught earlier

## Verify this pull request

This PR modifies the schema of the data that is being used across unit tests and certain integration tests to have a struct field. From now on Unit/Integration tests would catch any issue with struct fields.

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [x] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.