### PR TITLE
[HUDI-571] Add min/max headers on archived files

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieLogBlock.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/block/HoodieLogBlock.java
@@ -121,7 +121,7 @@ public abstract class HoodieLogBlock {
    * new enums at the end.
    */
   public enum HeaderMetadataType {
-    INSTANT_TIME, TARGET_INSTANT_TIME, SCHEMA, COMMAND_BLOCK_TYPE
+    INSTANT_TIME, TARGET_INSTANT_TIME, SCHEMA, COMMAND_BLOCK_TYPE, MIN_INSTANT_TIME, MAX_INSTANT_TIME
   }
 
   /**


### PR DESCRIPTION
## What is the purpose of the pull request

Make reading data from archived commits faster


## Brief change log
- Add min/max headers on archived files
- Use this information to filter reading unnecessary files when looking for range of commits
- Backward compatible. if headers are not present, will read all the data

## Verify this pull request


This pull request is already covered by existing tests, such as 
TestHoodieCommitArchiveLog

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.