### PR TITLE
[MINOR] Replace Thread.sleep with TimeUnit*

### DIFF
--- a/hudi-client/src/main/java/org/apache/hudi/index/hbase/HBaseIndex.java
+++ b/hudi-client/src/main/java/org/apache/hudi/index/hbase/HBaseIndex.java
@@ -66,6 +66,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import scala.Tuple2;
 
@@ -335,7 +336,7 @@ public class HBaseIndex<T extends HoodieRecordPayload> extends HoodieIndex<T> {
 
   private static void sleepForTime(int sleepTimeMs) {
     try {
-      Thread.sleep(sleepTimeMs);
+      TimeUnit.MILLISECONDS.sleep(sleepTimeMs);
     } catch (InterruptedException e) {
       LOG.error("Sleep interrupted during throttling", e);
       throw new RuntimeException(e);

--- a/hudi-client/src/test/java/org/apache/hudi/common/HoodieClientTestUtils.java
+++ b/hudi-client/src/test/java/org/apache/hudi/common/HoodieClientTestUtils.java
@@ -68,6 +68,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 /**
@@ -250,7 +251,7 @@ public class HoodieClientTestUtils {
 
   public static String writeParquetFile(String basePath, String partitionPath, List<HoodieRecord> records,
                                         Schema schema, BloomFilter filter, boolean createCommitTime) throws IOException, InterruptedException {
-    Thread.sleep(1000);
+    TimeUnit.SECONDS.sleep(1);
     String commitTime = HoodieTestUtils.makeNewCommitTime();
     String fileId = UUID.randomUUID().toString();
     String filename = FSUtils.makeDataFileName(commitTime, "1-0-1", fileId);

--- a/hudi-client/src/test/java/org/apache/hudi/func/TestBoundedInMemoryQueue.java
+++ b/hudi-client/src/test/java/org/apache/hudi/func/TestBoundedInMemoryQueue.java
@@ -47,6 +47,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -227,7 +228,7 @@ public class TestBoundedInMemoryQueue extends HoodieClientTestHarness {
     });
     // waiting for permits to expire.
     while (!isQueueFull(queue.rateLimiter)) {
-      Thread.sleep(10);
+      TimeUnit.MILLISECONDS.sleep(10);
     }
     Assert.assertEquals(0, queue.rateLimiter.availablePermits());
     Assert.assertEquals(recordLimit, queue.currentRateLimit);
@@ -240,7 +241,7 @@ public class TestBoundedInMemoryQueue extends HoodieClientTestHarness {
 
     // waiting for permits to expire.
     while (!isQueueFull(queue.rateLimiter)) {
-      Thread.sleep(10);
+      TimeUnit.MILLISECONDS.sleep(10);
     }
     // No change is expected in rate limit or number of queued records. We only expect
     // queueing thread to read
@@ -280,7 +281,7 @@ public class TestBoundedInMemoryQueue extends HoodieClientTestHarness {
 
     // waiting for permits to expire.
     while (!isQueueFull(queue1.rateLimiter)) {
-      Thread.sleep(10);
+      TimeUnit.MILLISECONDS.sleep(10);
     }
     // notify queueing thread of an exception and ensure that it exits.
     final Exception e = new Exception("Failing it :)");

--- a/hudi-client/src/test/java/org/apache/hudi/table/TestCopyOnWriteTable.java
+++ b/hudi-client/src/test/java/org/apache/hudi/table/TestCopyOnWriteTable.java
@@ -60,6 +60,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import scala.Tuple2;
 
@@ -204,7 +205,7 @@ public class TestCopyOnWriteTable extends HoodieClientTestHarness {
 
     List<HoodieRecord> updatedRecords = Arrays.asList(updatedRecord1, insertedRecord1);
 
-    Thread.sleep(1000);
+    TimeUnit.SECONDS.sleep(1);
     String newCommitTime = HoodieTestUtils.makeNewCommitTime();
     metaClient = HoodieTableMetaClient.reload(metaClient);
     final HoodieCopyOnWriteTable newTable = new HoodieCopyOnWriteTable(config, jsc);

--- a/hudi-client/src/test/java/org/apache/hudi/table/TestMergeOnReadTable.java
+++ b/hudi-client/src/test/java/org/apache/hudi/table/TestMergeOnReadTable.java
@@ -70,6 +70,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -882,7 +883,7 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
       writeClient.commit(newCommitTime, statuses);
 
       // Sleep for small interval (at least 1 second) to force a new rollback start time.
-      Thread.sleep(1000);
+      TimeUnit.SECONDS.sleep(1);
 
       // We will test HUDI-204 here. We will simulate rollback happening twice by copying the commit file to local fs
       // and calling rollback twice
@@ -915,7 +916,7 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
       assertEquals(0, numLogFiles);
       metaClient.getFs().copyFromLocalFile(new Path(file.getAbsolutePath()),
           new Path(metaClient.getMetaPath(), fileName));
-      Thread.sleep(1000);
+      TimeUnit.SECONDS.sleep(1);
       // Rollback again to pretend the first rollback failed partially. This should not error our
       writeClient.rollback(newCommitTime);
       folder.delete();

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/FSUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/FSUtils.java
@@ -50,6 +50,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -458,7 +459,7 @@ public class FSUtils {
       }
       // Sleep for 1 second before trying again. Typically it takes about 2-3 seconds to recover
       // under default settings
-      Thread.sleep(1000);
+      TimeUnit.SECONDS.sleep(1);
     }
     return recovered;
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/FailSafeConsistencyGuard.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/FailSafeConsistencyGuard.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -193,7 +194,7 @@ public class FailSafeConsistencyGuard implements ConsistencyGuard {
 
   void sleepSafe(long waitMs) {
     try {
-      Thread.sleep(waitMs);
+      TimeUnit.MILLISECONDS.sleep(waitMs);
     } catch (InterruptedException e) {
       // ignore & continue next attempt
     }

--- a/hudi-common/src/test/java/org/apache/hudi/common/minicluster/ZookeeperTestService.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/minicluster/ZookeeperTestService.java
@@ -36,6 +36,7 @@ import java.io.OutputStream;
 import java.io.Reader;
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.util.concurrent.TimeUnit;
 
 /**
  * A Zookeeper minicluster service implementation.
@@ -187,7 +188,7 @@ public class ZookeeperTestService {
         break;
       }
       try {
-        Thread.sleep(250);
+        TimeUnit.MILLISECONDS.sleep(250);
       } catch (InterruptedException e) {
         // ignore
       }
@@ -228,7 +229,7 @@ public class ZookeeperTestService {
         break;
       }
       try {
-        Thread.sleep(250);
+        TimeUnit.MILLISECONDS.sleep(250);
       } catch (InterruptedException e) {
         // ignore
       }

--- a/hudi-hive/src/test/java/org/apache/hudi/hive/util/HiveTestService.java
+++ b/hudi-hive/src/test/java/org/apache/hudi/hive/util/HiveTestService.java
@@ -56,6 +56,7 @@ import java.net.SocketException;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 public class HiveTestService {
 
@@ -162,7 +163,7 @@ public class HiveTestService {
         break;
       }
       try {
-        Thread.sleep(250);
+        TimeUnit.MILLISECONDS.sleep(250);
       } catch (InterruptedException e) {
         // ignore
       }

--- a/hudi-integ-test/src/test/java/org/apache/hudi/integ/ITTestHoodieSanity.java
+++ b/hudi-integ-test/src/test/java/org/apache/hudi/integ/ITTestHoodieSanity.java
@@ -25,6 +25,8 @@ import org.apache.hudi.common.model.HoodieTableType;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * Smoke tests to run as part of verification.
  */
@@ -123,7 +125,7 @@ public class ITTestHoodieSanity extends ITTestBase {
     } catch (AssertionError ex) {
       // In travis, sometimes, the hivemetastore is not ready even though we wait for the port to be up
       // Workaround to sleep for 5 secs and retry
-      Thread.sleep(5000);
+      TimeUnit.SECONDS.sleep(5);
       dropHiveTables(hiveTableName, tableType);
     }
 

--- a/hudi-spark/src/main/scala/org/apache/hudi/HoodieStreamingSink.scala
+++ b/hudi-spark/src/main/scala/org/apache/hudi/HoodieStreamingSink.scala
@@ -16,6 +16,8 @@
  */
 package org.apache.hudi
 
+import java.util.concurrent.TimeUnit
+
 import org.apache.hudi.exception.HoodieCorruptedDataException
 import org.apache.log4j.LogManager
 import org.apache.spark.sql.execution.streaming.Sink
@@ -114,7 +116,7 @@ class HoodieStreamingSink(sqlContext: SQLContext,
     fn match {
       case x: util.Success[T] => x
       case _ if n > 1 =>
-        Thread.sleep(waitInMillis)
+        TimeUnit.MILLISECONDS.sleep(waitInMillis)
         retry(n - 1, waitInMillis * 2)(fn)
       case f => f
     }

--- a/hudi-spark/src/test/java/HoodieJavaStreamingApp.java
+++ b/hudi-spark/src/test/java/HoodieJavaStreamingApp.java
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Sample program that writes & reads hoodie tables via the Spark datasource streaming.
@@ -176,13 +177,13 @@ public class HoodieJavaStreamingApp {
   public void show(SparkSession spark, FileSystem fs, Dataset<Row> inputDF1, Dataset<Row> inputDF2) throws Exception {
     inputDF1.write().mode(SaveMode.Append).json(streamingSourcePath);
     // wait for spark streaming to process one microbatch
-    Thread.sleep(3000);
+    TimeUnit.SECONDS.sleep(3);
     String commitInstantTime1 = HoodieDataSourceHelpers.latestCommit(fs, tablePath);
     LOG.info("First commit at instant time :" + commitInstantTime1);
 
     inputDF2.write().mode(SaveMode.Append).json(streamingSourcePath);
     // wait for spark streaming to process one microbatch
-    Thread.sleep(3000);
+    TimeUnit.SECONDS.sleep(3);
     String commitInstantTime2 = HoodieDataSourceHelpers.latestCommit(fs, tablePath);
     LOG.info("Second commit at instant time :" + commitInstantTime2);
 

--- a/hudi-spark/src/test/scala/TestDataSource.scala
+++ b/hudi-spark/src/test/scala/TestDataSource.scala
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import java.util.concurrent.TimeUnit
+
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.hudi.common.HoodieTestDataGenerator
 import org.apache.hudi.common.util.FSUtils
@@ -239,7 +241,7 @@ class TestDataSource extends AssertionsForJUnit {
     val f2 = Future {
       inputDF1.write.mode(SaveMode.Append).json(sourcePath)
       // wait for spark streaming to process one microbatch
-      Thread.sleep(3000)
+      TimeUnit.SECONDS.sleep(3)
       assertTrue(HoodieDataSourceHelpers.hasNewCommits(fs, destPath, "000"))
       val commitInstantTime1: String = HoodieDataSourceHelpers.latestCommit(fs, destPath)
       // Read RO View
@@ -249,7 +251,7 @@ class TestDataSource extends AssertionsForJUnit {
 
       inputDF2.write.mode(SaveMode.Append).json(sourcePath)
       // wait for spark streaming to process one microbatch
-      Thread.sleep(10000)
+      TimeUnit.SECONDS.sleep(10)
       val commitInstantTime2: String = HoodieDataSourceHelpers.latestCommit(fs, destPath)
 
       assertEquals(2, HoodieDataSourceHelpers.listCommitsSince(fs, destPath, "000").size())

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieWithTimelineServer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieWithTimelineServer.java
@@ -36,6 +36,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 
 public class HoodieWithTimelineServer implements Serializable {
@@ -95,7 +96,7 @@ public class HoodieWithTimelineServer implements Serializable {
     try (CloseableHttpClient client = HttpClientBuilder.create().build()) {
 
       System.out.println("Sleeping for " + cfg.delaySecs + " secs ");
-      Thread.sleep(cfg.delaySecs * 1000);
+      TimeUnit.SECONDS.sleep(cfg.delaySecs);
       System.out.println("Woke up after sleeping for " + cfg.delaySecs + " secs ");
 
       HttpGet request = new HttpGet(url);

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
@@ -70,6 +70,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -444,7 +445,7 @@ public class DeltaSync implements Serializable {
         LOG.error("Got error trying to start a new commit. Retrying after sleeping for a sec", ie);
         retryNum++;
         try {
-          Thread.sleep(1000);
+          TimeUnit.SECONDS.sleep(1);
         } catch (InterruptedException e) {
           // No-Op
         }

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamer.java
@@ -400,7 +400,7 @@ public class HoodieDeltaStreamer implements Serializable {
               if (toSleepMs > 0) {
                 LOG.info("Last sync ran less than min sync interval: " + cfg.minSyncIntervalSeconds + " s, sleep: "
                     + toSleepMs + " ms.");
-                Thread.sleep(toSleepMs);
+                TimeUnit.MILLISECONDS.sleep(toSleepMs);
               }
             } catch (Exception e) {
               LOG.error("Shutting down delta-sync due to exception", e);

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/perf/TimelineServerPerf.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/perf/TimelineServerPerf.java
@@ -121,7 +121,7 @@ public class TimelineServerPerf implements Serializable {
       System.out.println("Timeline Server Host Address=" + hostAddr + ", port=" + timelineServer.getServerPort());
       while (true) {
         try {
-          Thread.sleep(60000);
+          TimeUnit.MINUTES.sleep(1);
         } catch (InterruptedException e) {
           // skip it
         }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieDeltaStreamer.java
@@ -302,7 +302,7 @@ public class TestHoodieDeltaStreamer extends UtilitiesTestBase {
         boolean ret = false;
         while (!ret) {
           try {
-            Thread.sleep(3000);
+            TimeUnit.SECONDS.sleep(3);
             ret = condition.apply(true);
           } catch (Throwable error) {
             LOG.warn("Got error :", error);


### PR DESCRIPTION
## What is the purpose of the pull request

TimeUnit is probably easier to understand for non obvious durations.

## Brief change log

  - *Replace Thread.sleep with TimeUnit**

## Verify this pull request

This pull request is code cleanup without any test coverage.

## Committer checklist

 - [X] Has a corresponding JIRA in PR title & commit
 
 - [X] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.