### PR TITLE
[WIP] [HUDI-625] Fixing performance issues around DiskBasedMap & kryo

### DIFF
--- a/hudi-common/src/main/java/org/apache/hudi/common/model/BaseAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/BaseAvroPayload.java
@@ -26,6 +26,7 @@ import org.apache.avro.generic.GenericRecord;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * Base class for all AVRO record based payloads, that can be ordered based on a field.
@@ -39,7 +40,7 @@ public abstract class BaseAvroPayload implements Serializable {
   /**
    * For purposes of preCombining.
    */
-  protected final Comparable orderingVal;
+  public final Comparable orderingVal;
 
   /**
    * Instantiate {@link BaseAvroPayload}.
@@ -57,5 +58,29 @@ public abstract class BaseAvroPayload implements Serializable {
     if (orderingVal == null) {
       throw new HoodieException("Ordering value is null for record: " + record);
     }
+  }
+
+  public BaseAvroPayload(byte[] recordBytes, Comparable orderingVal) {
+    this.recordBytes = recordBytes;
+    this.orderingVal = orderingVal;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    BaseAvroPayload that = (BaseAvroPayload) o;
+    return Objects.deepEquals(this.recordBytes, that.recordBytes)
+        && Objects.equals(this.orderingVal, that.orderingVal);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(this.recordBytes, this.orderingVal);
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecord.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecord.java
@@ -66,6 +66,10 @@ public class HoodieRecord<T extends HoodieRecordPayload> implements Serializable
    */
   private boolean sealed;
 
+  public HoodieRecord() {
+
+  }
+
   public HoodieRecord(HoodieKey key, T data) {
     this.key = key;
     this.data = data;

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordLocation.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordLocation.java
@@ -35,6 +35,10 @@ public class HoodieRecordLocation implements Serializable {
     this.fileId = fileId;
   }
 
+  public HoodieRecordLocation() {
+    this(null, null);
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -54,11 +58,10 @@ public class HoodieRecordLocation implements Serializable {
 
   @Override
   public String toString() {
-    final StringBuilder sb = new StringBuilder("HoodieRecordLocation {");
-    sb.append("instantTime=").append(instantTime).append(", ");
-    sb.append("fileId=").append(fileId);
-    sb.append('}');
-    return sb.toString();
+    return "HoodieRecordLocation {"
+        + "instantTime=" + instantTime + ", "
+        + "fileId=" + fileId
+        + '}';
   }
 
   public String getInstantTime() {

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/OverwriteWithLatestAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/OverwriteWithLatestAvroPayload.java
@@ -33,14 +33,14 @@ import java.io.IOException;
  * 1. preCombine - Picks the latest delta record for a key, based on an ordering field 2.
  * combineAndGetUpdateValue/getInsertValue - Simply overwrites storage with latest delta record
  */
-public class OverwriteWithLatestAvroPayload extends BaseAvroPayload
-    implements HoodieRecordPayload<OverwriteWithLatestAvroPayload> {
+public class OverwriteWithLatestAvroPayload extends BaseAvroPayload implements HoodieRecordPayload<OverwriteWithLatestAvroPayload> {
 
-  /**
-   *
-   */
   public OverwriteWithLatestAvroPayload(GenericRecord record, Comparable orderingVal) {
     super(record, orderingVal);
+  }
+
+  public OverwriteWithLatestAvroPayload(byte[] recordBytes, Comparable orderingVal) {
+    super(recordBytes, orderingVal);
   }
 
   public OverwriteWithLatestAvroPayload(Option<GenericRecord> record) {

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieMergedLogRecordScanner.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/log/HoodieMergedLogRecordScanner.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.common.table.log;
 
+import com.google.common.collect.Iterators;
 import org.apache.hudi.common.model.HoodieKey;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.model.HoodieRecordPayload;
@@ -26,6 +27,7 @@ import org.apache.hudi.common.util.HoodieRecordSizeEstimator;
 import org.apache.hudi.common.util.HoodieTimer;
 import org.apache.hudi.common.util.SpillableMapUtils;
 import org.apache.hudi.common.util.collection.ExternalSpillableMap;
+import org.apache.hudi.common.util.collection.Pair;
 import org.apache.hudi.exception.HoodieIOException;
 
 import org.apache.avro.Schema;
@@ -94,7 +96,7 @@ public class HoodieMergedLogRecordScanner extends AbstractHoodieLogRecordScanner
 
   @Override
   public Iterator<HoodieRecord<? extends HoodieRecordPayload>> iterator() {
-    return records.iterator();
+    return Iterators.transform(records.iterator(), Pair::getRight);
   }
 
   public Map<String, HoodieRecord<? extends HoodieRecordPayload>> getRecords() {

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/collection/DiskBasedMap.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/collection/DiskBasedMap.java
@@ -53,7 +53,7 @@ import java.util.stream.Stream;
  * without any rollover support. It uses the following : 1) An in-memory map that tracks the key-> latest ValueMetadata.
  * 2) Current position in the file NOTE : Only String.class type supported for Key
  */
-public final class DiskBasedMap<T extends Serializable, R extends Serializable> implements Map<T, R>, Iterable<R> {
+public final class DiskBasedMap<T extends Serializable, R extends Serializable> implements Map<T, R>, Iterable<Pair<T,R>> {
 
   public static int BUFFER_SIZE = 128 * 1024;  // 128 KB
   private static final Logger LOG = LogManager.getLogger(DiskBasedMap.class);
@@ -167,8 +167,8 @@ public final class DiskBasedMap<T extends Serializable, R extends Serializable> 
    * Custom iterator to iterate over values written to disk.
    */
   @Override
-  public Iterator<R> iterator() {
-    return new LazyFileIterable(filePath, valueMetadataMap).iterator();
+  public Iterator<Pair<T,R>> iterator() {
+    return new LazyFileIterable<T, R>(filePath, valueMetadataMap).iterator();
   }
 
   /**
@@ -204,6 +204,7 @@ public final class DiskBasedMap<T extends Serializable, R extends Serializable> 
     if (entry == null) {
       return null;
     }
+    R d =  get(entry);
     return get(entry);
   }
 

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/collection/TestExternalSpillableMap.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/collection/TestExternalSpillableMap.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.common.util.collection;
 
+import com.google.common.collect.Iterators;
 import org.apache.hudi.common.HoodieCommonTestHarness;
 import org.apache.hudi.common.model.HoodieAvroPayload;
 import org.apache.hudi.common.model.HoodieKey;
@@ -74,7 +75,7 @@ public class TestExternalSpillableMap extends HoodieCommonTestHarness {
     List<IndexedRecord> iRecords = SchemaTestUtil.generateHoodieTestRecords(0, 100);
     List<String> recordKeys = SpillableMapTestUtils.upsertRecords(iRecords, records);
     assert (recordKeys.size() == 100);
-    Iterator<HoodieRecord<? extends HoodieRecordPayload>> itr = records.iterator();
+    Iterator<HoodieRecord<? extends HoodieRecordPayload>> itr = Iterators.transform(records.iterator(), Pair::getRight);
     List<HoodieRecord> oRecords = new ArrayList<>();
     while (itr.hasNext()) {
       HoodieRecord<? extends HoodieRecordPayload> rec = itr.next();
@@ -94,7 +95,7 @@ public class TestExternalSpillableMap extends HoodieCommonTestHarness {
     List<IndexedRecord> iRecords = SchemaTestUtil.generateHoodieTestRecords(0, 100);
     List<String> recordKeys = SpillableMapTestUtils.upsertRecords(iRecords, records);
     assert (recordKeys.size() == 100);
-    Iterator<HoodieRecord<? extends HoodieRecordPayload>> itr = records.iterator();
+    Iterator<HoodieRecord<? extends HoodieRecordPayload>> itr = Iterators.transform(records.iterator(), Pair::getRight);
     while (itr.hasNext()) {
       HoodieRecord<? extends HoodieRecordPayload> rec = itr.next();
       assert recordKeys.contains(rec.getRecordKey());
@@ -185,7 +186,7 @@ public class TestExternalSpillableMap extends HoodieCommonTestHarness {
     List<IndexedRecord> iRecords = SchemaTestUtil.generateHoodieTestRecords(0, 100);
     List<String> recordKeys = SpillableMapTestUtils.upsertRecords(iRecords, records);
     assert (recordKeys.size() == 100);
-    Iterator<HoodieRecord<? extends HoodieRecordPayload>> itr = records.iterator();
+    Iterator<HoodieRecord<? extends HoodieRecordPayload>> itr = Iterators.transform(records.iterator(), Pair::getRight);
     while (itr.hasNext()) {
       throw new IOException("Testing failures...");
     }


### PR DESCRIPTION
 - This is very rough cut of few things I tried; Just for sharing purposes
 - Kryo needs serializers and once we add them, the ser/deser is fast and writing finishes 10-20x faster
 - DiskbasedMap is tracking too many things redundantly and incurring its cost as well.
 - TODO : Need to break the kryo and map fix in differnt PRs
 - TODO : For map entry thinning, need to handle compaction, fix code structure, tests
 - TODO : For kyro, one more pass with good understanding of APIs, tests, null handling, cleanup

## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

*(For example: This pull request adds quick-start document.)*

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.