### PR TITLE
[HUDI-689] Change CLI command names to not have overlap

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/CommitsCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/CommitsCommand.java
@@ -173,7 +173,7 @@ public class CommitsCommand implements CommandMarker {
     }
   }
 
-  @CliCommand(value = "commits show archived", help = "Show the archived commits")
+  @CliCommand(value = "commits showarchived", help = "Show the archived commits")
   public String showArchivedCommits(
           @CliOption(key = {"includeExtraMetadata"}, help = "Include extra metadata",
                   unspecifiedDefaultValue = "false") final boolean includeExtraMetadata,

--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/CompactionCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/CompactionCommand.java
@@ -126,8 +126,8 @@ public class CompactionCommand implements CommandMarker {
     return printCompaction(compactionPlan, sortByField, descending, limit, headerOnly);
   }
 
-  @CliCommand(value = "compactions show archived", help = "Shows compaction details for specified time window")
-  public String compactionShowArchived(
+  @CliCommand(value = "compactions showarchived", help = "Shows compaction details for specified time window")
+  public String compactionsShowArchived(
           @CliOption(key = {"includeExtraMetadata"}, help = "Include extra metadata",
                   unspecifiedDefaultValue = "false") final boolean includeExtraMetadata,
           @CliOption(key = {"startTs"},  mandatory = false, help = "start time for compactions, default: now - 10 days")
@@ -160,7 +160,7 @@ public class CompactionCommand implements CommandMarker {
     }
   }
 
-  @CliCommand(value = "compaction show archived", help = "Shows compaction details for a specific compaction instant")
+  @CliCommand(value = "compaction showarchived", help = "Shows compaction details for a specific compaction instant")
   public String compactionShowArchived(
           @CliOption(key = "instant", mandatory = true,
                   help = "instant time") final String compactionInstantTime,


### PR DESCRIPTION
## What is the purpose of the pull request
I broke CLI when i added compactions show archived command.
 I still dont understand spring shell well enough to explain why the existing commands wont work. But the alternative commands I picked seemed to work. Please let me know if any of you have seen similar issues with spring shell and how command parsing works.

CLI 'commits show archived' fails with

->commits show archived
Option '' is not available for this command. Use tab assist or the "help" command to see the legal options
This seems to be because 'compactions show archived'. If i remove @CliCommand annotation from compactions, commits show archived works.

## Brief change log

- Chose different command names to make all commands 'work'
- change method names to not overlap with each other
- we may have to patch this to 0.5.2 branch as well 


## Verify this pull request

Manually verified the change by running CLI

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.