### PR TITLE
[HUDI-795] Ignoring missing aux folder

### DIFF
--- a/hudi-client/src/main/java/org/apache/hudi/table/HoodieCommitArchiveLog.java
+++ b/hudi-client/src/main/java/org/apache/hudi/table/HoodieCommitArchiveLog.java
@@ -18,7 +18,6 @@
 
 package org.apache.hudi.table;
 
-import java.io.FileNotFoundException;
 import org.apache.hudi.avro.model.HoodieArchivedMetaEntry;
 import org.apache.hudi.avro.model.HoodieCompactionPlan;
 import org.apache.hudi.avro.model.HoodieRollbackMetadata;
@@ -56,6 +55,7 @@ import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.apache.spark.api.java.JavaSparkContext;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -229,12 +229,14 @@ public class HoodieCommitArchiveLog {
               HoodieActiveTimeline.VALID_EXTENSIONS_IN_ACTIVE_TIMELINE,
               false);
     } catch (FileNotFoundException e) {
-      // On some FSs deletion of all files in the directory can auto remove the directory itself.
-      // GCS is one example, as it doesn't have real directories and subdirectories. When client
-      // removes all the files from a "folder" on GCS is has to create a special "/" to keep the folder
-      // around. If this doesn't happen (timeout, misconfigured client, ...) folder will be deleted and
-      // in this case we should not break when aux folder is not found.
-      // GCS information: (https://cloud.google.com/storage/docs/gsutil/addlhelp/HowSubdirectoriesWork)
+      /*
+       * On some FSs deletion of all files in the directory can auto remove the directory itself.
+       * GCS is one example, as it doesn't have real directories and subdirectories. When client
+       * removes all the files from a "folder" on GCS is has to create a special "/" to keep the folder
+       * around. If this doesn't happen (timeout, misconfigured client, ...) folder will be deleted and
+       * in this case we should not break when aux folder is not found.
+       * GCS information: (https://cloud.google.com/storage/docs/gsutil/addlhelp/HowSubdirectoriesWork)
+       */
       LOG.warn("Aux path not found. Skipping: " + metaClient.getMetaAuxiliaryPath());
       return success;
     }

--- a/hudi-client/src/main/java/org/apache/hudi/table/HoodieCommitArchiveLog.java
+++ b/hudi-client/src/main/java/org/apache/hudi/table/HoodieCommitArchiveLog.java
@@ -229,6 +229,12 @@ public class HoodieCommitArchiveLog {
               HoodieActiveTimeline.VALID_EXTENSIONS_IN_ACTIVE_TIMELINE,
               false);
     } catch (FileNotFoundException e) {
+      // On some FSs deletion of all files in the directory can auto remove the directory itself.
+      // GCS is one example, as it doesn't have real directories and subdirectories. When client
+      // removes all the files from a "folder" on GCS is has to create a special "/" to keep the folder
+      // around. If this doesn't happen (timeout, misconfigured client, ...) folder will be deleted and
+      // in this case we should not break when aux folder is not found.
+      // GCS information: (https://cloud.google.com/storage/docs/gsutil/addlhelp/HowSubdirectoriesWork)
       LOG.warn("Aux path not found. Skipping: " + metaClient.getMetaAuxiliaryPath());
       return success;
     }


### PR DESCRIPTION
## What is the purpose of the pull request

Seeing breakages on GCS. When something removes the folder deleteAllInstantsOlderorEqualsInAuxMetaFolder breaks.

## Brief change log

  - Modifed HoodieCommitArchiveLog.deleteAllInstantsOlderorEqualsInAuxMetaFolder to ignore missing folder

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.