### PR TITLE
[HUDI-817] fixed building IndexFileFilter with a wrong condition in Hood…

### DIFF
--- a/hudi-client/src/main/java/org/apache/hudi/index/bloom/HoodieGlobalBloomIndex.java
+++ b/hudi-client/src/main/java/org/apache/hudi/index/bloom/HoodieGlobalBloomIndex.java
@@ -86,7 +86,7 @@ public class HoodieGlobalBloomIndex<T extends HoodieRecordPayload> extends Hoodi
       JavaPairRDD<String, String> partitionRecordKeyPairRDD) {
 
     IndexFileFilter indexFileFilter =
-        config.getBloomIndexPruneByRanges() ? new IntervalTreeBasedGlobalIndexFileFilter(partitionToFileIndexInfo)
+        config.useBloomIndexTreebasedFilter() ? new IntervalTreeBasedGlobalIndexFileFilter(partitionToFileIndexInfo)
             : new ListBasedGlobalIndexFileFilter(partitionToFileIndexInfo);
 
     return partitionRecordKeyPairRDD.map(partitionRecordKeyPair -> {


### PR DESCRIPTION
#672  What is the purpose of the pull request
fixed bug, when building IndexFileFilter with a wrong condition in HoodieGlobalBloomIndex class

## Brief change log
use a wrong config parameter in build IndexFileFilter in HoodieGlobalBloomIndex  class

## Verify this pull request
No validation required

## Committer checklist