### PR TITLE
[HUDI-570] Improve test coverage for FSUtils.java

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/FSUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/FSUtils.java
@@ -466,9 +466,9 @@ public class FSUtils {
   public static void deleteOlderCleanMetaFiles(FileSystem fs, String metaPath, Stream<HoodieInstant> instants) {
     // TODO - this should be archived when archival is made general for all meta-data
     // skip MIN_CLEAN_TO_KEEP and delete rest
-    instants.skip(MIN_CLEAN_TO_KEEP).map(s -> {
+    instants.skip(MIN_CLEAN_TO_KEEP).forEach(s -> {
       try {
-        return fs.delete(new Path(metaPath, s.getFileName()), false);
+        fs.delete(new Path(metaPath, s.getFileName()), false);
       } catch (IOException e) {
         throw new HoodieIOException("Could not delete clean meta files" + s.getFileName(), e);
       }
@@ -478,9 +478,9 @@ public class FSUtils {
   public static void deleteOlderRollbackMetaFiles(FileSystem fs, String metaPath, Stream<HoodieInstant> instants) {
     // TODO - this should be archived when archival is made general for all meta-data
     // skip MIN_ROLLBACK_TO_KEEP and delete rest
-    instants.skip(MIN_ROLLBACK_TO_KEEP).map(s -> {
+    instants.skip(MIN_ROLLBACK_TO_KEEP).forEach(s -> {
       try {
-        return fs.delete(new Path(metaPath, s.getFileName()), false);
+        fs.delete(new Path(metaPath, s.getFileName()), false);
       } catch (IOException e) {
         throw new HoodieIOException("Could not delete rollback meta files " + s.getFileName(), e);
       }


### PR DESCRIPTION

## What is the purpose of the pull request
Increase the test coverage for FSUtils.java under hudi-common.

## Brief change log
Added test cases to increase coverage.

## Verify this pull request
This change added tests and can be verified as follows:
- testDeleteOlderRollbackFiles
- testDeleteOlderCleanMetaFiles
- testFileNameRelatedFunctions

## Committer checklist

 - [x ] Has a corresponding JIRA in PR title & commit
 
 - [x ] Commit message is descriptive of the change
 
 - [x ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.