### PR TITLE
[HUDI-584] Relocate spark-avro dependency by maven-shade-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ Prerequisites for building Apache Hudi:
 # Checkout code and build
 git clone https://github.com/apache/incubator-hudi.git && cd incubator-hudi
 mvn clean package -DskipTests -DskipITs
+
+# Start command
+spark-2.4.4-bin-hadoop2.7/bin/spark-shell \
+  --jars `ls packaging/hudi-spark-bundle/target/hudi-spark-bundle_2.11-*.*.*-SNAPSHOT.jar` \
+  --conf 'spark.serializer=org.apache.spark.serializer.KryoSerializer'
 ```
 
 To build the Javadoc for all Java and Scala classes:
@@ -69,6 +74,22 @@ The default Scala version supported is 2.11. To build for Scala 2.12 version, bu
 
 ```
 mvn clean package -DskipTests -DskipITs -Dscala-2.12
+```
+
+### Build without spark-avro module
+
+The default hudi-jar bundles spark-avro module. To build without spark-avro module, build using `spark-shade-unbundle-avro` profile
+
+```
+# Checkout code and build
+git clone https://github.com/apache/incubator-hudi.git && cd incubator-hudi
+mvn clean package -DskipTests -DskipITs -Pspark-shade-unbundle-avro
+
+# Start command
+spark-2.4.4-bin-hadoop2.7/bin/spark-shell \
+  --packages org.apache.spark:spark-avro_2.11:2.4.4 \
+  --jars `ls packaging/hudi-spark-bundle/target/hudi-spark-bundle_2.11-*.*.*-SNAPSHOT.jar` \
+  --conf 'spark.serializer=org.apache.spark.serializer.KryoSerializer'
 ```
 
 ## Quickstart

--- a/packaging/hudi-spark-bundle/pom.xml
+++ b/packaging/hudi-spark-bundle/pom.xml
@@ -89,6 +89,7 @@
                   <include>io.dropwizard.metrics:metrics-graphite</include>
                   <include>com.yammer.metrics:metrics-core</include>
 
+                  <include>org.apache.spark:spark-avro_${scala.binary.version}</include>
                   <include>org.apache.hive:hive-common</include>
                   <include>org.apache.hive:hive-service</include>
                   <include>org.apache.hive:hive-service-rpc</include>
@@ -100,6 +101,10 @@
                 <relocation>
                   <pattern>com.beust.jcommander.</pattern>
                   <shadedPattern>org.apache.hudi.com.beust.jcommander.</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.spark.sql.avro.</pattern>
+                  <shadedPattern>${spark.bundle.spark.shade.prefix}org.apache.spark.sql.avro.</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>org.apache.hive.jdbc.</pattern>
@@ -194,6 +199,13 @@
       <version>${project.version}</version>
     </dependency>
 
+    <!-- Spark (Packages) -->
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-avro_${scala.binary.version}</artifactId>
+      <scope>${spark.bundle.avro.scope}</scope>
+    </dependency>
+
     <!-- Parquet -->
     <dependency>
       <groupId>org.apache.parquet</groupId>
@@ -248,6 +260,12 @@
         <spark.bundle.hive.shade.prefix>org.apache.hudi.</spark.bundle.hive.shade.prefix>
       </properties>
     </profile>
+    <profile>
+      <id>spark-shade-unbundle-avro</id>
+      <properties>
+        <spark.bundle.avro.scope>provided</spark.bundle.avro.scope>
+        <spark.bundle.spark.shade.prefix></spark.bundle.spark.shade.prefix>
+      </properties>
+    </profile>
   </profiles>
 </project>
-

--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,8 @@
     <main.basedir>${project.basedir}</main.basedir>
     <spark.bundle.hive.scope>provided</spark.bundle.hive.scope>
     <spark.bundle.hive.shade.prefix></spark.bundle.hive.shade.prefix>
+    <spark.bundle.avro.scope>compile</spark.bundle.avro.scope>
+    <spark.bundle.spark.shade.prefix>org.apache.hudi.spark.</spark.bundle.spark.shade.prefix>
     <utilities.bundle.hive.scope>provided</utilities.bundle.hive.scope>
     <utilities.bundle.hive.shade.prefix></utilities.bundle.hive.shade.prefix>
     <argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>


### PR DESCRIPTION
## What is the purpose of the pull request

From [spark-avro-guide](http://spark.apache.org/docs/latest/sql-data-sources-avro.html), we know that the spark-avro module is external, it is not exists in [spark-2.4.4-bin-hadoop2.7.tgz](http://mirror.bit.edu.cn/apache/spark/spark-2.4.4/spark-2.4.4-bin-hadoop2.7.tgz).

**Shade spark-avro:**
- User will not use `--packages org.apache.spark:spark-avro_2.11:2.4.4`
- User also don't need care about using the `scala-2.11` or `scala-2.12`
- Avoid conflicts with local jar

## Brief change log

  - *Relocate spark-avro dependency by maven-shade-plugin*

## Verify this pull request

```
export SPARK_HOME=/work/BigData/install/spark/spark-2.4.4-bin-hadoop2.7

${SPARK_HOME}/bin/spark-shell \
    --jars `ls packaging/hudi-spark-bundle/target/hudi-spark-bundle_*.*-*.*.*-SNAPSHOT.jar` \
    --conf 'spark.serializer=org.apache.spark.serializer.KryoSerializer'

val basePath = "file:///tmp/hudi_mor_table"

var datas = List("""{ "name": "kenken", "ts": 1574297893836, "age": 12, "location": "latitude"}""")
val df = spark.read.json(spark.sparkContext.parallelize(datas, 2))
df.write.format("org.apache.hudi").
    option("hoodie.datasource.write.recordkey.field", "name").
    option("hoodie.datasource.write.partitionpath.field", "location").
    option("hoodie.datasource.write.precombine.field", "ts").
    option("hoodie.table.name", "tableName").
    mode("Overwrite").
    save(basePath)

spark.read.format("org.apache.hudi").load(basePath + "/*/").show()
```

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.