### PR TITLE
[HUDI-626] Add exportToTable option to CLI

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/HoodieCLI.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/HoodieCLI.java
@@ -18,6 +18,8 @@
 
 package org.apache.hudi.cli;
 
+import org.apache.hudi.cli.utils.SparkTempViewProvider;
+import org.apache.hudi.cli.utils.TempViewProvider;
 import org.apache.hudi.common.model.TimelineLayoutVersion;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 import org.apache.hudi.common.util.ConsistencyGuardConfig;
@@ -43,6 +45,7 @@ public class HoodieCLI {
   protected static HoodieTableMetaClient tableMetadata;
   public static HoodieTableMetaClient syncTableMetadata;
   public static TimelineLayoutVersion layoutVersion;
+  private static TempViewProvider tempViewProvider;
 
   /**
    * Enum for CLI state.
@@ -103,6 +106,14 @@ public class HoodieCLI {
       throw new NullPointerException("There is no hudi table. Please use connect command to set table first");
     }
     return tableMetadata;
+  }
+
+  public static synchronized TempViewProvider getTempViewProvider() {
+    if (tempViewProvider == null) {
+      tempViewProvider = new SparkTempViewProvider(HoodieCLI.class.getSimpleName());
+    }
+
+    return tempViewProvider;
   }
 
 }

--- a/hudi-cli/src/main/java/org/apache/hudi/cli/HoodiePrintHelper.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/HoodiePrintHelper.java
@@ -19,12 +19,15 @@
 package org.apache.hudi.cli;
 
 import org.apache.hudi.common.util.Option;
+import org.apache.hudi.common.util.StringUtils;
 
 import com.jakewharton.fliptables.FlipTable;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 
 /**
@@ -57,9 +60,36 @@ public class HoodiePrintHelper {
    */
   public static String print(TableHeader rowHeader, Map<String, Function<Object, String>> fieldNameToConverterMap,
       String sortByField, boolean isDescending, Integer limit, boolean headerOnly, List<Comparable[]> rows) {
+    return print(rowHeader, fieldNameToConverterMap, sortByField, isDescending, limit, headerOnly, rows, "");
+  }
+
+  /**
+   * Serialize Table to printable string and also export a temporary view to easily write sql queries.
+   *
+   * Ideally, exporting view needs to be outside PrintHelper, but all commands use this. So this is easy
+   * way to add support for all commands
+   *
+   * @param rowHeader Row Header
+   * @param fieldNameToConverterMap Field Specific Converters
+   * @param sortByField Sorting field
+   * @param isDescending Order
+   * @param limit Limit
+   * @param headerOnly Headers only
+   * @param rows List of rows
+   * @param tempTableName table name to export
+   * @return Serialized form for printing
+   */
+  public static String print(TableHeader rowHeader, Map<String, Function<Object, String>> fieldNameToConverterMap,
+      String sortByField, boolean isDescending, Integer limit, boolean headerOnly, List<Comparable[]> rows,
+      String tempTableName) {
 
     if (headerOnly) {
       return HoodiePrintHelper.print(rowHeader);
+    }
+
+    if (!StringUtils.isNullOrEmpty(tempTableName)) {
+      HoodieCLI.getTempViewProvider().createOrReplace(tempTableName, rowHeader.getFieldNames(),
+          rows.stream().map(columns -> Arrays.asList(columns)).collect(Collectors.toList()));
     }
 
     if (!sortByField.isEmpty() && !rowHeader.containsField(sortByField)) {

--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/TempViewCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/TempViewCommand.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.cli.commands;
+
+import org.apache.hudi.cli.HoodieCLI;
+
+import org.springframework.shell.core.CommandMarker;
+import org.springframework.shell.core.annotation.CliCommand;
+import org.springframework.shell.core.annotation.CliOption;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+/**
+ * CLI command to query/delete temp views.
+ */
+@Component
+public class TempViewCommand implements CommandMarker {
+
+  private static final String EMPTY_STRING = "";
+
+  @CliCommand(value = "temp_query", help = "query against created temp view")
+  public String query(
+          @CliOption(key = {"sql"}, mandatory = true, help = "select query to run against view") final String sql)
+          throws IOException {
+
+    HoodieCLI.getTempViewProvider().runQuery(sql);
+    return EMPTY_STRING;
+  }
+
+  @CliCommand(value = "temp_delete", help = "Delete view name")
+  public String delete(
+          @CliOption(key = {"view"}, mandatory = true, help = "view name") final String tableName)
+          throws IOException {
+
+    HoodieCLI.getTempViewProvider().deleteTable(tableName);
+    return EMPTY_STRING;
+  }
+}

--- a/hudi-cli/src/main/java/org/apache/hudi/cli/utils/SparkTempViewProvider.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/utils/SparkTempViewProvider.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.cli.utils;
+
+import org.apache.hudi.exception.HoodieException;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.apache.spark.SparkConf;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.SQLContext;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructType;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class SparkTempViewProvider implements TempViewProvider {
+  private static final Logger LOG = LogManager.getLogger(SparkTempViewProvider.class);
+
+  private JavaSparkContext jsc;
+  private SQLContext sqlContext;
+
+  public SparkTempViewProvider(String appName) {
+    try {
+      SparkConf sparkConf = new SparkConf().setAppName(appName)
+              .set("spark.serializer", "org.apache.spark.serializer.KryoSerializer").setMaster("local[8]");
+      jsc = new JavaSparkContext(sparkConf);
+      jsc.setLogLevel("ERROR");
+
+      sqlContext = new SQLContext(jsc);
+    } catch (Throwable ex) {
+      // log full stack trace and rethrow. Without this its difficult to debug failures, if any
+      LOG.error("unable to initialize spark context ", ex);
+      throw new HoodieException(ex);
+    }
+  }
+
+  @Override
+  public void createOrReplace(String tableName, List<String> headers, List<List<Comparable>> rows) {
+    try {
+      if (headers.isEmpty() || rows.isEmpty()) {
+        return;
+      }
+
+      if (rows.stream().filter(row -> row.size() != headers.size()).count() > 0) {
+        throw new HoodieException("Invalid row, does not match headers " + headers.size() + " " + rows.size());
+      }
+
+      // replace all whitespaces in headers to make it easy to write sql queries
+      List<String> headersNoSpaces = headers.stream().map(title -> title.replaceAll("\\s+",""))
+              .collect(Collectors.toList());
+
+      // generate schema for table
+      StructType structType = new StructType();
+      for (int i = 0; i < headersNoSpaces.size(); i++) {
+        // try guessing data type from column data.
+        DataType headerDataType = getDataType(rows.get(0).get(i));
+        structType = structType.add(DataTypes.createStructField(headersNoSpaces.get(i), headerDataType, true));
+      }
+      List<Row> records = rows.stream().map(row -> RowFactory.create(row.toArray(new Comparable[row.size()])))
+              .collect(Collectors.toList());
+      Dataset<Row> dataset = this.sqlContext.createDataFrame(records, structType);
+      dataset.createOrReplaceTempView(tableName);
+      System.out.println("Wrote table view: " + tableName);
+    } catch (Throwable ex) {
+      // log full stack trace and rethrow. Without this its difficult to debug failures, if any
+      LOG.error("unable to write ", ex);
+      throw new HoodieException(ex);
+    }
+  }
+
+  @Override
+  public void runQuery(String sqlText) {
+    try {
+      this.sqlContext.sql(sqlText).show(Integer.MAX_VALUE, false);
+    } catch (Throwable ex) {
+      // log full stack trace and rethrow. Without this its difficult to debug failures, if any
+      LOG.error("unable to read ", ex);
+      throw new HoodieException(ex);
+    }
+  }
+
+  @Override
+  public void deleteTable(String tableName) {
+    try {
+      sqlContext.sql("DROP TABLE IF EXISTS " + tableName);
+    } catch (Throwable ex) {
+      // log full stack trace and rethrow. Without this its difficult to debug failures, if any
+      LOG.error("unable to initialize spark context ", ex);
+      throw new HoodieException(ex);
+    }
+  }
+
+  private DataType getDataType(Comparable comparable) {
+    if (comparable instanceof Integer) {
+      return DataTypes.IntegerType;
+    }
+
+    if (comparable instanceof Double) {
+      return DataTypes.DoubleType;
+    }
+
+    if (comparable instanceof Long) {
+      return DataTypes.LongType;
+    }
+
+    if (comparable instanceof Boolean) {
+      return DataTypes.BooleanType;
+    }
+
+    // TODO add additional types when needed. default to string
+    return DataTypes.StringType;
+  }
+}

--- a/hudi-cli/src/main/java/org/apache/hudi/cli/utils/TempViewProvider.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/utils/TempViewProvider.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.cli.utils;
+
+import java.util.List;
+
+public interface TempViewProvider {
+  void createOrReplace(String tableName, List<String> headers, List<List<Comparable>> rows);
+
+  void runQuery(String sqlText);
+
+  void deleteTable(String tableName);
+}


### PR DESCRIPTION

## What is the purpose of the pull request
CLI shell is very restrictive and it is sometimes hard to filter specific rows. Adding ability to export results of CLI command into temporary table. So CLI users can write HiveQL queries to look for any specific information. 
(This idea has been brought up by multiple folks on the team, thanks everyone for great suggestions)

## Brief change log
- Add 'exportToTableName' cli option for commits command.
- This creates a temp table in spark session. Users can write HiveQL queries against the table to filter desired row.
- Note, intentionally not using Hoodie format for temp tables (to avoid versioning and any potential bugs in hoodie)
- Only added this option for commits. But can add it to other commands if general approach looks good.

Example usage:
->commits show archived --startTs "20200121224545" --endTs "20200224004414"   --includeExtraMetadata true --exportToTableName satishkotha_debug
Wrote table view: satishkotha_debug

>temp_query --sql "select Instant, NumInserts, NumWrites from satishkotha_debug where FileId='ed33bd99-466f-4417-bd92-5d914fa58a8f' and Instant > '20200123211217' order by Instant"
+--------------+----------+---------+
|Instant       |NumInserts|NumWrites|
+--------------+----------+---------+
|20200123221012|0         |2418     |
|20200123223835|0         |2418     |
|20200123231230|0         |2418     |
|20200123233911|0         |2418     |
|20200124000848|3         |3        |
|20200124004403|7         |10       |
|20200124013616|1         |11       |
|20200124020556|1         |12       |
|20200124061752|1         |13       |


## Verify this pull request

Only changes CLI. can be verified by running CLI commands.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.