### PR TITLE
[HUDI-743]: Remove FileIOUtils.close()

### DIFF
--- a/hudi-client/src/main/java/org/apache/hudi/metrics/Metrics.java
+++ b/hudi-client/src/main/java/org/apache/hudi/metrics/Metrics.java
@@ -18,7 +18,6 @@
 
 package org.apache.hudi.metrics;
 
-import org.apache.hudi.common.util.FileIOUtils;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieException;
 
@@ -53,7 +52,7 @@ public class Metrics {
     Runtime.getRuntime().addShutdownHook(new Thread(() -> {
       try {
         reporter.report();
-        FileIOUtils.close(reporter.getReporter(), true);
+        getReporter().close();
       } catch (Exception e) {
         e.printStackTrace();
       }

--- a/hudi-common/src/main/java/org/apache/hudi/common/util/FileIOUtils.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/util/FileIOUtils.java
@@ -18,10 +18,7 @@
 
 package org.apache.hudi.common.util;
 
-import javax.annotation.Nullable;
-
 import java.io.ByteArrayOutputStream;
-import java.io.Closeable;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -93,27 +90,5 @@ public class FileIOUtils {
     out.println(str);
     out.flush();
     out.close();
-  }
-
-  /**
-   * Closes a {@link Closeable}, with control over whether an {@code IOException} may be thrown.
-   * @param closeable the {@code Closeable} object to be closed, or null,
-   *      in which case this method does nothing.
-   * @param swallowIOException if true, don't propagate IO exceptions thrown by the {@code close} methods.
-   *
-   * @throws IOException if {@code swallowIOException} is false and {@code close} throws an {@code IOException}.
-   */
-  public static void close(@Nullable Closeable closeable, boolean swallowIOException)
-      throws IOException {
-    if (closeable == null) {
-      return;
-    }
-    try {
-      closeable.close();
-    } catch (IOException e) {
-      if (!swallowIOException) {
-        throw e;
-      }
-    }
   }
 }


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

Remove FileIOUtils.close() method - not needed anymore

## Brief change log

Removed FileIOUtils.close() method - not needed anymore

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.

## Committer checklist

 - [X] Has a corresponding JIRA in PR title & commit
 
 - [X] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.