### PR TITLE
[HUDI-800] fix Metrics getReporter().close() throws NPE when MetricsR…

### DIFF
--- a/hudi-client/src/main/java/org/apache/hudi/metrics/Metrics.java
+++ b/hudi-client/src/main/java/org/apache/hudi/metrics/Metrics.java
@@ -52,9 +52,11 @@ public class Metrics {
     Runtime.getRuntime().addShutdownHook(new Thread(() -> {
       try {
         reporter.report();
-        getReporter().close();
+        if (getReporter() != null) {
+          getReporter().close();
+        }
       } catch (Exception e) {
-        e.printStackTrace();
+        LOG.warn("Error while closing reporter", e);
       }
     }));
   }


### PR DESCRIPTION
…eporter is InMemoryMetricsReporter.

## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

*Fix HUDI-800 Metrics getReporter().close() throws NPE when MetricsReporter is InMemoryMetricsReporter*

## Brief change log

  - *Modify hudi-client/src/main/java/org/apache/hudi/metrics/Metrics.java when shutdown hook*

## Verify this pull request

*(Please pick either of the following options)*

This pull request is a trivial rework / code cleanup without any test coverage.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.