### PR TITLE
[HUDI-504] Restructuring and auto-generation of docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+language: ruby
+rvm:
+  - 2.6.3
+
+env:
+  global:
+    - GIT_USER="CI BOT"
+    - GIT_EMAIL="cibot@hudi.apache.org"
+    - GIT_REPO="apache"
+    - GIT_PROJECT="incubator-hudi"
+    - GIT_BRANCH="asf-site"
+    - DOCS_ROOT="`pwd`/docs"
+
+before_install:
+  - if [ "$(git show -s --format=%ae)" = "${GIT_EMAIL}" ]; then echo "avoid recursion, ignore ..."; exit 0; fi
+  - git config --global user.name ${GIT_USER}
+  - git config --global user.email ${GIT_EMAIL}
+  - git remote add hudi https://${GIT_TOKEN}@github.com/${GIT_REPO}/${GIT_PROJECT}.git
+  - git checkout -b pr
+  - git pull --rebase hudi asf-site
+
+script:
+  - pushd ${DOCS_ROOT}
+  - gem install bundler:2.0.2
+  - bundle install
+  - bundle update --bundler
+  - bundle exec jekyll build _config.yml --source . --destination _site
+  - popd
+
+after_success:
+  - echo $TRAVIS_PULL_REQUEST
+  - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then echo "ignore push build result for per submit"; exit 0; fi'
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then echo "pushing build result ..."; fi'
+  - \cp -rf ${DOCS_ROOT}/_site/* test-content
+  - git add -A
+  - git commit -am "Travis CI build asf-site"
+  - git push hudi pr:asf-site
+
+branches:
+  only:
+    - asf-site

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ after_success:
   - echo $TRAVIS_PULL_REQUEST
   - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then echo "ignore push build result for per submit"; exit 0; fi'
   - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then echo "pushing build result ..."; fi'
-  - \cp -rf ${DOCS_ROOT}/_site/* test-content
+  - mkdir test-content && \cp -rf ${DOCS_ROOT}/_site/* test-content
   - git add -A
   - git commit -am "Travis CI build asf-site"
   - git push hudi pr:asf-site

--- a/docs/_includes/nav_list
+++ b/docs/_includes/nav_list
@@ -18,20 +18,19 @@
             {% assign menu_label = "文档菜单" %}
         {% endif %}
     {% elsif page.version == "0.5.1" %}
-            {% assign navigation = site.data.navigation["0.5.1_docs"] %}
+        {% assign navigation = site.data.navigation["0.5.1_docs"] %}
 
-            {% if page.language == "cn" %}
-                {% assign navigation = site.data.navigation["0.5.1_cn_docs"] %}
-                {% assign menu_label = "文档菜单" %}
-            {% endif %}
-    {% endif %}
+        {% if page.language == "cn" %}
+            {% assign navigation = site.data.navigation["0.5.1_cn_docs"] %}
+            {% assign menu_label = "文档菜单" %}
+        {% endif %}
     {% elsif page.version == "0.5.2" %}
-            {% assign navigation = site.data.navigation["0.5.2_docs"] %}
+        {% assign navigation = site.data.navigation["0.5.2_docs"] %}
 
-            {% if page.language == "cn" %}
-                {% assign navigation = site.data.navigation["0.5.2_cn_docs"] %}
-                {% assign menu_label = "文档菜单" %}
-            {% endif %}
+        {% if page.language == "cn" %}
+            {% assign navigation = site.data.navigation["0.5.2_cn_docs"] %}
+            {% assign menu_label = "文档菜单" %}
+        {% endif %}
     {% endif %}
 {% endif %}
 


### PR DESCRIPTION
## What is the purpose of the pull request

Go ahead with RFC-10: [RFC-10](https://cwiki.apache.org/confluence/display/HUDI/RFC+-+10+%3A+Restructuring+and+auto-generation+of+docs)

Generate docs by using travis and push the builded result to asf-site branch.

## Brief change log

  - Add .travis.yml file

## Verify this pull request

**Main repo**
https://github.com/lamber-ken/hdocs/tree/asf-site

**Forked repo**
https://github.com/BigDataArtisans/hdocs/tree/asf-site

**Each submit PR** (will ignore push build result)
https://travis-ci.com/github/lamber-ken/hdocs/builds/153544519

**After merged PR**
https://www.travis-ci.org/github/lamber-ken/hdocs/builds/663174567

## Committer checklist

 - [X] Has a corresponding JIRA in PR title & commit
 
 - [X] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.