### PR TITLE
[HUDI-580] Fix incorrect license header in files

### DIFF
--- a/docker/build_local_docker_images.sh
+++ b/docker/build_local_docker_images.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-################################################################################
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -16,7 +15,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 while true; do
     read -p  "Docker images can be downloaded from docker hub and seamlessly mounted with latest HUDI jars. Do you still want to build docker images from scratch ?" yn

--- a/docker/compose/hadoop.env
+++ b/docker/compose/hadoop.env
@@ -1,4 +1,4 @@
-################################################################################
+
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -14,7 +14,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 HIVE_SITE_CONF_javax_jdo_option_ConnectionURL=jdbc:postgresql://hive-metastore-postgresql/metastore
 HIVE_SITE_CONF_javax_jdo_option_ConnectionDriverName=org.postgresql.Driver

--- a/docker/demo/compaction.commands
+++ b/docker/demo/compaction.commands
@@ -1,4 +1,4 @@
-################################################################################
+
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -14,7 +14,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 connect --path /user/hive/warehouse/stock_ticks_mor
 compactions show all

--- a/docker/demo/config/base.properties
+++ b/docker/demo/config/base.properties
@@ -1,4 +1,4 @@
-################################################################################
+
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -14,7 +14,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 hoodie.upsert.shuffle.parallelism=2
 hoodie.insert.shuffle.parallelism=2

--- a/docker/demo/config/dfs-source.properties
+++ b/docker/demo/config/dfs-source.properties
@@ -1,4 +1,4 @@
-################################################################################
+
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -14,7 +14,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 include=base.properties
 # Key fields, for kafka example

--- a/docker/demo/config/kafka-source.properties
+++ b/docker/demo/config/kafka-source.properties
@@ -1,4 +1,4 @@
-################################################################################
+
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -14,7 +14,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 include=base.properties
 # Key fields, for kafka example

--- a/docker/demo/get_min_commit_time.sh
+++ b/docker/demo/get_min_commit_time.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-################################################################################
+
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -15,7 +15,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 MIN_COMMIT_TIME=`hdfs dfs -ls -t /user/hive/warehouse/stock_ticks_cow/.hoodie/*.commit  | head -1 | awk -F'/' ' { print $7 } ' | awk -F'.' ' { print $1 } '`
 echo $MIN_COMMIT_TIME;

--- a/docker/demo/hive-batch1.commands
+++ b/docker/demo/hive-batch1.commands
@@ -1,4 +1,4 @@
-################################################################################
+
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -14,7 +14,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 add jar ${hudi.hadoop.bundle};
 

--- a/docker/demo/hive-batch2-after-compaction.commands
+++ b/docker/demo/hive-batch2-after-compaction.commands
@@ -1,4 +1,4 @@
-################################################################################
+
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -14,7 +14,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 add jar ${hudi.hadoop.bundle};
 

--- a/docker/demo/hive-incremental.commands
+++ b/docker/demo/hive-incremental.commands
@@ -1,4 +1,4 @@
-################################################################################
+
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -14,7 +14,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 add jar ${hudi.hadoop.bundle};
 

--- a/docker/demo/hive-table-check.commands
+++ b/docker/demo/hive-table-check.commands
@@ -1,4 +1,4 @@
-################################################################################
+
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -14,7 +14,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 add jar ${hudi.hadoop.bundle};
 show tables;

--- a/docker/demo/setup_demo_container.sh
+++ b/docker/demo/setup_demo_container.sh
@@ -1,4 +1,4 @@
-################################################################################
+
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -14,7 +14,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 echo "Copying spark default config and setting up configs"
 cp /var/hoodie/ws/docker/demo/config/spark-defaults.conf $SPARK_CONF_DIR/.

--- a/docker/hoodie/hadoop/base/Dockerfile
+++ b/docker/hoodie/hadoop/base/Dockerfile
@@ -1,4 +1,4 @@
-################################################################################
+
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -14,7 +14,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 FROM openjdk:8u212-jdk-slim-stretch
 MAINTAINER Hoodie

--- a/docker/hoodie/hadoop/base/entrypoint.sh
+++ b/docker/hoodie/hadoop/base/entrypoint.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-################################################################################
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -16,7 +15,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 
 #######################################################################################

--- a/docker/hoodie/hadoop/base/export_container_ip.sh
+++ b/docker/hoodie/hadoop/base/export_container_ip.sh
@@ -1,4 +1,4 @@
-################################################################################
+
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -14,7 +14,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 interfaces=( "en0" "eth0" )
 

--- a/docker/hoodie/hadoop/datanode/Dockerfile
+++ b/docker/hoodie/hadoop/datanode/Dockerfile
@@ -1,4 +1,4 @@
-################################################################################
+
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -14,7 +14,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 ARG HADOOP_VERSION=2.8.4 
 ARG HADOOP_DN_PORT=50075

--- a/docker/hoodie/hadoop/datanode/run_dn.sh
+++ b/docker/hoodie/hadoop/datanode/run_dn.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-################################################################################
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -16,7 +15,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 datadir=`echo $HDFS_CONF_dfs_datanode_data_dir | perl -pe 's#file://##'`
 if [ ! -d $datadir ]; then

--- a/docker/hoodie/hadoop/historyserver/Dockerfile
+++ b/docker/hoodie/hadoop/historyserver/Dockerfile
@@ -1,4 +1,4 @@
-################################################################################
+
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -14,7 +14,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 ARG HADOOP_VERSION=2.8.4 
 ARG HADOOP_HISTORY_PORT=8188

--- a/docker/hoodie/hadoop/historyserver/run_history.sh
+++ b/docker/hoodie/hadoop/historyserver/run_history.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-################################################################################
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -16,6 +15,5 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 $HADOOP_PREFIX/bin/yarn --config $HADOOP_CONF_DIR historyserver

--- a/docker/hoodie/hadoop/hive_base/Dockerfile
+++ b/docker/hoodie/hadoop/hive_base/Dockerfile
@@ -1,4 +1,4 @@
-################################################################################
+
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -14,7 +14,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 ARG HADOOP_VERSION=2.8.4 
 FROM apachehudi/hudi-hadoop_${HADOOP_VERSION}-base:latest

--- a/docker/hoodie/hadoop/hive_base/conf/beeline-log4j2.properties
+++ b/docker/hoodie/hadoop/hive_base/conf/beeline-log4j2.properties
@@ -1,4 +1,4 @@
-################################################################################
+
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -14,7 +14,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 status = INFO
 name = BeelineLog4j2

--- a/docker/hoodie/hadoop/hive_base/conf/hive-env.sh
+++ b/docker/hoodie/hadoop/hive_base/conf/hive-env.sh
@@ -1,4 +1,4 @@
-################################################################################
+
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -14,7 +14,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 # Set Hive and Hadoop environment variables here. These variables can be used
 # to control the execution of Hive. It should be used by admins to configure

--- a/docker/hoodie/hadoop/hive_base/conf/hive-exec-log4j2.properties
+++ b/docker/hoodie/hadoop/hive_base/conf/hive-exec-log4j2.properties
@@ -1,4 +1,4 @@
-################################################################################
+
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -14,7 +14,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 status = INFO
 name = HiveExecLog4j2

--- a/docker/hoodie/hadoop/hive_base/conf/hive-log4j2.properties
+++ b/docker/hoodie/hadoop/hive_base/conf/hive-log4j2.properties
@@ -1,4 +1,4 @@
-################################################################################
+
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -14,7 +14,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 status = INFO
 name = HiveLog4j2

--- a/docker/hoodie/hadoop/hive_base/conf/llap-daemon-log4j2.properties
+++ b/docker/hoodie/hadoop/hive_base/conf/llap-daemon-log4j2.properties
@@ -1,4 +1,4 @@
-################################################################################
+
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -14,7 +14,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 status = INFO
 name = LlapDaemonLog4j2

--- a/docker/hoodie/hadoop/hive_base/entrypoint.sh
+++ b/docker/hoodie/hadoop/hive_base/entrypoint.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-################################################################################
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -16,7 +15,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 # Set some sensible defaults
 export CORE_CONF_fs_defaultFS=${CORE_CONF_fs_defaultFS:-hdfs://`hostname -f`:8020}

--- a/docker/hoodie/hadoop/hive_base/startup.sh
+++ b/docker/hoodie/hadoop/hive_base/startup.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-################################################################################
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -16,7 +15,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 hadoop fs -mkdir       /tmp
 hadoop fs -mkdir -p    /user/hive/warehouse

--- a/docker/hoodie/hadoop/namenode/Dockerfile
+++ b/docker/hoodie/hadoop/namenode/Dockerfile
@@ -1,4 +1,4 @@
-################################################################################
+
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -14,7 +14,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 ARG HADOOP_VERSION=2.8.4 
 ARG HADOOP_WEBHDFS_PORT=50070

--- a/docker/hoodie/hadoop/namenode/run_nn.sh
+++ b/docker/hoodie/hadoop/namenode/run_nn.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-################################################################################
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -16,7 +15,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 namedir=`echo $HDFS_CONF_dfs_namenode_name_dir | perl -pe 's#file://##'`
 if [ ! -d $namedir ]; then

--- a/docker/hoodie/hadoop/prestobase/Dockerfile
+++ b/docker/hoodie/hadoop/prestobase/Dockerfile
@@ -1,4 +1,4 @@
-################################################################################
+
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -14,7 +14,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 
 ## Presto docker setup is based on https://github.com/smizy/docker-presto

--- a/docker/hoodie/hadoop/prestobase/bin/entrypoint.sh
+++ b/docker/hoodie/hadoop/prestobase/bin/entrypoint.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-################################################################################
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -16,7 +15,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 set -eo pipefail
 

--- a/docker/hoodie/hadoop/prestobase/bin/mustache.sh
+++ b/docker/hoodie/hadoop/prestobase/bin/mustache.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 
-################################################################################
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -16,7 +15,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 # `mustache.sh`, Mustache in POSIX shell.
 

--- a/docker/hoodie/hadoop/prestobase/etc/catalog/hive.properties
+++ b/docker/hoodie/hadoop/prestobase/etc/catalog/hive.properties
@@ -1,4 +1,4 @@
-################################################################################
+
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -14,7 +14,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
+
 connector.name=hive-hadoop2
 hive.metastore-cache-ttl=1s
 hive.metastore-refresh-interval=1m

--- a/docker/hoodie/hadoop/prestobase/etc/catalog/jmx.properties
+++ b/docker/hoodie/hadoop/prestobase/etc/catalog/jmx.properties
@@ -1,4 +1,4 @@
-################################################################################
+
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -14,7 +14,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
+
 connector.name=jmx
 jmx.dump-tables=java.lang:type=Runtime,com.facebook.presto.execution.scheduler:name=NodeScheduler
 jmx.dump-period=10s

--- a/docker/hoodie/hadoop/prestobase/etc/catalog/localfile.properties
+++ b/docker/hoodie/hadoop/prestobase/etc/catalog/localfile.properties
@@ -1,4 +1,4 @@
-################################################################################
+
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -14,7 +14,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
+
 connector.name=localfile
 presto-logs.http-request-log.location=/var/log/presto
 presto-logs.http-request-log.pattern=http-request.*

--- a/docker/hoodie/hadoop/prestobase/etc/coordinator.properties.mustache
+++ b/docker/hoodie/hadoop/prestobase/etc/coordinator.properties.mustache
@@ -1,4 +1,4 @@
-################################################################################
+
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -14,7 +14,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
+
 coordinator=true
 node-scheduler.include-coordinator=false
 http-server.http.port=8090

--- a/docker/hoodie/hadoop/prestobase/etc/jvm.config.mustache
+++ b/docker/hoodie/hadoop/prestobase/etc/jvm.config.mustache
@@ -1,4 +1,4 @@
-################################################################################
+
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -14,7 +14,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
+
 -server
 -Xmx{{PRESTO_JVM_MAX_HEAP}}
 -XX:+UseG1GC

--- a/docker/hoodie/hadoop/prestobase/etc/log.properties
+++ b/docker/hoodie/hadoop/prestobase/etc/log.properties
@@ -1,4 +1,4 @@
-################################################################################
+
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -14,5 +14,5 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
+
 com.facebook.presto=INFO

--- a/docker/hoodie/hadoop/prestobase/etc/node.properties.mustache
+++ b/docker/hoodie/hadoop/prestobase/etc/node.properties.mustache
@@ -1,4 +1,4 @@
-################################################################################
+
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -14,7 +14,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
+
 node.environment=production
 node.id={{PRESTO_NODE_ID}}
 node.data-dir={{PRESTO_LOG_DIR}}

--- a/docker/hoodie/hadoop/prestobase/etc/worker.properties.mustache
+++ b/docker/hoodie/hadoop/prestobase/etc/worker.properties.mustache
@@ -1,4 +1,4 @@
-################################################################################
+
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -14,7 +14,7 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
+
 coordinator=false
 http-server.http.port=8090
 query.max-memory={{PRESTO_QUERY_MAX_MEMORY}}

--- a/docker/hoodie/hadoop/prestobase/lib/mustache.sh
+++ b/docker/hoodie/hadoop/prestobase/lib/mustache.sh
@@ -1,4 +1,4 @@
-################################################################################
+
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -14,7 +14,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 # `mustache.sh`, Mustache in POSIX shell.
 

--- a/docker/hoodie/hadoop/spark_base/Dockerfile
+++ b/docker/hoodie/hadoop/spark_base/Dockerfile
@@ -1,4 +1,4 @@
-################################################################################
+
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -14,7 +14,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 ARG HADOOP_VERSION=2.8.4 
 ARG HIVE_VERSION=2.3.3

--- a/docker/hoodie/hadoop/spark_base/execute-step.sh
+++ b/docker/hoodie/hadoop/spark_base/execute-step.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-################################################################################
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -16,7 +15,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 if [ $ENABLE_INIT_DAEMON = "true" ]
    then

--- a/docker/hoodie/hadoop/spark_base/finish-step.sh
+++ b/docker/hoodie/hadoop/spark_base/finish-step.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-################################################################################
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -16,7 +15,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 if [ $ENABLE_INIT_DAEMON = "true" ]
    then

--- a/docker/hoodie/hadoop/spark_base/wait-for-step.sh
+++ b/docker/hoodie/hadoop/spark_base/wait-for-step.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-################################################################################
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -16,7 +15,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 if [ $ENABLE_INIT_DAEMON = "true" ]
    then

--- a/docker/hoodie/hadoop/sparkadhoc/Dockerfile
+++ b/docker/hoodie/hadoop/sparkadhoc/Dockerfile
@@ -1,4 +1,4 @@
-################################################################################
+
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -14,7 +14,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 ARG HADOOP_VERSION=2.8.4 
 ARG HIVE_VERSION=2.3.3

--- a/docker/hoodie/hadoop/sparkadhoc/adhoc.sh
+++ b/docker/hoodie/hadoop/sparkadhoc/adhoc.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-################################################################################
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -16,7 +15,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 . "/spark/sbin/spark-config.sh"
 

--- a/docker/hoodie/hadoop/sparkmaster/Dockerfile
+++ b/docker/hoodie/hadoop/sparkmaster/Dockerfile
@@ -1,4 +1,4 @@
-################################################################################
+
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -14,7 +14,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 ARG HADOOP_VERSION=2.8.4 
 ARG HIVE_VERSION=2.3.3

--- a/docker/hoodie/hadoop/sparkmaster/master.sh
+++ b/docker/hoodie/hadoop/sparkmaster/master.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-################################################################################
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -16,7 +15,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 export SPARK_MASTER_HOST=`hostname`
 

--- a/docker/hoodie/hadoop/sparkworker/Dockerfile
+++ b/docker/hoodie/hadoop/sparkworker/Dockerfile
@@ -1,4 +1,4 @@
-################################################################################
+
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -14,7 +14,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 ARG HADOOP_VERSION=2.8.4 
 ARG HIVE_VERSION=2.3.3

--- a/docker/hoodie/hadoop/sparkworker/worker.sh
+++ b/docker/hoodie/hadoop/sparkworker/worker.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-################################################################################
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -16,7 +15,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 . "/spark/sbin/spark-config.sh"
 

--- a/docker/setup_demo.sh
+++ b/docker/setup_demo.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-################################################################################
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -16,7 +15,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 SCRIPT_PATH=$(cd `dirname $0`; pwd)
 WS_ROOT=`dirname $SCRIPT_PATH`

--- a/docker/stop_demo.sh
+++ b/docker/stop_demo.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-################################################################################
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -16,7 +15,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 SCRIPT_PATH=$(cd `dirname $0`; pwd)
 # set up root directory

--- a/hudi-cli/conf/hudi-env.sh
+++ b/hudi-cli/conf/hudi-env.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-################################################################################
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -16,7 +15,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 # Set the necessary environment variables
 export HADOOP_CONF_DIR=${HADOOP_CONF_DIR:-"/etc/hadoop/conf"}

--- a/hudi-cli/hudi-cli.sh
+++ b/hudi-cli/hudi-cli.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-################################################################################
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -16,7 +15,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 HOODIE_JAR=`ls $DIR/target/hudi-cli-*.jar | grep -v source | grep -v javadoc`

--- a/hudi-hive/run_sync_tool.sh
+++ b/hudi-hive/run_sync_tool.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-################################################################################
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -16,7 +15,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 function error_exit {
     echo "$1" >&2   ## Send message to stderr. Exclude >&2 if you don't want it that way.

--- a/hudi-spark/run_hoodie_app.sh
+++ b/hudi-spark/run_hoodie_app.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-################################################################################
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -16,7 +15,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 function error_exit {
     echo "$1" >&2   ## Send message to stderr. Exclude >&2 if you don't want it that way.

--- a/hudi-spark/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
+++ b/hudi-spark/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
@@ -1,4 +1,4 @@
-################################################################################
+
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -14,7 +14,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 
 org.apache.hudi.DefaultSource

--- a/packaging/hudi-timeline-server-bundle/run_server.sh
+++ b/packaging/hudi-timeline-server-bundle/run_server.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-################################################################################
+
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -15,7 +15,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 #Ensure we pick the right jar even for hive11 builds

--- a/scripts/run_travis_tests.sh
+++ b/scripts/run_travis_tests.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-################################################################################
 #  Licensed to the Apache Software Foundation (ASF) under one
 #  or more contributor license agreements.  See the NOTICE file
 #  distributed with this work for additional information
@@ -16,7 +15,6 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 # limitations under the License.
-################################################################################
 
 mode=$1
 


### PR DESCRIPTION
## What is the purpose of the pull request

During the voting process on rc1 0.5.1-incubating release, Justin pointed out 
docker/hoodie/hadoop/base/entrypoint.sh has an incorrect license header,
But, many script files used the same license header like "entrypoint.sh" has.

From apache license guide[2], it says "The text should be enclosed in the appropriate comment syntax for the file format." So, need to remove the repeated "#".

Also, refered to 
https://github.com/apache/hive/blob/master/bin/init-hive-dfs.sh
https://github.com/apache/hive/blob/master/bin/hive-config.sh
https://github.com/apache/kafka/blob/trunk/bin/connect-distributed.sh
https://github.com/apache/kafka/blob/trunk/bin/kafka-leader-election.sh

[1] https://lists.apache.org/thread.html/rd3f4a72d82a4a5a81b2c6bd71e1417054daa38637ce8e07901f26f04%40%3Cgeneral.incubator.apache.org%3E
[2] https://www.apache.org/licenses/LICENSE-2.0

## Brief change log

  - Correct right license header

## Committer checklist

 - [X] Has a corresponding JIRA in PR title & commit
 
 - [X] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.