### PR TITLE
[HUDI-680] Update Jackson databind to 2.6.7.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -430,7 +430,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>${fasterxml.version}.1</version>
+        <version>${fasterxml.version}.3</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>


### PR DESCRIPTION

## What is the purpose of the pull request

https://issues.apache.org/jira/browse/HUDI-680

I would like to update Jackson databind to 2.6.7.3. Because this version is the latest jackson-databind of 2.6.7.x line and it has all CVE fixes up to 2.9.10.

https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.6.7.x

## Brief change log

- Update Jackson databind to 2.6.7.3

## Verify this pull request

Tested this change by building and running some sample job locally.


## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.