### PR TITLE
[HUDI-843] Add ability to specify time unit for  TimestampBasedKeyGenerator

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/keygen/TimestampBasedKeyGenerator.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/keygen/TimestampBasedKeyGenerator.java
@@ -69,7 +69,7 @@ public class TimestampBasedKeyGenerator extends SimpleKeyGenerator {
     // One value from TimestampType above
     private static final String TIMESTAMP_TYPE_FIELD_PROP = "hoodie.deltastreamer.keygen.timebased.timestamp.type";
     private static final String INPUT_TIME_UNIT =
-        "hoodie.deltastreamer.keygen.timebased.timestamp.scalar.time_unit";
+        "hoodie.deltastreamer.keygen.timebased.timestamp.scalar.time.unit";
     private static final String TIMESTAMP_INPUT_DATE_FORMAT_PROP =
         "hoodie.deltastreamer.keygen.timebased.input.dateformat";
     private static final String TIMESTAMP_OUTPUT_DATE_FORMAT_PROP =
@@ -133,7 +133,6 @@ public class TimestampBasedKeyGenerator extends SimpleKeyGenerator {
           "Unexpected type for partition field: " + partitionVal.getClass().getName());
       }
       Date timestamp = new Date(timeMs);
-
       String recordKey = DataSourceUtils.getNestedFieldValAsString(record, recordKeyField, true);
       if (recordKey == null || recordKey.isEmpty()) {
         throw new HoodieKeyException("recordKey value: \"" + recordKey + "\" for field: \"" + recordKeyField + "\" cannot be null or empty.");

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/keygen/TimestampBasedKeyGenerator.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/keygen/TimestampBasedKeyGenerator.java
@@ -113,7 +113,7 @@ public class TimestampBasedKeyGenerator extends SimpleKeyGenerator {
       } else if (partitionVal instanceof Long) {
         timeMs = convertLongTimeToSeconds((Long) partitionVal);
       } else if (partitionVal instanceof CharSequence) {
-        timeMs = inputDateFormat.parse(partitionVal.toString()).getTime() / 1000;
+        timeMs = inputDateFormat.parse(partitionVal.toString()).getTime();
       } else {
         throw new HoodieNotSupportedException(
           "Unexpected type for partition field: " + partitionVal.getClass().getName());

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/keygen/TestTimestampBasedKeyGenerator.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/keygen/TestTimestampBasedKeyGenerator.java
@@ -47,10 +47,15 @@ public class TestTimestampBasedKeyGenerator {
     properties.setProperty(DataSourceWriteOptions.HIVE_STYLE_PARTITIONING_OPT_KEY(), "false");
   }
   
-  private TypedProperties getBaseKeyConfig(String timestampType, String dateFormat, String timezone) {
+  private TypedProperties getBaseKeyConfig(String timestampType, String dateFormat, String timezone, String scalarType) {
     properties.setProperty("hoodie.deltastreamer.keygen.timebased.timestamp.type", timestampType);
     properties.setProperty("hoodie.deltastreamer.keygen.timebased.output.dateformat", dateFormat);
     properties.setProperty("hoodie.deltastreamer.keygen.timebased.timezone", timezone);
+
+    if (scalarType != null) {
+      properties.setProperty("hoodie.deltastreamer.keygen.timebased.timestamp.scalar.time_unit", scalarType);
+    }
+
     return properties;
   }
 
@@ -58,25 +63,36 @@ public class TestTimestampBasedKeyGenerator {
   public void testTimestampBasedKeyGenerator() {
     // timezone is GMT+8:00
     baseRecord.put("createTime", 1578283932000L);
-    properties = getBaseKeyConfig("EPOCHMILLISECONDS", "yyyy-MM-dd hh", "GMT+8:00");
+    properties = getBaseKeyConfig("EPOCHMILLISECONDS", "yyyy-MM-dd hh", "GMT+8:00", null);
     HoodieKey hk1 = new TimestampBasedKeyGenerator(properties).getKey(baseRecord);
     assertEquals("2020-01-06 12", hk1.getPartitionPath());
 
     // timezone is GMT
-    properties = getBaseKeyConfig("EPOCHMILLISECONDS", "yyyy-MM-dd hh", "GMT");
+    properties = getBaseKeyConfig("EPOCHMILLISECONDS", "yyyy-MM-dd hh", "GMT", null);
     HoodieKey hk2 = new TimestampBasedKeyGenerator(properties).getKey(baseRecord);
     assertEquals("2020-01-06 04", hk2.getPartitionPath());
 
     // timestamp is DATE_STRING, timezone is GMT+8:00
     baseRecord.put("createTime", "2020-01-06 12:12:12");
-    properties = getBaseKeyConfig("DATE_STRING", "yyyy-MM-dd hh", "GMT+8:00");
+    properties = getBaseKeyConfig("DATE_STRING", "yyyy-MM-dd hh", "GMT+8:00", null);
     properties.setProperty("hoodie.deltastreamer.keygen.timebased.input.dateformat", "yyyy-MM-dd hh:mm:ss");
     HoodieKey hk3 = new TimestampBasedKeyGenerator(properties).getKey(baseRecord);
     assertEquals("2020-01-06 12", hk3.getPartitionPath());
 
     // timezone is GMT
-    properties = getBaseKeyConfig("DATE_STRING", "yyyy-MM-dd hh", "GMT");
+    properties = getBaseKeyConfig("DATE_STRING", "yyyy-MM-dd hh", "GMT", null);
     HoodieKey hk4 = new TimestampBasedKeyGenerator(properties).getKey(baseRecord);
     assertEquals("2020-01-06 12", hk4.getPartitionPath());
+  }
+
+  @Test
+  public void testScalar() {
+    // timezone is GMT+8:00
+    baseRecord.put("createTime", 20000L);
+
+    // timezone is GMT
+    properties = getBaseKeyConfig("SCALAR", "yyyy-MM-dd hh", "GMT", "days");
+    HoodieKey hk5 = new TimestampBasedKeyGenerator(properties).getKey(baseRecord);
+    assertEquals(hk5.getPartitionPath(), "2024-10-04 12");
   }
 }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/keygen/TestTimestampBasedKeyGenerator.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/keygen/TestTimestampBasedKeyGenerator.java
@@ -53,7 +53,7 @@ public class TestTimestampBasedKeyGenerator {
     properties.setProperty("hoodie.deltastreamer.keygen.timebased.timezone", timezone);
 
     if (scalarType != null) {
-      properties.setProperty("hoodie.deltastreamer.keygen.timebased.timestamp.scalar.time_unit", scalarType);
+      properties.setProperty("hoodie.deltastreamer.keygen.timebased.timestamp.scalar.time.unit", scalarType);
     }
 
     return properties;


### PR DESCRIPTION
## What is the purpose of the pull request

Adding a way to specify any source time unit for TimestampBasedKeyGenerator. 
Properties probably need some refactoring, kept unix timestamp for backward compatibility
## Brief change log

*(for example:)*
  - updated TimestampBasedKeyGenerator

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.