### PR TITLE
[HUDI-552] Fix the schema mismatch in Row-to-Avro conversion

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/SourceFormatAdapter.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/SourceFormatAdapter.java
@@ -20,6 +20,7 @@ package org.apache.hudi.utilities.deltastreamer;
 
 import org.apache.hudi.AvroConversionUtils;
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.utilities.schema.FilebasedSchemaProvider;
 import org.apache.hudi.utilities.sources.AvroSource;
 import org.apache.hudi.utilities.sources.InputBatch;
 import org.apache.hudi.utilities.sources.JsonSource;
@@ -64,7 +65,17 @@ public final class SourceFormatAdapter {
       case ROW: {
         InputBatch<Dataset<Row>> r = ((RowSource) source).fetchNext(lastCkptStr, sourceLimit);
         return new InputBatch<>(Option.ofNullable(r.getBatch().map(
-            rdd -> (AvroConversionUtils.createRdd(rdd, HOODIE_RECORD_STRUCT_NAME, HOODIE_RECORD_NAMESPACE).toJavaRDD()))
+            rdd -> (
+                (r.getSchemaProvider() instanceof FilebasedSchemaProvider)
+                    // If the source schema is specified through Avro schema,
+                    // pass in the schema for the Row-to-Avro conversion
+                    // to avoid nullability mismatch between Avro schema and Row schema
+                    ? AvroConversionUtils.createRdd(
+                        rdd, r.getSchemaProvider().getSourceSchema(),
+                        HOODIE_RECORD_STRUCT_NAME, HOODIE_RECORD_NAMESPACE).toJavaRDD()
+                    : AvroConversionUtils.createRdd(
+                        rdd, HOODIE_RECORD_STRUCT_NAME, HOODIE_RECORD_NAMESPACE).toJavaRDD()
+                ))
             .orElse(null)), r.getCheckpointForNextBatch(), r.getSchemaProvider());
       }
       default:


### PR DESCRIPTION
## What is the purpose of the pull request

This PR addresses [HUDI-552](https://issues.apache.org/jira/browse/HUDI-552).  When using the `FilebasedSchemaProvider` to provide the source/target schema in Avro, while ingesting data with the same columns from `RowSource`, the DeltaStreamer failed.  The root cause is that when writing parquet files in Spark, all fields are automatically converted to be nullable for compatibility reasons.  If the source Avro schema has non-null fields, `AvroConversionUtils.createRdd` still uses the schema from the Dataframe to convert the Row to Avro record, resulting in a different schema (only nullability difference).

To fix this issue, the Avro schema, if exists, is passed to the conversion function to reconstruct the correct StructType for conversion.

## Brief change log

  - Passed the Avro schema to `createRdd` to generate the correct StructType for conversion in `DeltaSync.readFromSource` and `AvroConversionUtils.createRdd`
  - Added new tests to make sure the logic is correct (before this schema fix some of the new tests failed)

## Verify this pull request

This change added tests and can be verified as follows:

  - Added tests in `TestHoodieDeltaStreamer` to test the `HoodieDeltaStreamer` with `ParquetDFSSource` under different configurations

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.