### PR TITLE
[HUDI-687] Stop incremental reader on RO table before a pending compaction

### DIFF
--- a/hudi-client/src/test/java/org/apache/hudi/common/HoodieMergeOnReadTestUtils.java
+++ b/hudi-client/src/test/java/org/apache/hudi/common/HoodieMergeOnReadTestUtils.java
@@ -20,6 +20,7 @@ package org.apache.hudi.common;
 
 import org.apache.hudi.avro.HoodieAvroUtils;
 import org.apache.hudi.common.model.HoodieTestUtils;
+import org.apache.hudi.hadoop.HoodieParquetInputFormat;
 import org.apache.hudi.hadoop.realtime.HoodieParquetRealtimeInputFormat;
 
 import org.apache.avro.Schema;
@@ -51,29 +52,36 @@ public class HoodieMergeOnReadTestUtils {
   public static List<GenericRecord> getRecordsUsingInputFormat(List<String> inputPaths, String basePath,
                                                                 Configuration conf) {
     JobConf jobConf = new JobConf(conf);
+    return getRecordsUsingInputFormat(inputPaths, basePath, jobConf, new HoodieParquetRealtimeInputFormat());
+  }
+
+  public static List<GenericRecord> getRecordsUsingInputFormat(List<String> inputPaths,
+                                                               String basePath,
+                                                               JobConf jobConf,
+                                                               HoodieParquetInputFormat inputFormat) {
     Schema schema = HoodieAvroUtils.addMetadataFields(
         new Schema.Parser().parse(HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA));
-    HoodieParquetRealtimeInputFormat inputFormat = new HoodieParquetRealtimeInputFormat();
     setPropsForInputFormat(inputFormat, jobConf, schema, basePath);
     return inputPaths.stream().map(path -> {
       setInputPath(jobConf, path);
       List<GenericRecord> records = new ArrayList<>();
       try {
         List<InputSplit> splits = Arrays.asList(inputFormat.getSplits(jobConf, 1));
-        RecordReader recordReader = inputFormat.getRecordReader(splits.get(0), jobConf, null);
-        Void key = (Void) recordReader.createKey();
-        ArrayWritable writable = (ArrayWritable) recordReader.createValue();
-        while (recordReader.next(key, writable)) {
-          GenericRecordBuilder newRecord = new GenericRecordBuilder(schema);
-          // writable returns an array with [field1, field2, _hoodie_commit_time,
-          // _hoodie_commit_seqno]
-          Writable[] values = writable.get();
-          final int[] fieldIndex = {0};
-          assert schema.getFields().size() <= values.length;
-          schema.getFields().forEach(field -> {
-            newRecord.set(field, values[fieldIndex[0]++]);
-          });
-          records.add(newRecord.build());
+        for (InputSplit split : splits) {
+          RecordReader recordReader = inputFormat.getRecordReader(split, jobConf, null);
+          Void key = (Void) recordReader.createKey();
+          ArrayWritable writable = (ArrayWritable) recordReader.createValue();
+          while (recordReader.next(key, writable)) {
+            GenericRecordBuilder newRecord = new GenericRecordBuilder(schema);
+            // writable returns an array with [field1, field2, _hoodie_commit_time,
+            // _hoodie_commit_seqno]
+            Writable[] values = writable.get();
+            assert schema.getFields().size() <= values.length;
+            schema.getFields().forEach(field -> {
+              newRecord.set(field, values[field.pos()]);
+            });
+            records.add(newRecord.build());
+          }
         }
       } catch (IOException ie) {
         ie.printStackTrace();
@@ -85,7 +93,7 @@ public class HoodieMergeOnReadTestUtils {
     }).orElse(new ArrayList<GenericRecord>());
   }
 
-  private static void setPropsForInputFormat(HoodieParquetRealtimeInputFormat inputFormat, JobConf jobConf,
+  private static void setPropsForInputFormat(HoodieParquetInputFormat inputFormat, JobConf jobConf,
       Schema schema, String basePath) {
     List<Schema.Field> fields = schema.getFields();
     String names = fields.stream().map(f -> f.name().toString()).collect(Collectors.joining(","));

--- a/hudi-client/src/test/java/org/apache/hudi/table/TestMergeOnReadTable.java
+++ b/hudi-client/src/test/java/org/apache/hudi/table/TestMergeOnReadTable.java
@@ -18,6 +18,8 @@
 
 package org.apache.hudi.table;
 
+import org.apache.hadoop.mapred.FileInputFormat;
+import org.apache.hadoop.mapred.JobConf;
 import org.apache.hudi.client.HoodieReadClient;
 import org.apache.hudi.client.HoodieWriteClient;
 import org.apache.hudi.client.WriteStatus;
@@ -50,6 +52,9 @@ import org.apache.hudi.config.HoodieCompactionConfig;
 import org.apache.hudi.config.HoodieIndexConfig;
 import org.apache.hudi.config.HoodieStorageConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
+import org.apache.hudi.hadoop.HoodieHiveUtil;
+import org.apache.hudi.hadoop.HoodieParquetInputFormat;
+import org.apache.hudi.hadoop.realtime.HoodieParquetRealtimeInputFormat;
 import org.apache.hudi.index.HoodieIndex;
 import org.apache.hudi.index.HoodieIndex.IndexType;
 
@@ -70,6 +75,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -80,6 +86,12 @@ import static org.junit.Assert.assertTrue;
 
 public class TestMergeOnReadTable extends HoodieClientTestHarness {
 
+  private HoodieParquetInputFormat roInputFormat;
+  private JobConf roJobConf;
+
+  private HoodieParquetRealtimeInputFormat rtInputFormat;
+  private JobConf rtJobConf;
+
   @Before
   public void init() throws IOException {
     initDFS();
@@ -89,6 +101,15 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
     dfs.mkdirs(new Path(basePath));
     HoodieTestUtils.init(jsc.hadoopConfiguration(), basePath, HoodieTableType.MERGE_ON_READ);
     initTestDataGenerator();
+
+    // initialize parquet input format
+    roInputFormat = new HoodieParquetInputFormat();
+    roJobConf = new JobConf(jsc.hadoopConfiguration());
+    roInputFormat.setConf(roJobConf);
+
+    rtInputFormat = new HoodieParquetRealtimeInputFormat();
+    rtJobConf = new JobConf(jsc.hadoopConfiguration());
+    rtInputFormat.setConf(rtJobConf);
   }
 
   @After
@@ -114,63 +135,23 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
       client.startCommitWithTime(newCommitTime);
 
       List<HoodieRecord> records = dataGen.generateInserts(newCommitTime, 200);
-      JavaRDD<HoodieRecord> writeRecords = jsc.parallelize(records, 1);
-
-      List<WriteStatus> statuses = client.upsert(writeRecords, newCommitTime).collect();
-      assertNoWriteErrors(statuses);
-
-      HoodieTableMetaClient metaClient = new HoodieTableMetaClient(jsc.hadoopConfiguration(), cfg.getBasePath());
-      HoodieTable hoodieTable = HoodieTable.create(metaClient, cfg, jsc);
-
-      Option<HoodieInstant> deltaCommit = metaClient.getActiveTimeline().getDeltaCommitTimeline().firstInstant();
-      assertTrue(deltaCommit.isPresent());
-      Assert.assertEquals("Delta commit should be 001", "001", deltaCommit.get().getTimestamp());
-
-      Option<HoodieInstant> commit = metaClient.getActiveTimeline().getCommitTimeline().firstInstant();
-      assertFalse(commit.isPresent());
-
-      FileStatus[] allFiles = HoodieTestUtils.listAllDataFilesInPath(metaClient.getFs(), cfg.getBasePath());
-      BaseFileOnlyView roView =
-          new HoodieTableFileSystemView(metaClient, metaClient.getCommitTimeline().filterCompletedInstants(), allFiles);
-      Stream<HoodieBaseFile> dataFilesToRead = roView.getLatestBaseFiles();
-      assertTrue(!dataFilesToRead.findAny().isPresent());
-
-      roView = new HoodieTableFileSystemView(metaClient, hoodieTable.getCompletedCommitsTimeline(), allFiles);
-      dataFilesToRead = roView.getLatestBaseFiles();
-      assertTrue("should list the parquet files we wrote in the delta commit",
-          dataFilesToRead.findAny().isPresent());
+      insertAndGetFilePaths(records, client, cfg, newCommitTime);
 
       /**
        * Write 2 (updates)
        */
       newCommitTime = "004";
       client.startCommitWithTime(newCommitTime);
-
       records = dataGen.generateUpdates(newCommitTime, 100);
-      Map<HoodieKey, HoodieRecord> recordsMap = new HashMap<>();
-      for (HoodieRecord rec : records) {
-        if (!recordsMap.containsKey(rec.getKey())) {
-          recordsMap.put(rec.getKey(), rec);
-        }
-      }
-
-      statuses = client.upsert(jsc.parallelize(records, 1), newCommitTime).collect();
-      // Verify there are no errors
-      assertNoWriteErrors(statuses);
-      metaClient = HoodieTableMetaClient.reload(metaClient);
-      deltaCommit = metaClient.getActiveTimeline().getDeltaCommitTimeline().lastInstant();
-      assertTrue(deltaCommit.isPresent());
-      assertEquals("Latest Delta commit should be 004", "004", deltaCommit.get().getTimestamp());
-
-      commit = metaClient.getActiveTimeline().getCommitTimeline().firstInstant();
-      assertFalse(commit.isPresent());
+      updateAndGetFilePaths(records, client, cfg, newCommitTime);
 
       String compactionCommitTime = client.scheduleCompaction(Option.empty()).get().toString();
       client.compact(compactionCommitTime);
 
-      allFiles = HoodieTestUtils.listAllDataFilesInPath(dfs, cfg.getBasePath());
-      roView = new HoodieTableFileSystemView(metaClient, hoodieTable.getCompletedCommitsTimeline(), allFiles);
-      dataFilesToRead = roView.getLatestBaseFiles();
+      FileStatus[] allFiles = HoodieTestUtils.listAllDataFilesInPath(dfs, cfg.getBasePath());
+      HoodieTable hoodieTable = HoodieTable.create(metaClient, cfg, jsc);
+      HoodieTableFileSystemView roView = new HoodieTableFileSystemView(metaClient, hoodieTable.getCompletedCommitsTimeline(), allFiles);
+      Stream<HoodieBaseFile> dataFilesToRead = roView.getLatestBaseFiles();
       assertTrue(dataFilesToRead.findAny().isPresent());
 
       // verify that there is a commit
@@ -183,6 +164,101 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
 
       assertEquals("Must contain 200 records", 200,
           HoodieClientTestUtils.readSince(basePath, sqlContext, timeline, "000").count());
+    }
+  }
+
+  // test incremental read does not go past compaction instant for RO views
+  // For RT views, incremental read can go past compaction
+  @Test
+  public void testIncrementalReadsWithCompaction() throws Exception {
+    String partitionPath = "2020/02/20"; // use only one partition for this test
+    dataGen = new HoodieTestDataGenerator(new String[] { partitionPath });
+    HoodieWriteConfig cfg = getConfig(true);
+    try (HoodieWriteClient client = getWriteClient(cfg);) {
+
+      /**
+       * Write 1 (only inserts)
+       */
+      String commitTime1 = "001";
+      client.startCommitWithTime(commitTime1);
+
+      List<HoodieRecord> records001 = dataGen.generateInserts(commitTime1, 200);
+      insertAndGetFilePaths(records001, client, cfg, commitTime1);
+
+      // verify only one parquet file shows up with commit time 001
+      FileStatus[] incrementalROFiles = getROIncrementalFiles(partitionPath, true);
+      validateIncrementalFiles(partitionPath, 1, incrementalROFiles, roInputFormat,
+              roJobConf,200, commitTime1);
+      Path firstFilePath = incrementalROFiles[0].getPath();
+
+      FileStatus[] incrementalRTFiles = getRTIncrementalFiles(partitionPath);
+      validateIncrementalFiles(partitionPath, 1, incrementalRTFiles, rtInputFormat,
+              rtJobConf,200, commitTime1);
+      assertEquals(firstFilePath, incrementalRTFiles[0].getPath());
+
+      /**
+       * Write 2 (updates)
+       */
+      String updateTime = "004";
+      client.startCommitWithTime(updateTime);
+      List<HoodieRecord> records004 = dataGen.generateUpdates(updateTime, 100);
+      updateAndGetFilePaths(records004, client, cfg, updateTime);
+
+      // verify RO incremental reads - only one parquet file shows up because updates to into log files
+      incrementalROFiles = getROIncrementalFiles(partitionPath, false);
+      validateIncrementalFiles(partitionPath, 1, incrementalROFiles, roInputFormat,
+              roJobConf, 200, commitTime1);
+      assertEquals(firstFilePath, incrementalROFiles[0].getPath());
+
+      // verify RT incremental reads includes updates also
+      incrementalRTFiles = getRTIncrementalFiles(partitionPath);
+      validateIncrementalFiles(partitionPath, 1, incrementalRTFiles, rtInputFormat,
+              rtJobConf, 200, commitTime1, updateTime);
+
+      // request compaction, but do not perform compaction
+      String compactionCommitTime = "005";
+      client.scheduleCompactionAtInstant("005", Option.empty());
+
+      // verify RO incremental reads - only one parquet file shows up because updates go into log files
+      incrementalROFiles = getROIncrementalFiles(partitionPath, true);
+      validateIncrementalFiles(partitionPath,1, incrementalROFiles, roInputFormat,
+              roJobConf, 200, commitTime1);
+
+      // verify RT incremental reads includes updates also
+      incrementalRTFiles = getRTIncrementalFiles(partitionPath);
+      validateIncrementalFiles(partitionPath, 1, incrementalRTFiles, rtInputFormat,
+              rtJobConf, 200, commitTime1, updateTime);
+
+      // write 3 - more inserts
+      String insertsTime = "006";
+      List<HoodieRecord> records006 = dataGen.generateInserts(insertsTime, 200);
+      client.startCommitWithTime(insertsTime);
+      insertAndGetFilePaths(records006, client, cfg, insertsTime);
+
+      incrementalROFiles = getROIncrementalFiles(partitionPath, true);
+      assertEquals(firstFilePath, incrementalROFiles[0].getPath());
+      // verify 006 does not show up in RO mode because of pending compaction
+      validateIncrementalFiles(partitionPath, 1, incrementalROFiles, roInputFormat,
+              roJobConf, 200, commitTime1);
+
+      // verify that if stopAtCompaction is disabled, inserts from "insertsTime" show up
+      incrementalROFiles = getROIncrementalFiles(partitionPath, false);
+      validateIncrementalFiles(partitionPath,2, incrementalROFiles, roInputFormat,
+          roJobConf, 400, commitTime1, insertsTime);
+
+      // verify 006 shows up in RT views
+      incrementalRTFiles = getRTIncrementalFiles(partitionPath);
+      validateIncrementalFiles(partitionPath, 2, incrementalRTFiles, rtInputFormat,
+              rtJobConf, 400, commitTime1, updateTime, insertsTime);
+
+      // perform the scheduled compaction
+      client.compact(compactionCommitTime);
+
+      incrementalROFiles = getROIncrementalFiles(partitionPath, "002", -1, true);
+      assertTrue(incrementalROFiles.length == 2);
+      // verify 006 shows up because of pending compaction
+      validateIncrementalFiles(partitionPath, 2, incrementalROFiles, roInputFormat,
+              roJobConf, 400, commitTime1, compactionCommitTime, insertsTime);
     }
   }
 
@@ -1308,5 +1384,116 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
     for (WriteStatus status : statuses) {
       assertFalse("Errors found in write of " + status.getFileId(), status.hasErrors());
     }
+  }
+  
+  private FileStatus[] insertAndGetFilePaths(List<HoodieRecord> records, HoodieWriteClient client,
+                                             HoodieWriteConfig cfg, String commitTime) throws IOException {
+    JavaRDD<HoodieRecord> writeRecords = jsc.parallelize(records, 1);
+
+    List<WriteStatus> statuses = client.insert(writeRecords, commitTime).collect();
+    assertNoWriteErrors(statuses);
+
+    metaClient = new HoodieTableMetaClient(jsc.hadoopConfiguration(), cfg.getBasePath());
+    HoodieTable hoodieTable = HoodieTable.create(metaClient, cfg, jsc);
+
+    Option<HoodieInstant> deltaCommit = metaClient.getActiveTimeline().getDeltaCommitTimeline().lastInstant();
+    assertTrue(deltaCommit.isPresent());
+    Assert.assertEquals("Delta commit should be specified value", commitTime, deltaCommit.get().getTimestamp());
+
+    Option<HoodieInstant> commit = metaClient.getActiveTimeline().getCommitTimeline().lastInstant();
+    assertFalse(commit.isPresent());
+
+    FileStatus[] allFiles = HoodieTestUtils.listAllDataFilesInPath(metaClient.getFs(), cfg.getBasePath());
+    BaseFileOnlyView roView =
+            new HoodieTableFileSystemView(metaClient, metaClient.getCommitTimeline().filterCompletedInstants(), allFiles);
+    Stream<HoodieBaseFile> dataFilesToRead = roView.getLatestBaseFiles();
+    assertTrue(!dataFilesToRead.findAny().isPresent());
+
+    roView = new HoodieTableFileSystemView(metaClient, hoodieTable.getCompletedCommitsTimeline(), allFiles);
+    dataFilesToRead = roView.getLatestBaseFiles();
+    assertTrue("should list the parquet files we wrote in the delta commit",
+            dataFilesToRead.findAny().isPresent());
+    return allFiles;
+  }
+
+  private FileStatus[] updateAndGetFilePaths(List<HoodieRecord> records, HoodieWriteClient client,
+                                             HoodieWriteConfig cfg, String commitTime) throws IOException {
+    Map<HoodieKey, HoodieRecord> recordsMap = new HashMap<>();
+    for (HoodieRecord rec : records) {
+      if (!recordsMap.containsKey(rec.getKey())) {
+        recordsMap.put(rec.getKey(), rec);
+      }
+    }
+
+    List<WriteStatus> statuses = client.upsert(jsc.parallelize(records, 1), commitTime).collect();
+    // Verify there are no errors
+    assertNoWriteErrors(statuses);
+    metaClient = HoodieTableMetaClient.reload(metaClient);
+    Option<HoodieInstant> deltaCommit = metaClient.getActiveTimeline().getDeltaCommitTimeline().lastInstant();
+    assertTrue(deltaCommit.isPresent());
+    assertEquals("Latest Delta commit should match specified time",
+            commitTime, deltaCommit.get().getTimestamp());
+
+    Option<HoodieInstant> commit = metaClient.getActiveTimeline().getCommitTimeline().firstInstant();
+    assertFalse(commit.isPresent());
+    return HoodieTestUtils.listAllDataFilesInPath(metaClient.getFs(), cfg.getBasePath());
+  }
+
+  private FileStatus[] getROIncrementalFiles(String partitionPath, boolean stopAtCompaction)
+      throws Exception {
+    return getROIncrementalFiles(partitionPath, "000", -1, stopAtCompaction);
+  }
+
+  private FileStatus[] getROIncrementalFiles(String partitionPath, String startCommitTime, int numCommitsToPull, boolean stopAtCompaction)
+          throws Exception {
+    HoodieTestUtils.init(jsc.hadoopConfiguration(), basePath, HoodieTableType.MERGE_ON_READ);
+    setupIncremental(roJobConf, startCommitTime, numCommitsToPull, stopAtCompaction);
+    FileInputFormat.setInputPaths(roJobConf, basePath + "/" + partitionPath);
+    return roInputFormat.listStatus(roJobConf);
+  }
+
+  private FileStatus[] getRTIncrementalFiles(String partitionPath)
+          throws Exception {
+    return getRTIncrementalFiles(partitionPath, "000", -1);
+  }
+
+  private FileStatus[] getRTIncrementalFiles(String partitionPath, String startCommitTime, int numCommitsToPull)
+          throws Exception {
+    HoodieTestUtils.init(jsc.hadoopConfiguration(), basePath, HoodieTableType.MERGE_ON_READ);
+    setupIncremental(rtJobConf, startCommitTime, numCommitsToPull, false);
+    FileInputFormat.setInputPaths(rtJobConf, basePath + "/" + partitionPath);
+    return rtInputFormat.listStatus(rtJobConf);
+  }
+
+  private void setupIncremental(JobConf jobConf, String startCommit, int numberOfCommitsToPull, boolean stopAtCompaction) {
+    String modePropertyName =
+            String.format(HoodieHiveUtil.HOODIE_CONSUME_MODE_PATTERN, HoodieTestUtils.RAW_TRIPS_TEST_NAME);
+    jobConf.set(modePropertyName, HoodieHiveUtil.INCREMENTAL_SCAN_MODE);
+
+    String startCommitTimestampName =
+            String.format(HoodieHiveUtil.HOODIE_START_COMMIT_PATTERN, HoodieTestUtils.RAW_TRIPS_TEST_NAME);
+    jobConf.set(startCommitTimestampName, startCommit);
+
+    String maxCommitPulls =
+        String.format(HoodieHiveUtil.HOODIE_MAX_COMMIT_PATTERN, HoodieTestUtils.RAW_TRIPS_TEST_NAME);
+    jobConf.setInt(maxCommitPulls, numberOfCommitsToPull);
+
+    String stopAtCompactionPropName =
+        String.format(HoodieHiveUtil.HOODIE_STOP_AT_COMPACTION_PATTERN, HoodieTestUtils.RAW_TRIPS_TEST_NAME);
+    jobConf.setBoolean(stopAtCompactionPropName, stopAtCompaction);
+  }
+
+  private void validateIncrementalFiles(String partitionPath, int expectedNumFiles,
+                                        FileStatus[] files, HoodieParquetInputFormat inputFormat,
+                                        JobConf jobConf, int expectedRecords, String... expectedCommits) {
+
+    assertEquals(expectedNumFiles, files.length);
+    Set<String> expectedCommitsSet = Arrays.asList(expectedCommits).stream().collect(Collectors.toSet());
+    List<GenericRecord> records = HoodieMergeOnReadTestUtils.getRecordsUsingInputFormat(
+            Arrays.asList(basePath + "/" + partitionPath), basePath, jobConf, inputFormat);
+    assertEquals(expectedRecords, records.size());
+    Set<String> actualCommits = records.stream().map(r ->
+            r.get(HoodieRecord.COMMIT_TIME_METADATA_FIELD).toString()).collect(Collectors.toSet());
+    assertEquals(expectedCommitsSet, actualCommits);
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieDefaultTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieDefaultTimeline.java
@@ -112,7 +112,7 @@ public class HoodieDefaultTimeline implements HoodieTimeline {
   }
 
   @Override
-  public HoodieTimeline getCommitsAndCompactionTimeline() {
+  public HoodieDefaultTimeline getCommitsAndCompactionTimeline() {
     Set<String> validActions = CollectionUtils.createSet(COMMIT_ACTION, DELTA_COMMIT_ACTION, COMPACTION_ACTION);
     return new HoodieDefaultTimeline(instants.stream().filter(s -> validActions.contains(s.getAction())), details);
   }
@@ -134,6 +134,13 @@ public class HoodieDefaultTimeline implements HoodieTimeline {
     return new HoodieDefaultTimeline(instants.stream()
         .filter(s -> HoodieTimeline.compareTimestamps(s.getTimestamp(), instantTime, GREATER)).limit(numCommits),
         details);
+  }
+
+  @Override
+  public HoodieDefaultTimeline findInstantsBefore(String instantTime) {
+    return new HoodieDefaultTimeline(instants.stream()
+            .filter(s -> HoodieTimeline.compareTimestamps(s.getTimestamp(), instantTime, LESSER)),
+            details);
   }
 
   @Override

--- a/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/table/timeline/HoodieTimeline.java
@@ -144,6 +144,11 @@ public interface HoodieTimeline extends Serializable {
   HoodieTimeline findInstantsAfter(String instantTime, int numCommits);
 
   /**
+   * Create a new Timeline with all instants before specified time.
+   */
+  HoodieTimeline findInstantsBefore(String instantTime);
+
+  /**
    * Custom Filter of Instants.
    */
   HoodieTimeline filter(Predicate<HoodieInstant> filter);

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/TestHoodieActiveTimeline.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/timeline/TestHoodieActiveTimeline.java
@@ -18,6 +18,7 @@
 
 package org.apache.hudi.common.table.timeline;
 
+import org.apache.hadoop.fs.Path;
 import org.apache.hudi.common.HoodieCommonTestHarness;
 import org.apache.hudi.common.model.HoodieTestUtils;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
@@ -25,8 +26,6 @@ import org.apache.hudi.common.table.timeline.HoodieInstant.State;
 import org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion;
 import org.apache.hudi.common.util.CollectionUtils;
 import org.apache.hudi.common.util.Option;
-
-import org.apache.hadoop.fs.Path;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -153,10 +152,15 @@ public class TestHoodieActiveTimeline extends HoodieCommonTestHarness {
   public void testTimelineOperations() {
     timeline = new MockHoodieTimeline(Stream.of("01", "03", "05", "07", "09", "11", "13", "15", "17", "19"),
         Stream.of("21", "23"));
-    HoodieTestUtils.assertStreamEquals("", Stream.of("05", "07", "09", "11"), timeline.getCommitTimeline()
-        .filterCompletedInstants().findInstantsInRange("04", "11").getInstants().map(HoodieInstant::getTimestamp));
-    HoodieTestUtils.assertStreamEquals("", Stream.of("09", "11"), timeline.getCommitTimeline().filterCompletedInstants()
-        .findInstantsAfter("07", 2).getInstants().map(HoodieInstant::getTimestamp));
+    HoodieTestUtils.assertStreamEquals("findInstantsInRange should return 4 instants", Stream.of("05", "07", "09", "11"),
+        timeline.getCommitTimeline().filterCompletedInstants().findInstantsInRange("04", "11")
+            .getInstants().map(HoodieInstant::getTimestamp));
+    HoodieTestUtils.assertStreamEquals("findInstantsAfter 07 should return 2 instants", Stream.of("09", "11"),
+        timeline.getCommitTimeline().filterCompletedInstants().findInstantsAfter("07", 2)
+            .getInstants().map(HoodieInstant::getTimestamp));
+    HoodieTestUtils.assertStreamEquals("findInstantsBefore 07 should return 3 instants", Stream.of("01", "03", "05"),
+        timeline.getCommitTimeline().filterCompletedInstants().findInstantsBefore("07")
+            .getInstants().map(HoodieInstant::getTimestamp));
     assertFalse(timeline.empty());
     assertFalse(timeline.getCommitTimeline().filterPendingExcludingCompaction().empty());
     assertEquals("", 12, timeline.countInstants());

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieHiveUtil.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieHiveUtil.java
@@ -38,6 +38,23 @@ public class HoodieHiveUtil {
   public static final String HOODIE_CONSUME_MODE_PATTERN = "hoodie.%s.consume.mode";
   public static final String HOODIE_START_COMMIT_PATTERN = "hoodie.%s.consume.start.timestamp";
   public static final String HOODIE_MAX_COMMIT_PATTERN = "hoodie.%s.consume.max.commits";
+  /*
+   * Boolean property to stop incremental reader when there is a pending compaction.
+   * This is needed to prevent certain race conditions with RO views of MOR tables. only applicable for RO views.
+   *
+   * example timeline:
+   *
+   * t0 -> create bucket1.parquet
+   * t1 -> create and append updates bucket1.log
+   * t2 -> request compaction
+   * t3 -> create bucket2.parquet
+   *
+   * if compaction at t2 takes a long time, incremental readers on RO tables can move to t3 and would skip updates in t1
+   *
+   * To workaround this problem, we want to stop returning data belonging to commits > t2.
+   * After compaction is complete, incremental reader would see updates in t2, t3, so on.
+   */
+  public static final String HOODIE_STOP_AT_COMPACTION_PATTERN = "hoodie.%s.ro.stop.at.compaction";
   public static final String INCREMENTAL_SCAN_MODE = "INCREMENTAL";
   public static final String SNAPSHOT_SCAN_MODE = "SNAPSHOT";
   public static final String DEFAULT_SCAN_MODE = SNAPSHOT_SCAN_MODE;
@@ -45,6 +62,13 @@ public class HoodieHiveUtil {
   public static final int MAX_COMMIT_ALL = -1;
   public static final int DEFAULT_LEVELS_TO_BASEPATH = 3;
   public static final Pattern HOODIE_CONSUME_MODE_PATTERN_STRING = Pattern.compile("hoodie\\.(.*)\\.consume\\.mode");
+
+  public static boolean stopAtCompaction(JobContext job, String tableName) {
+    String compactionPropName = String.format(HOODIE_STOP_AT_COMPACTION_PATTERN, tableName);
+    boolean stopAtCompaction = job.getConfiguration().getBoolean(compactionPropName, true);
+    LOG.info("Read stop at compaction - " + stopAtCompaction);
+    return stopAtCompaction;
+  }
 
   public static Integer readMaxCommits(JobContext job, String tableName) {
     String maxCommitName = String.format(HOODIE_MAX_COMMIT_PATTERN, tableName);

--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/HoodieParquetRealtimeInputFormat.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/realtime/HoodieParquetRealtimeInputFormat.java
@@ -23,6 +23,7 @@ import org.apache.hudi.common.model.FileSlice;
 import org.apache.hudi.common.model.HoodieLogFile;
 import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieDefaultTimeline;
 import org.apache.hudi.common.table.timeline.HoodieInstant;
 import org.apache.hudi.common.table.timeline.HoodieTimeline;
 import org.apache.hudi.common.table.view.HoodieTableFileSystemView;
@@ -157,6 +158,12 @@ public class HoodieParquetRealtimeInputFormat extends HoodieParquetInputFormat i
     // Call the HoodieInputFormat::listStatus to obtain all latest parquet files, based on commit
     // timeline.
     return super.listStatus(job);
+  }
+
+  @Override
+  protected HoodieDefaultTimeline filterInstantsTimeline(HoodieDefaultTimeline timeline) {
+    // no specific filtering for Realtime format
+    return timeline;
   }
 
   /**

--- a/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/InputFormatTestUtil.java
+++ b/hudi-hadoop-mr/src/test/java/org/apache/hudi/hadoop/InputFormatTestUtil.java
@@ -50,8 +50,13 @@ public class InputFormatTestUtil {
     basePath.create();
     HoodieTestUtils.init(HoodieTestUtils.getDefaultHadoopConf(), basePath.getRoot().toString());
     File partitionPath = basePath.newFolder("2016", "05", "01");
+    return simulateInserts(partitionPath, "fileId1", numberOfFiles, commitNumber);
+  }
+
+  public static File simulateInserts(File partitionPath, String fileId, int numberOfFiles, String commitNumber)
+          throws IOException {
     for (int i = 0; i < numberOfFiles; i++) {
-      File dataFile = new File(partitionPath, FSUtils.makeDataFileName(commitNumber, TEST_WRITE_TOKEN, "fileid" + i));
+      File dataFile = new File(partitionPath, FSUtils.makeDataFileName(commitNumber, TEST_WRITE_TOKEN, fileId + i));
       dataFile.createNewFile();
     }
     return partitionPath;


### PR DESCRIPTION
## What is the purpose of the pull request
example timeline:

t0 -> create bucket1.parquet
t1 -> create and append updates bucket1.log
t2 -> request compaction
t3 -> create bucket2.parquet

if compaction at t2 takes a long time, incremental reads using HoodieParquetInputFormat may make progress to read commits at t3 and skip data ingested at t1 leading to 'data loss' .(Data will still be on disk, but incremental readers wont see it because its in log file and readers move to t3)

To workaround this problem, we want to stop returning data belonging to commits > compaction_requested/inprogress_instant. After compaction is complete, incremental reader would see updates in t2, t3, so on. Disadvantage is that long running compactions can make it look like reader is 'stuck'. But that is better than skipping updates.

## Brief change log

- Change HoodieParquetInputFormat to read commits prior to compaction instant
- Added unit tests to validate behavior
- Fix broken test utils for reading records

## Verify this pull request
This change added tests and can be verified as follows:
mvn test (TestMergeOnReadTable and TestHoodieActiveTimeline)

Some discussion is on https://github.com/apache/incubator-hudi/pull/1389, sorry I messed up rebase, so resending as a new PR to avoid confusion

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.