### PR TITLE
[WIP]HUDI-644 Implement checkpoint generator helper tool

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/HoodieDeltaStreamer.java
@@ -252,18 +252,16 @@ public class HoodieDeltaStreamer implements Serializable {
         + "https://spark.apache.org/docs/latest/job-scheduling.html")
     public Integer compactSchedulingMinShare = 0;
 
-    /**
-     * Compaction is enabled for MoR table by default. This flag disables it
-     */
     @Parameter(names = {"--disable-compaction"},
         description = "Compaction is enabled for MoR table by default. This flag disables it ")
     public Boolean forceDisableCompaction = false;
 
-    /**
-     * Resume Delta Streamer from this checkpoint.
-     */
     @Parameter(names = {"--checkpoint"}, description = "Resume Delta Streamer from this checkpoint.")
     public String checkpoint = null;
+
+    @Parameter(names = {"--searchCheckpoint"}, description = "Search checkpoint in backward if no check point "
+            + "presents in the latest commit")
+    public Boolean searchCheckpoint = false;
 
     @Parameter(names = {"--help", "-h"}, help = true)
     public Boolean help = false;


### PR DESCRIPTION

## What is the purpose of the pull request

This PR is to resolve the following problem:

The user is using a homebrew Spark data source to read new data and write to Hudi table

The user would like to migrate to Delta Streamer

But the Delta Streamer only checks the last commit metadata, if there is no checkpoint info, then the Delta Streamer will use the default. For Kafka source, it is LATEST. 

The user would like to run the homebrew Spark data source reader and Delta Streamer in parallel to prevent data loss, but the Spark data source writer will make commit without checkpoint info, which will reset the delta streamer. 

So if we have an option to allow the user to retrieve the checkpoint from previous commits instead of the latest commit would be helpful for the migration. 

## Brief change log

  - *Add an option to restrieve checkpoint in DeltaSync*

## Verify this pull request


This pull request is a trivial rework / code cleanup without any test coverage.


## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.