### PR TITLE
[HUDI-636] Fix could not get sources warnings while compiling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,19 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>2.2.1</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <version>3.0.0</version>
         <dependencies>


### PR DESCRIPTION
## What is the purpose of the pull request

During the voting process on rc1 0.5.1-incubating release[1], Justin pointed out that mvn log display could not get sources warnings, like
```

[INFO] --- maven-shade-plugin:3.1.1:shade (default) @ hudi-hadoop-mr-bundle ---
[INFO] Including org.apache.hudi:hudi-common:jar:0.5.2-SNAPSHOT in the shaded jar.
Downloading from aliyun: http://maven.aliyun.com/nexus/content/groups/public/org/apache/hudi/hudi-common/0.5.2-SNAPSHOT/hudi-common-0.5.2-SNAPSHOT-sources.jar
Downloading from cloudera: https://repository.cloudera.com/artifactory/cloudera-repos/org/apache/hudi/hudi-common/0.5.2-SNAPSHOT/hudi-common-0.5.2-SNAPSHOT-sources.jar
Downloading from confluent: https://packages.confluent.io/maven/org/apache/hudi/hudi-common/0.5.2-SNAPSHOT/hudi-common-0.5.2-SNAPSHOT-sources.jar
Downloading from libs-milestone: https://repo.spring.io/libs-milestone/org/apache/hudi/hudi-common/0.5.2-SNAPSHOT/hudi-common-0.5.2-SNAPSHOT-sources.jar
Downloading from libs-release: https://repo.spring.io/libs-release/org/apache/hudi/hudi-common/0.5.2-SNAPSHOT/hudi-common-0.5.2-SNAPSHOT-sources.jar
Downloading from apache.snapshots: https://repository.apache.org/snapshots/org/apache/hudi/hudi-common/0.5.2-SNAPSHOT/hudi-common-0.5.2-SNAPSHOT-sources.jar
[WARNING] Could not get sources for org.apache.hudi:hudi-common:jar:0.5.2-SNAPSHOT:compile
[INFO] Excluding com.fasterxml.jackson.core:jackson-annotations:jar:2.6.7 from the shaded jar.
[INFO] Excluding com.fasterxml.jackson.core:jackson-databind:jar:2.6.7.1 from the shaded jar.
[INFO] Excluding com.fasterxml.jackson.core:jackson-core:jar:2.6.7 from the shaded jar.
[INFO] Excluding org.apache.httpcomponents:fluent-hc:jar:4.3.2 from the shaded jar.
[INFO] Excluding commons-logging:commons-logging:jar:1.1.3 from the shaded jar.
[INFO] Excluding org.apache.httpcomponents:httpclient:jar:4.3.6 from the shaded jar.
[INFO] Excluding org.apache.httpcomponents:httpcore:jar:4.3.2 from the shaded jar.
[INFO] Excluding commons-codec:commons-codec:jar:1.6 from the shaded jar.
[INFO] Excluding org.rocksdb:rocksdbjni:jar:5.17.2 from the shaded jar.
[INFO] Including com.esotericsoftware:kryo-shaded:jar:4.0.2 in the shaded jar.
[INFO] Including com.esotericsoftware:minlog:jar:1.3.0 in the shaded jar.
[INFO] Including org.objenesis:objenesis:jar:2.5.1 in the shaded jar.
```

[1] https://lists.apache.org/thread.html/rd3f4a72d82a4a5a81b2c6bd71e1417054daa38637ce8e07901f26f04%40%3Cgeneral.incubator.apache.org%3E

## Brief change log

  - set createSourcesJar false.

## Verify this pull request

```
mvn clean package -DskipTests -DskipITs
```

## Committer checklist

 - [X] Has a corresponding JIRA in PR title & commit
 
 - [X] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.