### PR TITLE
[HUDI-537] Introduce `repair overwrite-hoodie-props` CLI command

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/RepairsCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/RepairsCommand.java
@@ -23,6 +23,7 @@ import org.apache.hudi.cli.HoodiePrintHelper;
 import org.apache.hudi.cli.utils.InputStreamConsumer;
 import org.apache.hudi.cli.utils.SparkUtil;
 import org.apache.hudi.common.model.HoodiePartitionMetadata;
+import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.util.FSUtils;
 
@@ -33,8 +34,16 @@ import org.springframework.shell.core.annotation.CliCommand;
 import org.springframework.shell.core.annotation.CliOption;
 import org.springframework.stereotype.Component;
 
+import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+import static org.apache.hudi.common.table.HoodieTableMetaClient.METAFOLDER_NAME;
 
 /**
  * CLI command to display and trigger repair options.
@@ -98,5 +107,34 @@ public class RepairsCommand implements CommandMarker {
     }
 
     return HoodiePrintHelper.print(new String[] {"Partition Path", "Metadata Present?", "Action"}, rows);
+  }
+
+  @CliCommand(value = "repair overwrite-hoodie-props", help = "Overwrite hoodie.properties with provided file. Risky operation. Proceed with caution!")
+  public String overwriteHoodieProperties(
+      @CliOption(key = {"new-props-file"}, help = "Path to a properties file on local filesystem to overwrite the table's hoodie.properties with")
+      final String overwriteFilePath) throws IOException {
+
+    HoodieTableMetaClient client = HoodieCLI.getTableMetaClient();
+    Properties newProps = new Properties();
+    newProps.load(new FileInputStream(new File(overwriteFilePath)));
+    Map<String, String> oldProps = client.getTableConfig().getProps();
+    Path metaPathDir = new Path(client.getBasePath(), METAFOLDER_NAME);
+    HoodieTableConfig.createHoodieProperties(client.getFs(), metaPathDir, newProps);
+
+    TreeSet<String> allPropKeys = new TreeSet<>();
+    allPropKeys.addAll(newProps.keySet().stream().map(Object::toString).collect(Collectors.toSet()));
+    allPropKeys.addAll(oldProps.keySet());
+
+    String[][] rows = new String[allPropKeys.size()][];
+    int ind = 0;
+    for (String propKey : allPropKeys) {
+      String[] row = new String[]{
+          propKey,
+          oldProps.getOrDefault(propKey, "null"),
+          newProps.getOrDefault(propKey, "null").toString()
+      };
+      rows[ind++] = row;
+    }
+    return HoodiePrintHelper.print(new String[] {"Property", "Old Value", "New Value"}, rows);
   }
 }


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

*(For example: This pull request adds quick-start document.)*

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

```
Welcome to Apache Hudi CLI. Please type help if you are looking for help. 
hudi->connect --path file:///tmp/hudi_cow_table
31342 [Spring Shell] INFO  org.apache.hudi.common.table.HoodieTableMetaClient  - Loading HoodieTableMetaClient from file:///tmp/hudi_cow_table
31433 [Spring Shell] WARN  org.apache.hadoop.util.NativeCodeLoader  - Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
31624 [Spring Shell] INFO  org.apache.hudi.common.util.FSUtils  - Hadoop Configuration: fs.defaultFS: [file:///], Config:[Configuration: core-default.xml, core-site.xml, mapred-default.xml, mapred-site.xml, yarn-default.xml, yarn-site.xml, hdfs-default.xml, hdfs-site.xml], FileSystem: [org.apache.hadoop.fs.LocalFileSystem@7fc13738]
31629 [Spring Shell] INFO  org.apache.hudi.common.table.HoodieTableConfig  - Loading table properties from file:/tmp/hudi_cow_table/.hoodie/hoodie.properties
31651 [Spring Shell] INFO  org.apache.hudi.common.table.HoodieTableMetaClient  - Finished Loading Table of type COPY_ON_WRITE(version=org.apache.hudi.common.model.TimelineLayoutVersion@20) from file:///tmp/hudi_cow_table
Metadata for table hudi_cow_table loaded
hudi:hudi_cow_table->repair overwrite-hoodie-props --new-props-file /tmp

optional --new-props-file: Path to a properties file on local filesystem to overwrite the table's hoodie.properties with; no default value
hudi:hudi_cow_table->repair overwrite-hoodie-props --new-props-file /tmp/hoodie-new.props
╔═════════════════════════════════╤════════════════╤═════════════════════════════════════════════════════════════╗
║ Property                        │ Old Value      │ New Value                                                   ║
╠═════════════════════════════════╪════════════════╪═════════════════════════════════════════════════════════════╣
║ hoodie.archivelog.folder        │ archived       │ archived                                                    ║
╟─────────────────────────────────┼────────────────┼─────────────────────────────────────────────────────────────╢
║ hoodie.compaction.payload.class │ null           │ org.apache.hudi.common.model.OverwriteWithLatestAvroPayload ║
╟─────────────────────────────────┼────────────────┼─────────────────────────────────────────────────────────────╢
║ hoodie.table.name               │ hudi_cow_table │ hudi_cow_table                                              ║
╟─────────────────────────────────┼────────────────┼─────────────────────────────────────────────────────────────╢
║ hoodie.table.type               │ COPY_ON_WRITE  │ MERGE_ON_READ                                               ║
╟─────────────────────────────────┼────────────────┼─────────────────────────────────────────────────────────────╢
║ hoodie.timeline.layout.version  │ null           │ 1                                                           ║
╚═════════════════════════════════╧════════════════╧═════════════════════════════════════════════════════════════╝

hudi:hudi_cow_table->

```

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.