### PR TITLE
[HUDI-734] Fix error: cannot create directory ‘test-content’: File exists

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ after_success:
   - echo $TRAVIS_PULL_REQUEST
   - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then echo "ignore push build result for per submit"; exit 0; fi'
   - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then echo "pushing build result ..."; fi'
-  - mkdir test-content && \cp -rf ${DOCS_ROOT}/_site/* test-content
+  - mkdir -p test-content && \cp -rf ${DOCS_ROOT}/_site/* test-content
   - git add -A
   - git commit -am "Travis CI build asf-site"
   - git push hudi pr:asf-site


### PR DESCRIPTION
## What is the purpose of the pull request

The `mkdir: cannot create directory ‘test-content’: File exists` error affacts `\cp -rf ...` command.

https://travis-ci.org/github/apache/incubator-hudi/builds/666647086

![image](https://user-images.githubusercontent.com/20113411/77509920-9e712e00-6ea8-11ea-93e7-d98ad374e015.png)

## Brief change log

 - Add `-p` option

## Verify this pull request

This pull request is a trivial rework without any test coverage.

## Committer checklist

 - [X] Has a corresponding JIRA in PR title & commit
 
 - [X] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.