### PR TITLE
[HUDI-716] Exception: Not an Avro data file when running HoodieCleanClient.runClean

### DIFF
--- a/hudi-cli/src/main/java/org/apache/hudi/cli/commands/RepairsCommand.java
+++ b/hudi-cli/src/main/java/org/apache/hudi/cli/commands/RepairsCommand.java
@@ -26,8 +26,11 @@ import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.model.HoodiePartitionMetadata;
 import org.apache.hudi.common.table.HoodieTableConfig;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.table.timeline.HoodieActiveTimeline;
+import org.apache.hudi.common.util.CleanerUtils;
 
 import org.apache.hadoop.fs.Path;
+import org.apache.log4j.Logger;
 import org.apache.spark.launcher.SparkLauncher;
 import org.springframework.shell.core.CommandMarker;
 import org.springframework.shell.core.annotation.CliCommand;
@@ -50,6 +53,8 @@ import static org.apache.hudi.common.table.HoodieTableMetaClient.METAFOLDER_NAME
  */
 @Component
 public class RepairsCommand implements CommandMarker {
+
+  private static final Logger LOG = Logger.getLogger(RepairsCommand.class);
 
   @CliCommand(value = "repair deduplicate",
       help = "De-duplicate a partition path contains duplicates & produce repaired files to replace with")
@@ -136,5 +141,21 @@ public class RepairsCommand implements CommandMarker {
       rows[ind++] = row;
     }
     return HoodiePrintHelper.print(new String[] {"Property", "Old Value", "New Value"}, rows);
+  }
+
+  @CliCommand(value = "repair corrupted clean files", help = "repair corrupted clean files")
+  public void removeCorruptedPendingCleanAction() {
+
+    HoodieTableMetaClient client = HoodieCLI.getTableMetaClient();
+    HoodieActiveTimeline activeTimeline = HoodieCLI.getTableMetaClient().getActiveTimeline();
+
+    activeTimeline.filterInflightsAndRequested().getInstants().forEach(instant -> {
+      try {
+        CleanerUtils.getCleanerPlan(client, instant);
+      } catch (IOException e) {
+        LOG.warn("try to remove corrupted instant file: " + instant);
+        FSUtils.deleteInstantFile(client.getFs(), client.getMetaPath(), instant);
+      }
+    });
   }
 }

--- a/hudi-client/src/main/java/org/apache/hudi/client/HoodieCleanClient.java
+++ b/hudi-client/src/main/java/org/apache/hudi/client/HoodieCleanClient.java
@@ -85,7 +85,11 @@ public class HoodieCleanClient<T extends HoodieRecordPayload> extends AbstractHo
     // If there are inflight(failed) or previously requested clean operation, first perform them
     table.getCleanTimeline().filterInflightsAndRequested().getInstants().forEach(hoodieInstant -> {
       LOG.info("There were previously unfinished cleaner operations. Finishing Instant=" + hoodieInstant);
-      runClean(table, hoodieInstant);
+      try {
+        runClean(table, hoodieInstant);
+      } catch (Exception e) {
+        LOG.warn("Failed to perform previous clean operation, instant: " + hoodieInstant, e);
+      }
     });
 
     Option<HoodieCleanerPlan> cleanerPlanOpt = scheduleClean(startCleanTime);

--- a/hudi-client/src/test/java/org/apache/hudi/table/TestCleaner.java
+++ b/hudi-client/src/test/java/org/apache/hudi/table/TestCleaner.java
@@ -985,6 +985,25 @@ public class TestCleaner extends TestHoodieClientBase {
   }
 
   /**
+   * Test clean previous corrupted cleanFiles.
+   */
+  @Test
+  public void testCleanPreviousCorruptedCleanFiles() {
+    HoodieWriteConfig config =
+        HoodieWriteConfig.newBuilder()
+            .withPath(basePath).withAssumeDatePartitioning(true)
+            .withCompactionConfig(HoodieCompactionConfig.newBuilder()
+            .withCleanerPolicy(HoodieCleaningPolicy.KEEP_LATEST_FILE_VERSIONS).retainFileVersions(1).build())
+            .build();
+
+    HoodieTestUtils.createCorruptedPendingCleanFiles(metaClient, getNextInstant());
+    metaClient = HoodieTableMetaClient.reload(metaClient);
+
+    List<HoodieCleanStat> cleanStats = runCleaner(config);
+    assertEquals("Must not clean any files", 0, cleanStats.size());
+  }
+
+  /**
    * Common test method for validating pending compactions.
    *
    * @param config Hoodie Write Config

--- a/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/fs/FSUtils.java
@@ -487,6 +487,15 @@ public class FSUtils {
     });
   }
 
+  public static void deleteInstantFile(FileSystem fs, String metaPath, HoodieInstant instant) {
+    try {
+      LOG.warn("try to delete instant file: " + instant);
+      fs.delete(new Path(metaPath, instant.getFileName()), false);
+    } catch (IOException e) {
+      throw new HoodieIOException("Could not delete instant file" + instant.getFileName(), e);
+    }
+  }
+
   public static void deleteOlderRestoreMetaFiles(FileSystem fs, String metaPath, Stream<HoodieInstant> instants) {
     // TODO - this should be archived when archival is made general for all meta-data
     // skip MIN_ROLLBACK_TO_KEEP and delete rest


### PR DESCRIPTION
## What is the purpose of the pull request

More context, please go ahead with https://issues.apache.org/jira/browse/HUDI-716

Fix `Not an avro data file ...`
```
org.apache.spark.deploy.SparkSubmit$.main(SparkSubmit.scala:929) at org.apache.spark.deploy.SparkSubmit.main(SparkSubmit.scala)
Caused by: java.io.IOException: Not an Avro data file 
  at org.apache.avro.file.DataFileReader.openReader(DataFileReader.java:50) 
  at org.apache.hudi.common.util.AvroUtils.deserializeAvroMetadata(AvroUtils.java:147) 
  at org.apache.hudi.common.util.CleanerUtils.getCleanerPlan(CleanerUtils.java:87) 
  at org.apache.hudi.client.HoodieCleanClient.runClean(HoodieCleanClient.java:141) ... 24 more
```

With 0.5.1 onwards, hudi would first scan all files and store the plan (atomically) in .clean.requested and .clean.inflight before triggering the actual clean. If there are any intermittent failures, subsequent clean would read the cleaner plan again and retry.

![image](https://user-images.githubusercontent.com/20113411/77221539-6eaee700-6b85-11ea-825d-6e9fe3d78cc4.png)

![image](https://user-images.githubusercontent.com/20113411/77221347-00b5f000-6b84-11ea-9e60-1aeee946bc90.png)

## Verify this pull request

This pull request is a trivial rework without any test coverage.

## Committer checklist

 - [X] Has a corresponding JIRA in PR title & commit
 
 - [X] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.