### PR TITLE
[HUDI-478] Fix too many files with unapproved license when execute build_local_docker_images

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -329,6 +329,7 @@
               <exclude>DISCLAIMER-WIP</exclude>
               <exclude>**/.*</exclude>
               <exclude>**/*.json</exclude>
+              <exclude>**/*.log</exclude>
               <exclude>**/*.sqltemplate</exclude>
               <exclude>**/compose_env</exclude>
               <exclude>**/*NOTICE*</exclude>


### PR DESCRIPTION
## What is the purpose of the pull request

User reported this issue: https://issues.apache.org/jira/browse/HUDI-478

Met the same exception: from rat.txt report, it says `hoodie-cmd.log` miss the license header

```
JavaDocs are generated, thus a license header is optional.
Generated files do not require license headers.

1 Unknown Licenses

*****************************************************

Files with unapproved licenses:

  /Users/dcadmin/Desktop/hudi-work/incubator-hudi/hudi-cli/hoodie-cmd.log

*****************************************************
```

## Brief change log

  - Add `*.log` to exclude list

## Verify this pull request

Test by executing `./build_local_docker_images.sh`

## Committer checklist

 - [X] Has a corresponding JIRA in PR title & commit
 
 - [X] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.