### PR TITLE
[HUDI-605] Avoid calculating the size of schema redundantly

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/util/HoodieRecordSizeEstimator.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/HoodieRecordSizeEstimator.java
@@ -35,11 +35,10 @@ public class HoodieRecordSizeEstimator<T extends HoodieRecordPayload> implements
 
   private static final Logger LOG = LogManager.getLogger(HoodieRecordSizeEstimator.class);
 
-  // Schema used to get GenericRecord from HoodieRecordPayload then convert to bytes and vice-versa
-  private final Schema schema;
+  private final long sizeOfSchema;
 
   public HoodieRecordSizeEstimator(Schema schema) {
-    this.schema = schema;
+    sizeOfSchema = ObjectSizeCalculator.getObjectSize(schema);
   }
 
   @Override
@@ -49,8 +48,9 @@ public class HoodieRecordSizeEstimator<T extends HoodieRecordPayload> implements
     // note the sizes and differences. A correct estimation in such cases is handled in
     /** {@link ExternalSpillableMap} **/
     long sizeOfRecord = ObjectSizeCalculator.getObjectSize(hoodieRecord);
-    long sizeOfSchema = ObjectSizeCalculator.getObjectSize(schema);
-    LOG.info("SizeOfRecord => " + sizeOfRecord + " SizeOfSchema => " + sizeOfSchema);
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("SizeOfRecord => " + sizeOfRecord + " SizeOfSchema => " + sizeOfSchema);
+    }
     return sizeOfRecord;
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/collection/DiskBasedMap.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/collection/DiskBasedMap.java
@@ -223,8 +223,8 @@ public final class DiskBasedMap<T extends Serializable, R extends Serializable> 
   private synchronized R put(T key, R value, boolean flush) {
     try {
       byte[] val = SerializationUtils.serialize(value);
-      int valueSize = val.length;
-      long timestamp = System.currentTimeMillis();
+      Integer valueSize = val.length;
+      Long timestamp = System.currentTimeMillis();
       this.valueMetadataMap.put(key,
           new DiskBasedMap.ValueMetadata(this.filePath, valueSize, filePosition.get(), timestamp));
       byte[] serializedKey = SerializationUtils.serialize(key);

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/collection/DiskBasedMap.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/collection/DiskBasedMap.java
@@ -223,8 +223,8 @@ public final class DiskBasedMap<T extends Serializable, R extends Serializable> 
   private synchronized R put(T key, R value, boolean flush) {
     try {
       byte[] val = SerializationUtils.serialize(value);
-      Integer valueSize = val.length;
-      Long timestamp = System.currentTimeMillis();
+      int valueSize = val.length;
+      long timestamp = System.currentTimeMillis();
       this.valueMetadataMap.put(key,
           new DiskBasedMap.ValueMetadata(this.filePath, valueSize, filePosition.get(), timestamp));
       byte[] serializedKey = SerializationUtils.serialize(key);


### PR DESCRIPTION
## What is the purpose of the pull request

The same schema object is shared amongst all records in the JVM.

## Brief change log

  - Calculate the size of schema when init HoodieRecordSizeEstimator

## Verify this pull request

This pull request is already covered by existing tests: 
`org.apache.hudi.common.util.collection.TestDiskBasedMap`.

## Committer checklist

 - [X] Has a corresponding JIRA in PR title & commit
 
 - [X] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.