### PR TITLE
[HUDI-617] Add support for types implementing CharSequence

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/keygen/TimestampBasedKeyGenerator.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/keygen/TimestampBasedKeyGenerator.java
@@ -103,7 +103,7 @@ public class TimestampBasedKeyGenerator extends SimpleKeyGenerator {
         unixTime = ((Float) partitionVal).longValue();
       } else if (partitionVal instanceof Long) {
         unixTime = (Long) partitionVal;
-      } else if (partitionVal instanceof String) {
+      } else if (partitionVal instanceof CharSequence) {
         unixTime = inputDateFormat.parse(partitionVal.toString()).getTime() / 1000;
       } else {
         throw new HoodieNotSupportedException(


### PR DESCRIPTION
## What is the purpose of the pull request
Data types extending CharSequence implement a #toString method which
provides an easy way to convert them to String. For example,
org.apache.avro.util.Utf8 is easily convertible into String if we use
the toString() method. It's better to make the support more generic to
support a wider range of data types as partitionKey.

## Brief change log
  - *Modified TimestampBasedKeyGenerator to support data types convertible to String*

## Verify this pull request

This pull request is already covered by existing tests, such as *TestTimestampBasedKeyGenerator.java*.

## Committer checklist

- [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.