### PR TITLE
[HUDI-710] Fixing failure in Staging Validation Script

### DIFF
--- a/scripts/release/validate_staged_release.sh
+++ b/scripts/release/validate_staged_release.sh
@@ -97,7 +97,7 @@ cd hudi-${RELEASE_VERSION}-incubating-rc${RC_NUM}
 
 ### BEGIN: Binary Files Check
 echo "Checking for binary files in source release"
-numBinaryFiles=`find . -iname '*' | xargs -I {} file -I {} | grep -va directory | grep -va 'text/' | grep -va 'application/xml' | wc -l | sed -e s'/ //g'`
+numBinaryFiles=`find . -iname '*' | xargs -I {} file -I {} | grep -va directory | grep -va 'text/' | grep -va 'application/xml' | grep -va 'application/json' | wc -l | sed -e s'/ //g'`
 
 if [ "$numBinaryFiles" -gt "0" ]; then
   echo -e "There were non-text files in source release. Please check below\n"


### PR DESCRIPTION
Works after fixing the issue. 

 ./release/validate_staged_release.sh --release=0.5.2 --rc_num=1
/tmp/validation_scratch_dir_001 ~/projects/new_ws/hudi/scripts
Checking Checksum of Source Release
		Checksum Check of Source Release - [OK]

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 21027  100 21027    0     0  52567      0 --:--:-- --:--:-- --:--:-- 52567
Checking Signature
		Signature Check - [OK]

Checking for binary files in source release
		No Binary Files in Source Release? - [OK]

Checking for DISCLAIMER
		DISCLAIMER file exists ? [OK]

Checking for LICENSE and NOTICE
		License file exists ? [OK]
		Notice file exists ? [OK]

Performing custom Licensing Check 
		Licensing Check Passed [OK]

Running RAT Check
		RAT Check Passed [OK]
