### PR TITLE
[MINOR] remove Hive dependency from delta streamer

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/deltastreamer/DeltaSync.java
@@ -130,7 +130,7 @@ public class DeltaSync implements Serializable {
   /**
    * Hive Config.
    */
-  private transient HiveConf hiveConf;
+  private transient Configuration hiveConf;
 
   /**
    * Bag of properties with source, hoodie client, key generator etc.
@@ -153,7 +153,7 @@ public class DeltaSync implements Serializable {
   private transient HoodieWriteClient writeClient;
 
   public DeltaSync(HoodieDeltaStreamer.Config cfg, SparkSession sparkSession, SchemaProvider schemaProvider,
-                   TypedProperties props, JavaSparkContext jssc, FileSystem fs, HiveConf hiveConf,
+                   TypedProperties props, JavaSparkContext jssc, FileSystem fs, Configuration hiveConf,
                    Function<HoodieWriteClient, Boolean> onInitializingHoodieWriteClient) throws IOException {
 
     this.cfg = cfg;
@@ -454,8 +454,7 @@ public class DeltaSync implements Serializable {
       HiveSyncConfig hiveSyncConfig = DataSourceUtils.buildHiveSyncConfig(props, cfg.targetBasePath);
       LOG.info("Syncing target hoodie table with hive table(" + hiveSyncConfig.tableName + "). Hive metastore URL :"
           + hiveSyncConfig.jdbcUrl + ", basePath :" + cfg.targetBasePath);
-
-      new HiveSyncTool(hiveSyncConfig, hiveConf, fs).syncHoodieTable();
+      new HiveSyncTool(hiveSyncConfig, new HiveConf(hiveConf, HiveConf.class), fs).syncHoodieTable();
     }
   }
 


### PR DESCRIPTION
## What is the purpose of the pull request

This change will remove Hive dependency from the delta streamer if the user don't trigger the hive sync.

## Brief change log

  - Change the configuration type in DeltaStreamer and DeltaSync.

## Verify this pull request

This pull request is already covered by existing tests, such as `testBulkInsertsAndUpsertsWithSQLBasedTransformerFor2StepPipeline` in
`TestHoodieDeltaStreamer`

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.