### PR TITLE
[WIP] [HUDI-558] Introduce ability to compress bloom filters while storing in parquet

### DIFF
--- a/hudi-cli/src/main/scala/org/apache/hudi/cli/SparkHelpers.scala
+++ b/hudi-cli/src/main/scala/org/apache/hudi/cli/SparkHelpers.scala
@@ -43,7 +43,7 @@ object SparkHelpers {
     val schema: Schema = sourceRecords.get(0).getSchema
     val filter: BloomFilter = BloomFilterFactory.createBloomFilter(HoodieIndexConfig.DEFAULT_BLOOM_FILTER_NUM_ENTRIES.toInt, HoodieIndexConfig.DEFAULT_BLOOM_FILTER_FPP.toDouble,
       HoodieIndexConfig.DEFAULT_HOODIE_BLOOM_INDEX_FILTER_DYNAMIC_MAX_ENTRIES.toInt, HoodieIndexConfig.DEFAULT_BLOOM_INDEX_FILTER_TYPE);
-    val writeSupport: HoodieAvroWriteSupport = new HoodieAvroWriteSupport(new AvroSchemaConverter().convert(schema), schema, filter)
+    val writeSupport: HoodieAvroWriteSupport = new HoodieAvroWriteSupport(new AvroSchemaConverter().convert(schema), schema, filter, java.lang.Boolean.parseBoolean(HoodieIndexConfig.DEFAULT_BLOOM_INDEX_ENABLE_COMPRESSION))
     val parquetConfig: HoodieParquetConfig = new HoodieParquetConfig(writeSupport, CompressionCodecName.GZIP, HoodieStorageConfig.DEFAULT_PARQUET_BLOCK_SIZE_BYTES.toInt, HoodieStorageConfig.DEFAULT_PARQUET_PAGE_SIZE_BYTES.toInt, HoodieStorageConfig.DEFAULT_PARQUET_FILE_MAX_BYTES.toInt, fs.getConf, HoodieStorageConfig.DEFAULT_STREAM_COMPRESSION_RATIO.toDouble)
     val writer = new HoodieParquetWriter[HoodieJsonPayload, IndexedRecord](commitTime, destinationFile, parquetConfig, schema)
     for (rec <- sourceRecords) {

--- a/hudi-client/src/main/java/org/apache/hudi/config/HoodieIndexConfig.java
+++ b/hudi-client/src/main/java/org/apache/hudi/config/HoodieIndexConfig.java
@@ -58,6 +58,8 @@ public class HoodieIndexConfig extends DefaultHoodieConfig {
   public static final String DEFAULT_BLOOM_INDEX_FILTER_TYPE = BloomFilterTypeCode.SIMPLE.name();
   public static final String HOODIE_BLOOM_INDEX_FILTER_DYNAMIC_MAX_ENTRIES = "hoodie.bloom.index.filter.dynamic.max.entries";
   public static final String DEFAULT_HOODIE_BLOOM_INDEX_FILTER_DYNAMIC_MAX_ENTRIES = "100000";
+  public static final String BLOOM_INDEX_ENABLE_COMPRESSION = "hoodie.bloom.index.compressed";
+  public static final String DEFAULT_BLOOM_INDEX_ENABLE_COMPRESSION = "false";
 
   // 1B bloom filter checks happen in 250 seconds. 500ms to read a bloom filter.
   // 10M checks in 2500ms, thus amortizing the cost of reading bloom filter across partitions.
@@ -177,6 +179,11 @@ public class HoodieIndexConfig extends DefaultHoodieConfig {
       return this;
     }
 
+    public Builder bloomIndexEnableCompression(boolean enableCompression) {
+      props.setProperty(BLOOM_INDEX_ENABLE_COMPRESSION, Boolean.toString(enableCompression));
+      return this;
+    }
+
     public Builder bloomIndexKeysPerBucket(int keysPerBucket) {
       props.setProperty(BLOOM_INDEX_KEYS_PER_BUCKET_PROP, String.valueOf(keysPerBucket));
       return this;
@@ -212,6 +219,8 @@ public class HoodieIndexConfig extends DefaultHoodieConfig {
           BLOOM_INDEX_TREE_BASED_FILTER_PROP, DEFAULT_BLOOM_INDEX_TREE_BASED_FILTER);
       setDefaultOnCondition(props, !props.containsKey(BLOOM_INDEX_BUCKETIZED_CHECKING_PROP),
           BLOOM_INDEX_BUCKETIZED_CHECKING_PROP, DEFAULT_BLOOM_INDEX_BUCKETIZED_CHECKING);
+      setDefaultOnCondition(props, !props.containsKey(BLOOM_INDEX_ENABLE_COMPRESSION),
+          BLOOM_INDEX_ENABLE_COMPRESSION, DEFAULT_BLOOM_INDEX_ENABLE_COMPRESSION);
       setDefaultOnCondition(props, !props.containsKey(BLOOM_INDEX_KEYS_PER_BUCKET_PROP),
           BLOOM_INDEX_KEYS_PER_BUCKET_PROP, DEFAULT_BLOOM_INDEX_KEYS_PER_BUCKET);
       setDefaultOnCondition(props, !props.contains(BLOOM_INDEX_FILTER_TYPE),

--- a/hudi-client/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -318,6 +318,10 @@ public class HoodieWriteConfig extends DefaultHoodieConfig {
     return Double.parseDouble(props.getProperty(HoodieIndexConfig.BLOOM_FILTER_FPP));
   }
 
+  public boolean isBloomFilterCompressionEnabled() {
+    return Boolean.parseBoolean(props.getProperty(HoodieIndexConfig.BLOOM_INDEX_ENABLE_COMPRESSION));
+  }
+
   public String getHbaseZkQuorum() {
     return props.getProperty(HoodieHBaseIndexConfig.HBASE_ZKQUORUM_PROP);
   }

--- a/hudi-client/src/main/java/org/apache/hudi/io/storage/HoodieStorageWriterFactory.java
+++ b/hudi-client/src/main/java/org/apache/hudi/io/storage/HoodieStorageWriterFactory.java
@@ -57,7 +57,8 @@ public class HoodieStorageWriterFactory {
             config.getDynamicBloomFilterMaxNumEntries(),
             config.getBloomFilterType());
     HoodieAvroWriteSupport writeSupport =
-        new HoodieAvroWriteSupport(new AvroSchemaConverter().convert(schema), schema, filter);
+        new HoodieAvroWriteSupport(new AvroSchemaConverter().convert(schema), schema, filter,
+            config.isBloomFilterCompressionEnabled());
 
     HoodieParquetConfig parquetConfig = new HoodieParquetConfig(writeSupport, config.getParquetCompressionCodec(),
         config.getParquetBlockSize(), config.getParquetPageSize(), config.getParquetMaxFileSize(),

--- a/hudi-client/src/test/java/org/apache/hudi/common/HoodieClientTestUtils.java
+++ b/hudi-client/src/test/java/org/apache/hudi/common/HoodieClientTestUtils.java
@@ -224,7 +224,7 @@ public class HoodieClientTestUtils {
           .createBloomFilter(10000, 0.0000001, -1, BloomFilterTypeCode.SIMPLE.name());
     }
     HoodieAvroWriteSupport writeSupport =
-        new HoodieAvroWriteSupport(new AvroSchemaConverter().convert(schema), schema, filter);
+        new HoodieAvroWriteSupport(new AvroSchemaConverter().convert(schema), schema, filter, true);
     String commitTime = FSUtils.getCommitTime(filename);
     HoodieParquetConfig config = new HoodieParquetConfig(writeSupport, CompressionCodecName.GZIP,
         ParquetWriter.DEFAULT_BLOCK_SIZE, ParquetWriter.DEFAULT_PAGE_SIZE, 120 * 1024 * 1024,

--- a/hudi-common/src/main/java/org/apache/hudi/common/bloom/filter/BloomFilter.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/bloom/filter/BloomFilter.java
@@ -44,6 +44,11 @@ public interface BloomFilter {
   String serializeToString();
 
   /**
+   * Serialize the bloom filter as byte array.
+   */
+  byte[] serializeToBytes();
+
+  /**
    * @return the bloom index type code.
    **/
   BloomFilterTypeCode getBloomFilterTypeCode();

--- a/hudi-common/src/main/java/org/apache/hudi/common/bloom/filter/HoodieDynamicBoundedBloomFilter.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/bloom/filter/HoodieDynamicBoundedBloomFilter.java
@@ -89,13 +89,18 @@ public class HoodieDynamicBoundedBloomFilter implements BloomFilter {
 
   @Override
   public String serializeToString() {
+    return DatatypeConverter.printBase64Binary(serializeToBytes());
+  }
+
+  @Override
+  public byte[] serializeToBytes() {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     DataOutputStream dos = new DataOutputStream(baos);
     try {
       internalDynamicBloomFilter.write(dos);
       byte[] bytes = baos.toByteArray();
       dos.close();
-      return DatatypeConverter.printBase64Binary(bytes);
+      return bytes;
     } catch (IOException e) {
       throw new HoodieIndexException("Could not serialize BloomFilter instance", e);
     }

--- a/hudi-common/src/main/java/org/apache/hudi/common/bloom/filter/SimpleBloomFilter.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/bloom/filter/SimpleBloomFilter.java
@@ -97,13 +97,18 @@ public class SimpleBloomFilter implements BloomFilter {
    */
   @Override
   public String serializeToString() {
+    return DatatypeConverter.printBase64Binary(serializeToBytes());
+  }
+
+  @Override
+  public byte[] serializeToBytes() {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     DataOutputStream dos = new DataOutputStream(baos);
     try {
       filter.write(dos);
       byte[] bytes = baos.toByteArray();
       dos.close();
-      return DatatypeConverter.printBase64Binary(bytes);
+      return bytes;
     } catch (IOException e) {
       throw new HoodieIndexException("Could not serialize BloomFilter instance", e);
     }

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/GzipCompressionUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/GzipCompressionUtils.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.util;
+
+import javax.xml.bind.DatatypeConverter;
+import org.apache.hudi.exception.HoodieIOException;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+
+/**
+ * Gzip compression utils.
+ */
+public class GzipCompressionUtils {
+
+  public static final String TYPE = "GZIP";
+
+  // Use 1MB buffer
+  private static final int BUFFER_SIZE = 1024 * 1024;
+
+  /**
+   * GZip Compress a raw string.
+   * @param data Uncompressed String
+   * @return
+   */
+  public static String compress(String data) {
+    try (ByteArrayOutputStream bos = new ByteArrayOutputStream(data.length())) {
+      GZIPOutputStream gzip = new GZIPOutputStream(bos);
+      gzip.write(data.getBytes(StandardCharsets.UTF_8));
+      gzip.close();
+      byte[] compressed = bos.toByteArray();
+      Base64.Encoder encoder = Base64.getMimeEncoder();
+      return new String(encoder.encode(compressed), StandardCharsets.UTF_8);
+    } catch (IOException ioe) {
+      throw new HoodieIOException(ioe.getMessage(), ioe);
+    }
+  }
+
+  /**
+   * GZip Compress a raw byte array.
+   * @param data Uncompressed String
+   * @return
+   */
+  public static String compress(byte[] data) {
+    try (ByteArrayOutputStream bos = new ByteArrayOutputStream(data.length)) {
+      GZIPOutputStream gzip = new GZIPOutputStream(bos);
+      gzip.write(data);
+      gzip.close();
+      return DatatypeConverter.printBase64Binary(bos.toByteArray());
+    } catch (IOException ioe) {
+      throw new HoodieIOException(ioe.getMessage(), ioe);
+    }
+  }
+
+  /**
+   * Uncompress a gzip-compressed string.
+   * @param compressed Compressed String
+   * @return
+   */
+  public static String decompress(String compressed) {
+    Base64.Decoder decoder = Base64.getMimeDecoder();
+    try (final GZIPInputStream gzipInput = new GZIPInputStream(
+        new ByteArrayInputStream(decoder.decode(compressed.getBytes(StandardCharsets.UTF_8))));
+        final ByteArrayOutputStream byteOut = new ByteArrayOutputStream()) {
+      byte[] buf = new byte[BUFFER_SIZE];
+      int numRead = 0;
+      while (-1 != (numRead = gzipInput.read(buf))) {
+        byteOut.write(buf, 0, numRead);
+      }
+      return new String(byteOut.toByteArray(), StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      throw new HoodieIOException(e.getMessage(), e);
+    }
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/common/HoodieCommonTestHarness.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/HoodieCommonTestHarness.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.common;
 
+import java.util.Random;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.model.HoodieTestUtils;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
@@ -34,6 +35,8 @@ import java.io.IOException;
  * The common hoodie test harness to provide the basic infrastructure.
  */
 public class HoodieCommonTestHarness {
+
+  private static final Random RAND = new Random(46474747);
 
   protected String basePath = null;
 
@@ -89,5 +92,22 @@ public class HoodieCommonTestHarness {
    */
   protected HoodieTableType getTableType() {
     return HoodieTableType.COPY_ON_WRITE;
+  }
+
+
+  /**
+   * Generate random String of required length.
+   * @param stringLength Length of random string generated.
+   * @return
+   */
+  public static String generateRandomString(int stringLength) {
+    int lowLimit = 48; // ascii for 0
+    int upperLimit = 122; // ascii for z
+    StringBuilder buffer = new StringBuilder(stringLength);
+    for (int i = 0; i < stringLength; i++) {
+      int randomLimitedInt = lowLimit + (int) (RAND.nextFloat() * (upperLimit - lowLimit + 1));
+      buffer.append((char) randomLimitedInt);
+    }
+    return buffer.toString();
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestGzipCompressionUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestGzipCompressionUtils.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.util;
+
+import org.apache.hudi.common.HoodieCommonTestHarness;
+import org.apache.hudi.common.bloom.filter.BloomFilter;
+import org.apache.hudi.common.bloom.filter.SimpleBloomFilter;
+
+import org.apache.hadoop.util.hash.Hash;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.UUID;
+
+public class TestGzipCompressionUtils {
+
+  @Test
+  public void testCompressDeCompressString() {
+    String expected = HoodieCommonTestHarness.generateRandomString(2048);
+    String compressed = GzipCompressionUtils.compress(expected);
+    String decompressed = GzipCompressionUtils.decompress(compressed);
+    Assert.assertEquals(expected, decompressed);
+  }
+
+  @Test
+  public void testCompressDeCompressBloomFilter() {
+    String bloomFilterString = generateBloomIndexString();
+    String compressed = GzipCompressionUtils.compress(bloomFilterString);
+    String decompressed = GzipCompressionUtils.decompress(compressed);
+    Assert.assertEquals(bloomFilterString.length(), decompressed.length());
+    // Ensure Bloom Filter can be formed with decompressed value
+    BloomFilter bloomFilter = new SimpleBloomFilter(decompressed);
+    Assert.assertEquals(bloomFilterString, decompressed);
+  }
+
+  private static String generateBloomIndexString() {
+    int maxNumEntries = 100000;
+    BloomFilter bloomFilter = new SimpleBloomFilter(60000, 0.000000001, Hash.MURMUR_HASH);
+    for (int i = 0; i < (int)(maxNumEntries * 0.25); i++) {
+      bloomFilter.add(UUID.randomUUID().toString());
+    }
+    return bloomFilter.serializeToString();
+  }
+}

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestParquetUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestParquetUtils.java
@@ -41,7 +41,6 @@ import org.junit.runners.Parameterized.Parameters;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -58,17 +57,21 @@ import static org.junit.Assert.assertTrue;
 public class TestParquetUtils extends HoodieCommonTestHarness {
 
   String bloomFilterTypeToTest;
+  Boolean enableCompression;
 
-  @Parameters()
-  public static Collection<Object[]> data() {
+  @Parameters(name = "{index} => bloomFilterTypeToTest={0}, enableCompression={1}")
+  public static Iterable<Object[]> data() {
     return Arrays.asList(new Object[][] {
-        {BloomFilterTypeCode.SIMPLE.name()},
-        {BloomFilterTypeCode.DYNAMIC_V0.name()}
+        {BloomFilterTypeCode.SIMPLE.name(), Boolean.TRUE},
+        {BloomFilterTypeCode.SIMPLE.name(), Boolean.FALSE},
+        {BloomFilterTypeCode.DYNAMIC_V0.name(), Boolean.TRUE},
+        {BloomFilterTypeCode.DYNAMIC_V0.name(), Boolean.FALSE}
     });
   }
 
-  public TestParquetUtils(String bloomFilterTypeToTest) {
+  public TestParquetUtils(String bloomFilterTypeToTest, Boolean enableCompression) {
     this.bloomFilterTypeToTest = bloomFilterTypeToTest;
+    this.enableCompression = enableCompression;
   }
 
   @Before
@@ -132,7 +135,7 @@ public class TestParquetUtils extends HoodieCommonTestHarness {
     BloomFilter filter = BloomFilterFactory
         .createBloomFilter(1000, 0.0001, 10000, bloomFilterTypeToTest);
     HoodieAvroWriteSupport writeSupport =
-        new HoodieAvroWriteSupport(new AvroSchemaConverter().convert(schema), schema, filter);
+        new HoodieAvroWriteSupport(new AvroSchemaConverter().convert(schema), schema, filter, enableCompression);
     ParquetWriter writer = new ParquetWriter(new Path(filePath), writeSupport, CompressionCodecName.GZIP,
         120 * 1024 * 1024, ParquetWriter.DEFAULT_PAGE_SIZE);
     for (String rowKey : rowKeys) {

--- a/hudi-hive/src/test/java/org/apache/hudi/hive/TestUtil.java
+++ b/hudi-hive/src/test/java/org/apache/hudi/hive/TestUtil.java
@@ -271,7 +271,7 @@ public class TestUtil {
     org.apache.parquet.schema.MessageType parquetSchema = new AvroSchemaConverter().convert(schema);
     BloomFilter filter = BloomFilterFactory.createBloomFilter(1000, 0.0001, -1,
         BloomFilterTypeCode.SIMPLE.name());
-    HoodieAvroWriteSupport writeSupport = new HoodieAvroWriteSupport(parquetSchema, schema, filter);
+    HoodieAvroWriteSupport writeSupport = new HoodieAvroWriteSupport(parquetSchema, schema, filter, true);
     ParquetWriter writer = new ParquetWriter(filePath, writeSupport, CompressionCodecName.GZIP, 120 * 1024 * 1024,
         ParquetWriter.DEFAULT_PAGE_SIZE, ParquetWriter.DEFAULT_PAGE_SIZE, ParquetWriter.DEFAULT_IS_DICTIONARY_ENABLED,
         ParquetWriter.DEFAULT_IS_VALIDATING_ENABLED, ParquetWriter.DEFAULT_WRITER_VERSION, fileSystem.getConf());


### PR DESCRIPTION

## What is the purpose of the pull request

* Introduce ability to compress bloom filters while storing in parquet

## Verify this pull request

This change added tests and can be verified as follows:

## Committer checklist

 - [X ] Has a corresponding JIRA in PR title & commit
 
 - [ X] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.