### PR TITLE
[HUDI-606] Improve execute build_local_docker_images.sh script

### DIFF
--- a/docker/build_local_docker_images.sh
+++ b/docker/build_local_docker_images.sh
@@ -18,6 +18,9 @@
 # limitations under the License.
 ################################################################################
 
+SCRIPT_PATH=$(cd `dirname $0`; pwd)
+WS_ROOT=`dirname $SCRIPT_PATH`
+
 while true; do
     read -p  "Docker images can be downloaded from docker hub and seamlessly mounted with latest HUDI jars. Do you still want to build docker images from scratch ?" yn
     case $yn in
@@ -26,6 +29,6 @@ while true; do
         * ) echo "Please answer yes or no.";;
     esac
 done
-pushd ../
+pushd ${WS_ROOT}
 mvn clean pre-integration-test -DskipTests -Ddocker.compose.skip=true -Ddocker.build.skip=false
 popd


### PR DESCRIPTION
## What is the purpose of the pull request

When fixing HUDI-478 #1323, need to switch to `docker` dir firstly, then execute the script.
This pr aims to improve the script, like `stop_demo.sh` & `setup_demo.sh` does.

## Brief change log

  - *Improve execute build_local_docker_images.sh script*

## Verify this pull request

Test by execute `docker/build_local_docker_images.sh`

## Committer checklist

 - [X] Has a corresponding JIRA in PR title & commit
 
 - [X] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.