### PR TITLE
[HUDI-574] Fix CLI counts small file inserts as updates

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/CommitsCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/CommitsCommand.java
@@ -208,11 +208,11 @@ public class CommitsCommand implements CommandMarker {
       for (HoodieWriteStat stat : stats) {
         if (stat.getPrevCommit().equals(HoodieWriteStat.NULL_COMMIT)) {
           totalFilesAdded += 1;
-          totalRecordsInserted += stat.getNumWrites();
         } else {
           totalFilesUpdated += 1;
           totalRecordsUpdated += stat.getNumUpdateWrites();
         }
+        totalRecordsInserted += stat.getNumInserts();
         totalBytesWritten += stat.getTotalWriteBytes();
         totalWriteErrors += stat.getTotalWriteErrors();
       }


### PR DESCRIPTION
## What is the purpose of the pull request

Total Records Inserted is reported as zero because cli counts small file inserts as updates

## Brief change log

  - Use `stat.getNumInserts();`

## Verify this pull request

![image](https://user-images.githubusercontent.com/20113411/74212175-f32c6100-4ccd-11ea-8265-0b7691b83800.png)

## Committer checklist

 - [X] Has a corresponding JIRA in PR title & commit
 
 - [X] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.