### PR TITLE
[HUDI-573] Refactoring getter to avoid double extrametadata in json representation of HoodieCommitMetadata

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieCommitMetadata.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieCommitMetadata.java
@@ -47,7 +47,7 @@ public class HoodieCommitMetadata implements Serializable {
   protected Map<String, List<HoodieWriteStat>> partitionToWriteStats;
   protected Boolean compacted;
 
-  private Map<String, String> extraMetadataMap;
+  private Map<String, String> extraMetadata;
 
   // for ser/deser
   public HoodieCommitMetadata() {
@@ -55,7 +55,7 @@ public class HoodieCommitMetadata implements Serializable {
   }
 
   public HoodieCommitMetadata(boolean compacted) {
-    extraMetadataMap = new HashMap<>();
+    extraMetadata = new HashMap<>();
     partitionToWriteStats = new HashMap<>();
     this.compacted = compacted;
   }
@@ -68,7 +68,7 @@ public class HoodieCommitMetadata implements Serializable {
   }
 
   public void addMetadata(String metaKey, String value) {
-    extraMetadataMap.put(metaKey, value);
+    extraMetadata.put(metaKey, value);
   }
 
   public List<HoodieWriteStat> getWriteStats(String partitionPath) {
@@ -76,7 +76,7 @@ public class HoodieCommitMetadata implements Serializable {
   }
 
   public Map<String, String> getExtraMetadata() {
-    return extraMetadataMap;
+    return extraMetadata;
   }
 
   public Map<String, List<HoodieWriteStat>> getPartitionToWriteStats() {
@@ -84,7 +84,7 @@ public class HoodieCommitMetadata implements Serializable {
   }
 
   public String getMetadata(String metaKey) {
-    return extraMetadataMap.get(metaKey);
+    return extraMetadata.get(metaKey);
   }
 
   public Boolean getCompacted() {
@@ -343,6 +343,6 @@ public class HoodieCommitMetadata implements Serializable {
   @Override
   public String toString() {
     return "HoodieCommitMetadata{partitionToWriteStats=" + partitionToWriteStats + ", compacted=" + compacted
-        + ", extraMetadataMap=" + extraMetadataMap + '}';
+        + ", extraMetadata=" + extraMetadata + '}';
   }
 }


### PR DESCRIPTION
## What is the purpose of the pull request

This PR fixes the double representation of the extra metadata map in HoodieCommitMetadata

## Brief change log

Refactored getter in HoodieCommitMetadata to avoid double string representation when object is converted to json string.
