### PR TITLE
[HUDI-789]Adjust logic of upsert in HDFSParquetImporter

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/HDFSParquetImporter.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/HDFSParquetImporter.java
@@ -100,6 +100,10 @@ public class HDFSParquetImporter implements Serializable {
 
   }
 
+  private boolean isUpsert() {
+    return "upsert".equals(cfg.command.toLowerCase());
+  }
+
   public int dataImport(JavaSparkContext jsc, int retry) {
     this.fs = FSUtils.getFs(cfg.targetPath, jsc.hadoopConfiguration());
     this.props = cfg.propsFilePath == null ? UtilHelpers.buildProperties(cfg.configs)
@@ -108,7 +112,7 @@ public class HDFSParquetImporter implements Serializable {
     int ret = -1;
     try {
       // Verify that targetPath is not present.
-      if (fs.exists(new Path(cfg.targetPath))) {
+      if (fs.exists(new Path(cfg.targetPath)) && !isUpsert()) {
         throw new HoodieIOException(String.format("Make sure %s is not present.", cfg.targetPath));
       }
       do {
@@ -122,19 +126,21 @@ public class HDFSParquetImporter implements Serializable {
 
   protected int dataImport(JavaSparkContext jsc) throws IOException {
     try {
-      if (fs.exists(new Path(cfg.targetPath))) {
+      if (fs.exists(new Path(cfg.targetPath)) && !isUpsert()) {
         // cleanup target directory.
         fs.delete(new Path(cfg.targetPath), true);
       }
 
+      if (!fs.exists(new Path(cfg.targetPath))) {
+        // Initialize target hoodie table.
+        Properties properties = new Properties();
+        properties.put(HoodieTableConfig.HOODIE_TABLE_NAME_PROP_NAME, cfg.tableName);
+        properties.put(HoodieTableConfig.HOODIE_TABLE_TYPE_PROP_NAME, cfg.tableType);
+        HoodieTableMetaClient.initTableAndGetMetaClient(jsc.hadoopConfiguration(), cfg.targetPath, properties);
+      }
+
       // Get schema.
       String schemaStr = UtilHelpers.parseSchema(fs, cfg.schemaFile);
-
-      // Initialize target hoodie table.
-      Properties properties = new Properties();
-      properties.put(HoodieTableConfig.HOODIE_TABLE_NAME_PROP_NAME, cfg.tableName);
-      properties.put(HoodieTableConfig.HOODIE_TABLE_TYPE_PROP_NAME, cfg.tableType);
-      HoodieTableMetaClient.initTableAndGetMetaClient(jsc.hadoopConfiguration(), cfg.targetPath, properties);
 
       HoodieWriteClient client =
           UtilHelpers.createHoodieClient(jsc, cfg.targetPath, schemaStr, cfg.parallelism, Option.empty(), props);

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHDFSParquetImporter.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHDFSParquetImporter.java
@@ -97,7 +97,7 @@ public class TestHDFSParquetImporter implements Serializable {
   public void init() throws IOException, ParseException {
     basePath = (new Path(dfsBasePath, Thread.currentThread().getStackTrace()[1].getMethodName())).toString();
 
-    // Hoodie root folder
+    // Hoodie root folder.
     hoodieFolder = new Path(basePath, "testTarget");
 
     // Create generic records.

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHDFSParquetImporter.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHDFSParquetImporter.java
@@ -248,7 +248,7 @@ public class TestHDFSParquetImporter implements Serializable {
               row.getDouble(5), row.getDouble(6), row.getDouble(7)))
           .collect(Collectors.toList());
 
-      // get expected result
+      // get expected result.
       List<HoodieTripModel> expected = expectData.stream().map(g ->
           new HoodieTripModel(Double.parseDouble(g.get("timestamp").toString()),
               g.get("_row_key").toString(),

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHDFSParquetImporter.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHDFSParquetImporter.java
@@ -18,7 +18,6 @@
 
 package org.apache.hudi.utilities;
 
-import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.hudi.client.HoodieReadClient;
 import org.apache.hudi.client.HoodieWriteClient;
 import org.apache.hudi.common.HoodieClientTestUtils;
@@ -423,16 +422,28 @@ public class TestHDFSParquetImporter implements Serializable {
 
     @Override
     public int hashCode() {
-      HashCodeBuilder builder = new HashCodeBuilder();
-      builder.append(timestamp);
-      builder.append(rowKey);
-      builder.append(rider);
-      builder.append(driver);
-      builder.append(beginLat);
-      builder.append(beginLon);
-      builder.append(endLat);
-      builder.append(endLon);
-      return builder.toHashCode();
+      int iConstant = 37;
+      int iTotal = 17;
+      iTotal = appendHash(iTotal, iConstant, Double.doubleToLongBits(timestamp));
+      iTotal = appendHash(iTotal, iConstant, rowKey);
+      iTotal = appendHash(iTotal, iConstant, rider);
+      iTotal = appendHash(iTotal, iConstant, driver);
+      iTotal = appendHash(iTotal, iConstant, Double.doubleToLongBits(beginLat));
+      iTotal = appendHash(iTotal, iConstant, Double.doubleToLongBits(beginLon));
+      iTotal = appendHash(iTotal, iConstant, Double.doubleToLongBits(endLat));
+      iTotal = appendHash(iTotal, iConstant, Double.doubleToLongBits(endLon));
+      return iTotal;
+    }
+
+    // Generate hashcode, refer to org.apache.commons.lang.builder.HashCodeBuilder.
+    // It is forbidden to import class HashCodeBuilder， because of checkstyle.
+    //
+    private int appendHash(int total, int constant, long value) {
+      return total * constant + ((int) (value ^ (value >> 32)));
+    }
+
+    private int appendHash(int total, int constant, String value) {
+      return total * constant + value.hashCode();
     }
   }
 }


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

*In `HDFSParquetImporter`, `upsert` is equivalent to `insert` (remove old metadata, then create and insert data). But `upsert` means update and insert on old data. *

## Brief change log

*(for example:)*
  - *Adjust logic of upsert in HDFSParquetImporter*

## Verify this pull request

This pull request is a trivial rework / code cleanup without any test coverage.

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.