### PR TITLE
[MINOR] Fix broken README link

### DIFF
--- a/docs/_pages/contributing.cn.md
+++ b/docs/_pages/contributing.cn.md
@@ -108,7 +108,7 @@ and more importantly also try to improve the process along the way as well.
    - For involved changes, it's best to also run the entire integration test suite using `mvn clean install`
    - For website changes, please build the site locally & test navigation, formatting & links thoroughly
    - If your code change changes some aspect of documentation (e.g new config, default value change), 
-     please ensure there is another PR to [update the docs](https://github.com/apache/incubator-hudi/blob/asf-site/docs/README.md) as well.
+     please ensure there is another PR to [update the docs](https://github.com/apache/incubator-hudi/tree/asf-site/README.md) as well.
  - Sending a Pull Request
    - Format commit and the pull request title like `[HUDI-XXX] Fixes bug in Spark Datasource`, 
      where you replace `HUDI-XXX` with the appropriate JIRA issue. 

--- a/docs/_pages/contributing.md
+++ b/docs/_pages/contributing.md
@@ -107,7 +107,7 @@ and more importantly also try to improve the process along the way as well.
    - For involved changes, it's best to also run the entire integration test suite using `mvn clean install`
    - For website changes, please build the site locally & test navigation, formatting & links thoroughly
    - If your code change changes some aspect of documentation (e.g new config, default value change), 
-     please ensure there is another PR to [update the docs](https://github.com/apache/incubator-hudi/blob/asf-site/docs/README.md) as well.
+     please ensure there is another PR to [update the docs](https://github.com/apache/incubator-hudi/tree/asf-site/README.md) as well.
  - Sending a Pull Request
    - Format commit and the pull request title like `[HUDI-XXX] Fixes bug in Spark Datasource`, 
      where you replace `HUDI-XXX` with the appropriate JIRA issue. 


### PR DESCRIPTION
## What is the purpose of the pull request

Fix broken doc link.

Change
`https://github.com/apache/incubator-hudi/blob/asf-site`
to
`https://github.com/apache/incubator-hudi/tree/asf-site`

## Brief change log

  - Fix broken link

## Verify this pull request

This pull request is a trivial code cleanup without any test coverage.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.