### PR TITLE
[HUDI-627] Aggregate code coverage and publish to codecov.io during CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,3 +37,5 @@ script:
   # https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received
   - while sleep 9m; do echo "=====[ $SECONDS seconds still running ]====="; done &
   - scripts/run_travis_tests.sh $TEST_SUITE
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/hudi-hadoop-mr/pom.xml
+++ b/hudi-hadoop-mr/pom.xml
@@ -114,6 +114,10 @@
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/hudi-hive/pom.xml
+++ b/hudi-hive/pom.xml
@@ -202,6 +202,10 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/hudi-spark/pom.xml
+++ b/hudi-spark/pom.xml
@@ -144,6 +144,10 @@
         <groupId>org.scalastyle</groupId>
         <artifactId>scalastyle-maven-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 

--- a/hudi-timeline-service/pom.xml
+++ b/hudi-timeline-service/pom.xml
@@ -55,6 +55,10 @@
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+      </plugin>
     </plugins>
 
     <resources>

--- a/packaging/hudi-spark-bundle/pom.xml
+++ b/packaging/hudi-spark-bundle/pom.xml
@@ -155,6 +155,24 @@
           </execution>
         </executions>
       </plugin>
+      <!-- Adding test coverage report aggregation to this module as this seems to cover all of the required dependencies -->
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>post-unit-test</id>
+            <phase>test</phase>
+            <goals>
+              <goal>report-aggregate</goal>
+            </goals>
+            <configuration>
+              <!-- Sets the output directory for the code coverage report. -->
+              <outputDirectory>${project.reporting.outputDirectory}/jacoco-ut</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
      <resources>
        <resource>
@@ -191,6 +209,11 @@
     <dependency>
       <groupId>org.apache.hudi</groupId>
       <artifactId>hudi-spark_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hudi</groupId>
+      <artifactId>hudi-timeline-service</artifactId>
       <version>${project.version}</version>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,7 @@
     <utilities.bundle.hive.scope>provided</utilities.bundle.hive.scope>
     <utilities.bundle.hive.shade.prefix></utilities.bundle.hive.shade.prefix>
     <argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>
+    <jacoco.version>0.8.5</jacoco.version>
   </properties>
 
   <scm>
@@ -264,7 +265,7 @@
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.7.8</version>
+          <version>${jacoco.version}</version>
           <executions>
             <!--
                 Prepares the property pointing to the JaCoCo runtime agent which
@@ -275,10 +276,6 @@
               <goals>
                 <goal>prepare-agent</goal>
               </goals>
-              <configuration>
-                <!-- Sets the path to the file which contains the execution data. -->
-                <destFile>${project.build.directory}/coverage-reports/jacoco-ut.exec</destFile>
-              </configuration>
             </execution>
             <!--
                 Ensures that the code coverage report for unit tests is created after
@@ -291,8 +288,6 @@
                 <goal>report</goal>
               </goals>
               <configuration>
-                <!-- Sets the path to the file which contains the execution data. -->
-                <dataFile>${project.build.directory}/coverage-reports/jacoco-ut.exec</dataFile>
                 <!-- Sets the output directory for the code coverage report. -->
                 <outputDirectory>${project.reporting.outputDirectory}/jacoco-ut</outputDirectory>
               </configuration>


### PR DESCRIPTION
## What is the purpose of the pull request

- This PR aggregates code coverage across modules to get a holistic coverage number (since we have tests that gets run across modules. e.g. hudi-client tests classes in hudi-common)
- This also published the report to codecov.io (e.g. [report from the fork](https://codecov.io/gh/ramachandranms/incubator-hudi))
- Above step automatically adds coverage report to every PR (e.g. [PR from fork](https://github.com/ramachandranms/incubator-hudi/pull/2))

## Brief change log

- Modified pom files to include coverage in missing modules (hudi-hadoop-mr, hudi-spark & hudi-timeline-service)
- Added a wrapper module for aggregation (due to limitations in jacoco). This can be remove in future once [this PR](https://github.com/jacoco/jacoco/pull/1007) gets merged to a release.

## Verify this pull request

- Ran travis in private fork and verified the published report & PR.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.