### PR TITLE
[WIP][HUDI-752]Make CompactionAdminClient spark-free

### DIFF
--- a/hudi-client/src/main/java/org/apache/hudi/client/utils/SparkEngineUtils.java
+++ b/hudi-client/src/main/java/org/apache/hudi/client/utils/SparkEngineUtils.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hudi.client.utils;
+
+import org.apache.spark.SparkContext;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.api.java.function.FlatMapFunction;
+import org.apache.spark.api.java.function.Function;
+
+import java.util.List;
+
+/**
+ * Util class for spark Engine.
+ */
+public class SparkEngineUtils {
+  private static JavaSparkContext jsc;
+
+  public static void setJsc(JavaSparkContext javaSparkContext) {
+    jsc = javaSparkContext;
+  }
+
+  /**
+   * Get the only SparkContext from JVM.
+   */
+  public static JavaSparkContext getJsc() {
+    if (jsc == null) {
+      jsc = new JavaSparkContext(SparkContext.getOrCreate());
+    }
+    return jsc;
+  }
+
+  /**
+   * Parallelize map function.
+   */
+  public static <T, R> List<R> parallelizeMap(List<T> list, int num, Function<T, R> f) {
+    return jsc.parallelize(list, num).map(f).collect();
+  }
+
+  /**
+   * Parallelize flat map function.
+   */
+  public static <T, R> List<R> parallelizeFlatMap(List<T> list, int num, FlatMapFunction<T, R> f) {
+    return jsc.parallelize(list, num).flatMap(f).collect();
+  }
+}

--- a/hudi-client/src/main/java/org/apache/hudi/client/utils/SparkEngineUtils.java
+++ b/hudi-client/src/main/java/org/apache/hudi/client/utils/SparkEngineUtils.java
@@ -26,7 +26,7 @@ import org.apache.spark.api.java.function.Function;
 import java.util.List;
 
 /**
- * Util class for spark Engine.
+ * Util class for Spark Engine.
  */
 public class SparkEngineUtils {
   private static JavaSparkContext jsc;

--- a/hudi-client/src/main/java/org/apache/hudi/client/utils/SparkEngineUtils.java
+++ b/hudi-client/src/main/java/org/apache/hudi/client/utils/SparkEngineUtils.java
@@ -26,7 +26,7 @@ import org.apache.spark.api.java.function.Function;
 import java.util.List;
 
 /**
- * Util class for Spark Engine.
+ * Util class for Spark engine.
  */
 public class SparkEngineUtils {
   private static JavaSparkContext jsc;

--- a/hudi-client/src/test/java/org/apache/hudi/client/TestCompactionAdminClient.java
+++ b/hudi-client/src/test/java/org/apache/hudi/client/TestCompactionAdminClient.java
@@ -65,7 +65,7 @@ public class TestCompactionAdminClient extends TestHoodieClientBase {
     initPath();
     initSparkContexts();
     metaClient = HoodieTestUtils.init(HoodieTestUtils.getDefaultHadoopConf(), basePath, MERGE_ON_READ);
-    client = new CompactionAdminClient(jsc, basePath);
+    client = new CompactionAdminClient(basePath);
   }
 
   @After

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieCompactionAdminTool.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HoodieCompactionAdminTool.java
@@ -60,7 +60,7 @@ public class HoodieCompactionAdminTool {
    */
   public void run(JavaSparkContext jsc) throws Exception {
     HoodieTableMetaClient metaClient = new HoodieTableMetaClient(jsc.hadoopConfiguration(), cfg.basePath);
-    try (CompactionAdminClient admin = new CompactionAdminClient(jsc, cfg.basePath)) {
+    try (CompactionAdminClient admin = new CompactionAdminClient(cfg.basePath)) {
       final FileSystem fs = FSUtils.getFs(cfg.basePath, jsc.hadoopConfiguration());
       if (cfg.outputPath != null && fs.exists(new Path(cfg.outputPath))) {
         throw new IllegalStateException("Output File Path already exists");


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

* There can only one `SparkContext` in  JVM. So, we can store it in a `Factory `class, then we can get it everywhere. After that, we make many class spark-free*

## Brief change log

*(for example:)*
  - *Make CompactionAdminClient spark-free*

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.