### PR TITLE
[HUDI-633] limit archive file block size by number of bytes

### DIFF
--- a/hudi-client/src/main/java/org/apache/hudi/config/HoodieCompactionConfig.java
+++ b/hudi-client/src/main/java/org/apache/hudi/config/HoodieCompactionConfig.java
@@ -50,6 +50,7 @@ public class HoodieCompactionConfig extends DefaultHoodieConfig {
   public static final String MAX_COMMITS_TO_KEEP_PROP = "hoodie.keep.max.commits";
   public static final String MIN_COMMITS_TO_KEEP_PROP = "hoodie.keep.min.commits";
   public static final String COMMITS_ARCHIVAL_BATCH_SIZE_PROP = "hoodie.commits.archival.batch";
+  public static final String COMMITS_ARCHIVAL_MEM_SIZE_PROP = "hoodie.commits.archival.mem.size";
   // Upsert uses this file size to compact new data onto existing files..
   public static final String PARQUET_SMALL_FILE_LIMIT_BYTES = "hoodie.parquet.small.file.limit";
   // By default, treat any file <= 100MB as a small file.
@@ -103,6 +104,8 @@ public class HoodieCompactionConfig extends DefaultHoodieConfig {
   private static final String DEFAULT_MAX_COMMITS_TO_KEEP = "30";
   private static final String DEFAULT_MIN_COMMITS_TO_KEEP = "20";
   private static final String DEFAULT_COMMITS_ARCHIVAL_BATCH_SIZE = String.valueOf(10);
+  // Do not read more than specified memory size for writing archived log
+  private static final String DEFAULT_COMMITS_ARCHIVAL_MEM_SIZE = String.valueOf(6 * 1024 * 1024);
   public static final String TARGET_PARTITIONS_PER_DAYBASED_COMPACTION_PROP =
       "hoodie.compaction.daybased.target.partitions";
   // 500GB of target IO per compaction (both read and write)
@@ -241,6 +244,11 @@ public class HoodieCompactionConfig extends DefaultHoodieConfig {
       return this;
     }
 
+    public Builder withCommitsArchivalMemSize(int memSize) {
+      props.setProperty(COMMITS_ARCHIVAL_MEM_SIZE_PROP, String.valueOf(memSize));
+      return this;
+    }
+
     public HoodieCompactionConfig build() {
       HoodieCompactionConfig config = new HoodieCompactionConfig(props);
       setDefaultOnCondition(props, !props.containsKey(AUTO_CLEAN_PROP), AUTO_CLEAN_PROP, DEFAULT_AUTO_CLEAN);
@@ -283,6 +291,8 @@ public class HoodieCompactionConfig extends DefaultHoodieConfig {
           TARGET_PARTITIONS_PER_DAYBASED_COMPACTION_PROP, DEFAULT_TARGET_PARTITIONS_PER_DAYBASED_COMPACTION);
       setDefaultOnCondition(props, !props.containsKey(COMMITS_ARCHIVAL_BATCH_SIZE_PROP),
           COMMITS_ARCHIVAL_BATCH_SIZE_PROP, DEFAULT_COMMITS_ARCHIVAL_BATCH_SIZE);
+      setDefaultOnCondition(props, !props.containsKey(COMMITS_ARCHIVAL_MEM_SIZE_PROP),
+              COMMITS_ARCHIVAL_MEM_SIZE_PROP, DEFAULT_COMMITS_ARCHIVAL_MEM_SIZE);
 
       HoodieCleaningPolicy.valueOf(props.getProperty(CLEANER_POLICY_PROP));
 

--- a/hudi-client/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
+++ b/hudi-client/src/main/java/org/apache/hudi/config/HoodieWriteConfig.java
@@ -303,6 +303,10 @@ public class HoodieWriteConfig extends DefaultHoodieConfig {
     return Integer.parseInt(props.getProperty(HoodieCompactionConfig.COMMITS_ARCHIVAL_BATCH_SIZE_PROP));
   }
 
+  public int getCommitArchivalMemSize() {
+    return Integer.parseInt(props.getProperty(HoodieCompactionConfig.COMMITS_ARCHIVAL_MEM_SIZE_PROP));
+  }
+
   /**
    * index properties.
    */

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/HoodieTestUtils.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/HoodieTestUtils.java
@@ -291,7 +291,23 @@ public class HoodieTestUtils {
   }
 
   public static void createCleanFiles(HoodieTableMetaClient metaClient, String basePath,
-      String commitTime, Configuration configuration)
+                                      String commitTime, Configuration configuration) throws IOException {
+    createCleanFiles(metaClient, basePath, commitTime, configuration, 0);
+  }
+
+  public static void createCleanFiles(HoodieTableMetaClient metaClient, String basePath, String commitTime,
+              Configuration configuration, int numDeleteFailureToSimulate) throws IOException {
+
+    List<String> deleteFailures = new ArrayList<>();
+    for (int i = 0; i < numDeleteFailureToSimulate; i++) {
+      deleteFailures.add("failedPrefix" + rand.nextInt());
+    }
+
+    createCleanFiles(metaClient, basePath, commitTime, configuration, deleteFailures);
+  }
+
+  public static void createCleanFiles(HoodieTableMetaClient metaClient, String basePath,
+      String commitTime, Configuration configuration, List<String> deleteFailures)
       throws IOException {
     createPendingCleanFiles(metaClient, commitTime);
     Path commitFile = new Path(
@@ -300,7 +316,7 @@ public class HoodieTestUtils {
     try (FSDataOutputStream os = fs.create(commitFile, true)) {
       HoodieCleanStat cleanStats = new HoodieCleanStat(HoodieCleaningPolicy.KEEP_LATEST_FILE_VERSIONS,
           DEFAULT_PARTITION_PATHS[rand.nextInt(DEFAULT_PARTITION_PATHS.length)], new ArrayList<>(), new ArrayList<>(),
-          new ArrayList<>(), commitTime);
+          deleteFailures, commitTime);
       // Create the clean metadata
 
       HoodieCleanMetadata cleanMetadata =


### PR DESCRIPTION
## What is the purpose of the pull request

With large clean files, archival process results in OOM. See HUDI-633. Limit archive file block size by number of bytes

## Brief change log

- Add option to limit  archival batch size by number of bytes in block in addition to maximum number of records allowed in a batch
- This does not prevent OOM if a single record is larger than jvm heap size.  
- Note that in worst case, a single instant details can take up entire block. This likely has higher metadata overhead. But I think marginal increase in storage is acceptable for metadata. 

## Verify this pull request

This change added tests and can be verified as follows:
- Run TestHoodieCommitArchiveLog#testArchiveTableWithLargeCleanFiles
- Verified large clean file that caused OOM can be archived with specified config.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.