### PR TITLE
[HUDI-612] Fix return no data when using incremental query

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/HoodieTimeline.java
@@ -238,7 +238,7 @@ public interface HoodieTimeline extends Serializable {
    * Return true if specified timestamp is in range (startTs, endTs].
    */
   static boolean isInRange(String timestamp, String startTs, String endTs) {
-    return HoodieTimeline.compareTimestamps(timestamp, startTs, GREATER)
+    return HoodieTimeline.compareTimestamps(timestamp, startTs, GREATER_OR_EQUAL)
             && HoodieTimeline.compareTimestamps(timestamp, endTs, LESSER_OR_EQUAL);
   }
 

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/string/TestHoodieActiveTimeline.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/string/TestHoodieActiveTimeline.java
@@ -160,6 +160,7 @@ public class TestHoodieActiveTimeline extends HoodieCommonTestHarness {
     HoodieTestUtils.assertStreamEquals("", Stream.of("09", "11"), timeline.getCommitTimeline().filterCompletedInstants()
         .findInstantsAfter("07", 2).getInstants().map(HoodieInstant::getTimestamp));
     assertFalse(timeline.empty());
+    assertEquals(1, timeline.getCommitTimeline().filterCompletedInstants().findInstantsInRange("05", "05").countInstants());
     assertFalse(timeline.getCommitTimeline().filterPendingExcludingCompaction().empty());
     assertEquals("", 12, timeline.countInstants());
     HoodieTimeline activeCommitTimeline = timeline.getCommitTimeline().filterCompletedInstants();


### PR DESCRIPTION
## What is the purpose of the pull request

When using incremental query, if specify a specific time instant, will return no data.

## Brief change log

  - Change `GREATER` to `GREATER_OR_EQUAL` like `LESSER_OR_EQUAL` does.

## Verify this pull request

This pull request is already covered by `TestHoodieActiveTimeline#testTimelineOperations`.

## Committer checklist

 - [X] Has a corresponding JIRA in PR title & commit
 
 - [X] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.