### PR TITLE
[HUDI-587] Fixed generation of jacoco coverage reports.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,7 @@
     <spark.bundle.hive.shade.prefix></spark.bundle.hive.shade.prefix>
     <utilities.bundle.hive.scope>provided</utilities.bundle.hive.scope>
     <utilities.bundle.hive.shade.prefix></utilities.bundle.hive.shade.prefix>
+    <argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>
   </properties>
 
   <scm>
@@ -235,7 +236,6 @@
           <excludes>
             <exclude>**/IT*.java</exclude>
           </excludes>
-          <argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>
         </configuration>
       </plugin>
     </plugins>
@@ -264,11 +264,6 @@
               <configuration>
                 <!-- Sets the path to the file which contains the execution data. -->
                 <destFile>${project.build.directory}/coverage-reports/jacoco-ut.exec</destFile>
-                <!--
-                    Sets the name of the property containing the settings
-                    for JaCoCo runtime agent.
-                -->
-                <propertyName>surefireArgLine</propertyName>
               </configuration>
             </execution>
             <!--


### PR DESCRIPTION
## What is the purpose of the pull request
Fix generation of jacococ coverage reports after unit tests are run.

## Brief change log

surefire plugin's argLine is moved into a property. This configuration allows jacoco plugin to modify the argLine to insert it's Java Agent's configuration during pre-unit-test stage.

## Verify this pull request

This pull request is already covered by existing tests, such as *(please describe tests)*.

Executed unit test and confirmed that coverage report is generated. See these logs:

mvn test -Dtest=TestHoodieActiveTimeline

10:33:33 [INFO] --- jacoco-maven-plugin:0.7.8:prepare-agent (pre-unit-test) @ hudi-common ---
10:33:33 [INFO] argLine set to -javaagent:/home/pwason/.m2/repository/org/jacoco/org.jacoco.agent/0.7.8/org.jacoco.agent-0.7.8-runtime.jar=destfile=/home/pwason/work/java/incubator-hudi/hudi-common/target/coverage-reports/jacoco-ut.exec -Xmx1024m -XX:MaxPermSize=256m

...
...

10:33:41 [INFO] --- jacoco-maven-plugin:0.7.8:report (post-unit-test) @ hudi-common ---
10:33:41 [INFO] Loading execution data file /home/pwason/work/java/incubator-hudi/hudi-common/target/coverage-reports/jacoco-ut.exec
10:33:42 [INFO] Analyzed bundle 'hudi-common' with 273 classes


ls -al hudi-common/target/coverage-reports/jacoco-ut.exec
-rw-rw-r-- 1 pwason pwason 49240 Jan 31 10:33 hudi-common/target/coverage-reports/jacoco-ut.exec


## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.