### PR TITLE
[HUDI-539] Add "Config" constructor to HoodieROTablePathFilter

### DIFF
--- a/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieROTablePathFilter.java
+++ b/hudi-hadoop-mr/src/main/java/org/apache/hudi/hadoop/HoodieROTablePathFilter.java
@@ -63,12 +63,21 @@ public class HoodieROTablePathFilter implements PathFilter, Serializable {
    */
   private HashSet<String> nonHoodiePathCache;
 
+  /**
+   * Hadoop configurations for the FileSystem.
+   */
+  private Configuration conf;
 
   private transient FileSystem fs;
 
   public HoodieROTablePathFilter() {
-    hoodiePathCache = new HashMap<>();
-    nonHoodiePathCache = new HashSet<>();
+    this(new Configuration());
+  }
+
+  public HoodieROTablePathFilter(Configuration conf) {
+    this.hoodiePathCache = new HashMap<>();
+    this.nonHoodiePathCache = new HashSet<>();
+    this.conf = conf;
   }
 
   /**
@@ -93,7 +102,7 @@ public class HoodieROTablePathFilter implements PathFilter, Serializable {
     Path folder = null;
     try {
       if (fs == null) {
-        fs = path.getFileSystem(new Configuration());
+        fs = path.getFileSystem(conf);
       }
 
       // Assumes path is a file


### PR DESCRIPTION
Allows HoodieROTablePathFilter to accept a configuration for
initializing the filesystem. This fixes a bug with Presto's use of this
pathfilter. (when combined with the corresponding presto patch)

## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

*(For example: This pull request adds quick-start document.)*

## Brief change log

*(for example:)*
  - *Modify AnnotationLocation checkstyle rule in checkstyle.xml*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

*(or)*

This pull request is already covered by existing tests, such as *(please describe tests)*.

(or)

This change added tests and can be verified as follows:

*(example:)*

  - *Added integration tests for end-to-end.*
  - *Added HoodieClientWriteTest to verify the change.*
  - *Manually verified the change by running a job locally.*

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.