### PR TITLE
[HUDI -409] Match header and footer block length to improve corrupted block detection

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFormatWriter.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieLogFormatWriter.java
@@ -158,6 +158,9 @@ public class HoodieLogFormatWriter implements HoodieLogFormat.Writer {
     this.output.write(footerBytes);
     // 9. Write the total size of the log block (including magic) which is everything written
     // until now (for reverse pointer)
+    // Update: this information is now used in determining if a block is corrupt by comparing to the
+    //   block size in header. This change assumes that the block size will be the last data written
+    //   to a block. Read will break if any data is written past this point for a block.
     this.output.writeLong(this.output.size() - currentSize);
     // Flush every block to disk
     flush();


### PR DESCRIPTION
## What is the purpose of the pull request

- This PR is to address the JIRA ticket - [HUDI-409](https://issues.apache.org/jira/browse/HUDI-409)
- Current logic to determine corrupted block (by just using \#HUDI\# marker alone) fails to address following issues
  1. Crashing the reader if the next block of the corrupted block has the exact same size as amount of missing data from the corrupted block
  2. Start of the next block is determined solely based on the marker and this can create multiple corrupted block if the partial data of corrupted block has the marker as part of the written data

## Brief change log

- Made changes to HoodieLogFileReader's `next()` and `prev()` methods. Added additional check to validate if block sizes stored at start and end of the blocks are the same. Report block as corrupted if they don't match
- Modified existing unit tests `TestHoodieLogFormat#testAppendAndReadOnCorruptedLog()` & `TestHoodieLogFormat#testAppendAndReadOnCorruptedLogInReverse()` to add additional blocks to validate the reader changes

## Verify this pull request

This change added tests and can be verified as follows:

- Modified  `TestHoodieLogFormat#testAppendAndReadOnCorruptedLog()` & `TestHoodieLogFormat#testAppendAndReadOnCorruptedLogInReverse()` tests to account for the change

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.