### PR TITLE
[HUDI-553] Building/Running Hudi on higher java versions

### DIFF
--- a/hudi-cli/pom.xml
+++ b/hudi-cli/pom.xml
@@ -44,6 +44,11 @@
           <groupId>net.alchim31.maven</groupId>
           <artifactId>scala-maven-plugin</artifactId>
           <version>${scala-maven-plugin.version}</version>
+          <configuration>
+            <args>
+              <arg>-nobootcp</arg>
+            </args>
+          </configuration>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/hudi-common/src/main/java/org/apache/hudi/common/bloom/filter/HoodieDynamicBoundedBloomFilter.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/bloom/filter/HoodieDynamicBoundedBloomFilter.java
@@ -18,11 +18,10 @@
 
 package org.apache.hudi.common.bloom.filter;
 
+import org.apache.hudi.common.util.Base64CodecUtil;
 import org.apache.hudi.exception.HoodieIndexException;
 
 import org.apache.hadoop.util.bloom.Key;
-
-import javax.xml.bind.DatatypeConverter;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -66,7 +65,7 @@ public class HoodieDynamicBoundedBloomFilter implements BloomFilter {
    */
   HoodieDynamicBoundedBloomFilter(String serString, BloomFilterTypeCode typeCode) {
     // ignoring the type code for now, since we have just one version
-    byte[] bytes = DatatypeConverter.parseBase64Binary(serString);
+    byte[] bytes = Base64CodecUtil.decode(serString);
     DataInputStream dis = new DataInputStream(new ByteArrayInputStream(bytes));
     try {
       internalDynamicBloomFilter = new InternalDynamicBloomFilter();
@@ -95,7 +94,7 @@ public class HoodieDynamicBoundedBloomFilter implements BloomFilter {
       internalDynamicBloomFilter.write(dos);
       byte[] bytes = baos.toByteArray();
       dos.close();
-      return DatatypeConverter.printBase64Binary(bytes);
+      return Base64CodecUtil.encode(bytes);
     } catch (IOException e) {
       throw new HoodieIndexException("Could not serialize BloomFilter instance", e);
     }

--- a/hudi-common/src/main/java/org/apache/hudi/common/bloom/filter/SimpleBloomFilter.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/bloom/filter/SimpleBloomFilter.java
@@ -18,11 +18,10 @@
 
 package org.apache.hudi.common.bloom.filter;
 
+import org.apache.hudi.common.util.Base64CodecUtil;
 import org.apache.hudi.exception.HoodieIndexException;
 
 import org.apache.hadoop.util.bloom.Key;
-
-import javax.xml.bind.DatatypeConverter;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -66,7 +65,7 @@ public class SimpleBloomFilter implements BloomFilter {
    */
   public SimpleBloomFilter(String serString) {
     this.filter = new org.apache.hadoop.util.bloom.BloomFilter();
-    byte[] bytes = DatatypeConverter.parseBase64Binary(serString);
+    byte[] bytes = Base64CodecUtil.decode(serString);
     DataInputStream dis = new DataInputStream(new ByteArrayInputStream(bytes));
     try {
       this.filter.readFields(dis);
@@ -103,7 +102,7 @@ public class SimpleBloomFilter implements BloomFilter {
       filter.write(dos);
       byte[] bytes = baos.toByteArray();
       dos.close();
-      return DatatypeConverter.printBase64Binary(bytes);
+      return Base64CodecUtil.encode(bytes);
     } catch (IOException e) {
       throw new HoodieIndexException("Could not serialize BloomFilter instance", e);
     }

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/Base64CodecUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/Base64CodecUtil.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.util;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+public final class Base64CodecUtil {
+
+    /**
+     * Decodes data from the input string into using the encoding scheme.
+     *
+     * @param serString
+     * @return A newly-allocated byte array containing the decoded bytes.
+     */
+    public static byte[] decode(String serString) {
+        return Base64.getDecoder().decode(serString.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Encodes all bytes from the specified byte array into String using StandardCharsets.UTF_8.
+     *
+     * @param data byte[] source data
+     * @return base64 encoded data
+     */
+    public static String encode(byte[] data) {
+        return new String(Base64.getEncoder().encode(data), StandardCharsets.UTF_8);
+    }
+
+}

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/Base64CodecUtil.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/Base64CodecUtil.java
@@ -23,24 +23,24 @@ import java.util.Base64;
 
 public final class Base64CodecUtil {
 
-    /**
-     * Decodes data from the input string into using the encoding scheme.
-     *
-     * @param serString
-     * @return A newly-allocated byte array containing the decoded bytes.
-     */
-    public static byte[] decode(String serString) {
-        return Base64.getDecoder().decode(serString.getBytes(StandardCharsets.UTF_8));
-    }
+  /**
+   * Decodes data from the input string into using the encoding scheme.
+   *
+   * @param serString
+   * @return A newly-allocated byte array containing the decoded bytes.
+   */
+  public static byte[] decode(String serString) {
+    return Base64.getDecoder().decode(serString.getBytes(StandardCharsets.UTF_8));
+  }
 
-    /**
-     * Encodes all bytes from the specified byte array into String using StandardCharsets.UTF_8.
-     *
-     * @param data byte[] source data
-     * @return base64 encoded data
-     */
-    public static String encode(byte[] data) {
-        return new String(Base64.getEncoder().encode(data), StandardCharsets.UTF_8);
-    }
+  /**
+   * Encodes all bytes from the specified byte array into String using StandardCharsets.UTF_8.
+   *
+   * @param data byte[] source data
+   * @return base64 encoded data
+   */
+  public static String encode(byte[] data) {
+    return new String(Base64.getEncoder().encode(data), StandardCharsets.UTF_8);
+  }
 
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestBase64CodecUtil.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestBase64CodecUtil.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.common.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+public class TestBase64CodecUtil {
+
+    @Test
+    public void testCodec() {
+
+        int times = 100;
+        UUID uuid = UUID.randomUUID();
+
+        for (int i = 0; i < times; i++) {
+
+            byte[] originalData = uuid.toString().getBytes(StandardCharsets.UTF_8);
+
+            String encodeData = Base64CodecUtil.encode(originalData);
+            byte[] decodeData = Base64CodecUtil.decode(encodeData);
+
+            Assert.assertArrayEquals(originalData, decodeData);
+        }
+
+    }
+
+}

--- a/hudi-common/src/test/java/org/apache/hudi/common/util/TestBase64CodecUtil.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/util/TestBase64CodecUtil.java
@@ -26,22 +26,22 @@ import java.util.UUID;
 
 public class TestBase64CodecUtil {
 
-    @Test
-    public void testCodec() {
+  @Test
+  public void testCodec() {
 
-        int times = 100;
-        UUID uuid = UUID.randomUUID();
+    int times = 100;
+    UUID uuid = UUID.randomUUID();
 
-        for (int i = 0; i < times; i++) {
+    for (int i = 0; i < times; i++) {
 
-            byte[] originalData = uuid.toString().getBytes(StandardCharsets.UTF_8);
+      byte[] originalData = uuid.toString().getBytes(StandardCharsets.UTF_8);
 
-            String encodeData = Base64CodecUtil.encode(originalData);
-            byte[] decodeData = Base64CodecUtil.decode(encodeData);
+      String encodeData = Base64CodecUtil.encode(originalData);
+      byte[] decodeData = Base64CodecUtil.decode(encodeData);
 
-            Assert.assertArrayEquals(originalData, decodeData);
-        }
-
+      Assert.assertArrayEquals(originalData, decodeData);
     }
+
+  }
 
 }

--- a/hudi-spark/pom.xml
+++ b/hudi-spark/pom.xml
@@ -42,6 +42,11 @@
           <groupId>net.alchim31.maven</groupId>
           <artifactId>scala-maven-plugin</artifactId>
           <version>${scala-maven-plugin.version}</version>
+          <configuration>
+            <args>
+              <arg>-nobootcp</arg>
+            </args>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
     <metrics.version>4.1.1</metrics.version>
     <spark.version>2.4.4</spark.version>
     <avro.version>1.8.2</avro.version>
-    <scala.version>2.11.8</scala.version>
+    <scala.version>2.11.12</scala.version>
     <scala.binary.version>2.11</scala.binary.version>
     <apache-rat-plugin.version>0.12</apache-rat-plugin.version>
     <scala-maven-plugin.version>3.3.1</scala-maven-plugin.version>


### PR DESCRIPTION
## What is the purpose of the pull request

Support building/running Hudi on higher java versions (8 & 11).

## Brief change log
1. `package javax.xml.bind does not exist`
  - sun.misc.BASE64Encoder/Decoder (JDK 6,7,8)
  - javax.xml.bind.DatatypeConverter (JDK 6,7,8)
  - java.util.Base64.{Encoder, Decoder} (JDK 8,9,11)
 
2. Need upgrade to `scala-2.11.12` https://github.com/sbt/zinc/issues/641
```
[ERROR] error: scala.reflect.internal.MissingRequirementError: object java.lang.Object in compiler mirror not found.
[ERROR]    at scala.reflect.internal.MissingRequirementError$.signal(MissingRequirementError.scala:17)
[ERROR]    at scala.reflect.internal.MissingRequirementError$.notFound(MissingRequirementError.scala:18)
[ERROR]    at scala.reflect.internal.Mirrors$RootsBase.getModuleOrClass(Mirrors.scala:53)
```

3. `java.lang.NoClassDefFoundError: javax/tools/ToolProvider` 
https://github.com/davidB/scala-maven-plugin/issues/217
```
[ERROR] error: java.lang.NoClassDefFoundError: javax/tools/ToolProvider
[INFO]  at scala.reflect.io.JavaToolsPlatformArchive.iterator(ZipArchive.scala:301)
[INFO]  at scala.collection.IterableLike$class.foreach(IterableLike.scala:72)
[INFO]  at scala.reflect.io.AbstractFile.foreach(AbstractFile.scala:92)
[INFO]  at scala.tools.nsc.util.DirectoryClassPath.traverse(ClassPath.scala:277)
[INFO]  at scala.tools.nsc.util.DirectoryClassPath.x$15$lzycompute(ClassPath.scala:299)
[INFO]  at scala.tools.nsc.util.DirectoryClassPath.x$15(ClassPath.scala:299)
```

## Verify this pull request

`Spark-2.4.4` doesn't support JDK 9 https://issues.apache.org/jira/browse/SPARK-24417

Using `spark-3.0.0-preview2-bin-hadoop2.7` and `hudi - 2.12`
```
mvn clean package -DskipTests -Dscala-2.12
```
```
/bin/spark-shell \
  --packages org.apache.spark:spark-avro_2.12:2.4.4 \
  --jars `ls packaging/hudi-spark-bundle/target/hudi-spark-bundle_*.*-*.*.*-SNAPSHOT.jar` \
  --conf 'spark.serializer=org.apache.spark.serializer.KryoSerializer'
```

## Committer checklist

 - [X] Has a corresponding JIRA in PR title & commit
 
 - [X] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.