### PR TITLE
[HUDI-810] Migrate ClientTestHarness to JUnit 5

### DIFF
--- a/hudi-cli/src/test/java/org/apache/hudi/cli/AbstractShellIntegrationTest.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/AbstractShellIntegrationTest.java
@@ -20,10 +20,10 @@ package org.apache.hudi.cli;
 
 import org.apache.hudi.common.HoodieClientTestHarness;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.springframework.shell.Bootstrap;
 import org.springframework.shell.core.JLineShellComponent;
 
@@ -31,25 +31,26 @@ import org.springframework.shell.core.JLineShellComponent;
  * Class to start Bootstrap and JLineShellComponent.
  */
 public abstract class AbstractShellIntegrationTest extends HoodieClientTestHarness {
+
   private static JLineShellComponent shell;
 
-  @BeforeClass
+  @BeforeAll
   public static void startup() {
     Bootstrap bootstrap = new Bootstrap();
     shell = bootstrap.getJLineShellComponent();
   }
 
-  @AfterClass
+  @AfterAll
   public static void shutdown() {
     shell.stop();
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     initResources();
   }
 
-  @After
+  @AfterEach
   public void teardown() throws Exception {
     cleanupResources();
   }

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestArchivedCommitsCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestArchivedCommitsCommand.java
@@ -32,9 +32,9 @@ import org.apache.hudi.config.HoodieCompactionConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.table.HoodieTimelineArchiveLog;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.shell.core.CommandResult;
 
 import java.io.File;
@@ -43,8 +43,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test Cases for {@link ArchivedCommitsCommand}.
@@ -53,7 +53,7 @@ public class TestArchivedCommitsCommand extends AbstractShellIntegrationTest {
 
   private String tablePath;
 
-  @Before
+  @BeforeEach
   public void init() throws IOException {
     initDFS();
     jsc.hadoopConfiguration().addResource(dfs.getConf());
@@ -95,7 +95,7 @@ public class TestArchivedCommitsCommand extends AbstractShellIntegrationTest {
     archiveLog.archiveIfRequired(jsc);
   }
 
-  @After
+  @AfterEach
   public void clean() throws IOException {
     cleanupDFS();
   }
@@ -122,7 +122,7 @@ public class TestArchivedCommitsCommand extends AbstractShellIntegrationTest {
     for (int i = 100; i < 104; i++) {
       String instant = String.valueOf(i);
       for (int j = 0; j < 3; j++) {
-        Comparable[] defaultComp = new Comparable[]{"commit", instant,
+        Comparable[] defaultComp = new Comparable[] {"commit", instant,
             HoodieTestCommitMetadataGenerator.DEFAULT_SECOND_PARTITION_PATH,
             HoodieTestCommitMetadataGenerator.DEFAULT_FILEID,
             HoodieTestCommitMetadataGenerator.DEFAULT_PRE_COMMIT,
@@ -162,12 +162,12 @@ public class TestArchivedCommitsCommand extends AbstractShellIntegrationTest {
     TableHeader header = new TableHeader().addTableHeaderField("CommitTime").addTableHeaderField("CommitType");
     for (int i = 100; i < 103; i++) {
       String instant = String.valueOf(i);
-      Comparable[] result = new Comparable[]{instant, "commit"};
+      Comparable[] result = new Comparable[] {instant, "commit"};
       rows.add(result);
       rows.add(result);
       rows.add(result);
     }
-    rows.add(new Comparable[]{"103", "commit"});
+    rows.add(new Comparable[] {"103", "commit"});
     String expected = HoodiePrintHelper.print(header, new HashMap<>(), "", false, 10, false, rows);
     assertEquals(expected, cr.getResult().toString());
 
@@ -181,7 +181,7 @@ public class TestArchivedCommitsCommand extends AbstractShellIntegrationTest {
     for (int i = 100; i < 104; i++) {
       String instant = String.valueOf(i);
       // Since HoodiePrintHelper order data by default, need to order commitMetadata
-      Comparable[] result = new Comparable[]{
+      Comparable[] result = new Comparable[] {
           instant, "commit", HoodieTestCommitUtilities.convertAndOrderCommitMetadata(metadata)};
       rows.add(result);
       rows.add(result);

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestSparkEnvCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestSparkEnvCommand.java
@@ -21,11 +21,11 @@ package org.apache.hudi.cli.commands;
 import org.apache.hudi.cli.AbstractShellIntegrationTest;
 import org.apache.hudi.cli.HoodiePrintHelper;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.shell.core.CommandResult;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test Cases for {@link SparkEnvCommand}.
@@ -48,7 +48,7 @@ public class TestSparkEnvCommand extends AbstractShellIntegrationTest {
 
     //Get
     cr = getShell().executeCommand("show env --key SPARK_HOME");
-    String result = HoodiePrintHelper.print(new String[] {"key", "value"}, new String[][]{new String[]{"SPARK_HOME", "/usr/etc/spark"}});
+    String result = HoodiePrintHelper.print(new String[] {"key", "value"}, new String[][] {new String[] {"SPARK_HOME", "/usr/etc/spark"}});
     assertEquals(result, cr.getResult().toString());
   }
 }

--- a/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestTableCommand.java
+++ b/hudi-cli/src/test/java/org/apache/hudi/cli/commands/TestTableCommand.java
@@ -24,30 +24,30 @@ import org.apache.hudi.common.fs.ConsistencyGuardConfig;
 import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.shell.core.CommandResult;
 
 import java.io.File;
 
 import static org.apache.hudi.common.table.HoodieTableMetaClient.METAFOLDER_NAME;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test Cases for {@link TableCommand}.
  */
 public class TestTableCommand extends AbstractShellIntegrationTest {
 
-  private String tableName = "test_table";
+  private final String tableName = "test_table";
   private String tablePath;
   private String metaPath;
 
   /**
    * Init path after Mini hdfs init.
    */
-  @Before
+  @BeforeEach
   public void init() {
     HoodieCLI.conf = jsc.hadoopConfiguration();
     tablePath = basePath + File.separator + tableName;
@@ -74,7 +74,7 @@ public class TestTableCommand extends AbstractShellIntegrationTest {
     // Test connect with specified values
     CommandResult cr = getShell().executeCommand(
         "connect --path " + tablePath + " --initialCheckIntervalMs 3000 "
-          + "--maxWaitIntervalMs 40000 --maxCheckIntervalMs 8");
+            + "--maxWaitIntervalMs 40000 --maxCheckIntervalMs 8");
     assertTrue(cr.isSuccess());
 
     // Check specified values
@@ -113,7 +113,7 @@ public class TestTableCommand extends AbstractShellIntegrationTest {
     // Test create with specified values
     CommandResult cr = getShell().executeCommand(
         "create --path " + tablePath + " --tableName " + tableName
-          + " --tableType MERGE_ON_READ --archiveLogFolder archive");
+            + " --tableType MERGE_ON_READ --archiveLogFolder archive");
     assertTrue(cr.isSuccess());
     assertEquals("Metadata for table " + tableName + " loaded", cr.getResult().toString());
     HoodieTableMetaClient client = HoodieCLI.getTableMetaClient();

--- a/hudi-client/src/test/java/org/apache/hudi/client/TestHoodieClientBase.java
+++ b/hudi-client/src/test/java/org/apache/hudi/client/TestHoodieClientBase.java
@@ -51,9 +51,8 @@ import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.sql.SQLContext;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -64,9 +63,9 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Base Class providing setup/cleanup and utility methods for testing Hoodie Client facing tests.
@@ -75,12 +74,12 @@ public class TestHoodieClientBase extends HoodieClientTestHarness {
 
   private static final Logger LOG = LogManager.getLogger(TestHoodieClientBase.class);
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     initResources();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     cleanupResources();
   }
@@ -170,7 +169,7 @@ public class TestHoodieClientBase extends HoodieClientTestHarness {
   public static void assertNoWriteErrors(List<WriteStatus> statuses) {
     // Verify there are no errors
     for (WriteStatus status : statuses) {
-      assertFalse("Errors found in write of " + status.getFileId(), status.hasErrors());
+      assertFalse(status.hasErrors(), "Errors found in write of " + status.getFileId());
     }
   }
 
@@ -200,7 +199,7 @@ public class TestHoodieClientBase extends HoodieClientTestHarness {
       assertTrue(HoodiePartitionMetadata.hasPartitionMetadata(fs, new Path(basePath, partitionPath)));
       HoodiePartitionMetadata pmeta = new HoodiePartitionMetadata(fs, new Path(basePath, partitionPath));
       pmeta.readFromFS();
-      Assert.assertEquals(HoodieTestDataGenerator.DEFAULT_PARTITION_DEPTH, pmeta.getPartitionDepth());
+      assertEquals(HoodieTestDataGenerator.DEFAULT_PARTITION_DEPTH, pmeta.getPartitionDepth());
     }
   }
 
@@ -212,9 +211,9 @@ public class TestHoodieClientBase extends HoodieClientTestHarness {
    */
   protected void checkTaggedRecords(List<HoodieRecord> taggedRecords, String instantTime) {
     for (HoodieRecord rec : taggedRecords) {
-      assertTrue("Record " + rec + " found with no location.", rec.isCurrentLocationKnown());
-      assertEquals("All records should have commit time " + instantTime + ", since updates were made",
-          rec.getCurrentLocation().getInstantTime(), instantTime);
+      assertTrue(rec.isCurrentLocationKnown(), "Record " + rec + " found with no location.");
+      assertEquals(rec.getCurrentLocation().getInstantTime(), instantTime,
+          "All records should have commit time " + instantTime + ", since updates were made");
     }
   }
 
@@ -231,7 +230,7 @@ public class TestHoodieClientBase extends HoodieClientTestHarness {
       if (!partitionToKeys.containsKey(partitionPath)) {
         partitionToKeys.put(partitionPath, new HashSet<>());
       }
-      assertFalse("key " + key + " is duplicate within partition " + partitionPath, partitionToKeys.get(partitionPath).contains(key));
+      assertFalse(partitionToKeys.get(partitionPath).contains(key), "key " + key + " is duplicate within partition " + partitionPath);
       partitionToKeys.get(partitionPath).add(key);
     }
   }
@@ -472,30 +471,30 @@ public class TestHoodieClientBase extends HoodieClientTestHarness {
     HoodieTimeline timeline = new HoodieActiveTimeline(metaClient).getCommitTimeline();
 
     if (assertForCommit) {
-      assertEquals("Expecting " + expTotalCommits + " commits.", expTotalCommits,
-          timeline.findInstantsAfter(initCommitTime, Integer.MAX_VALUE).countInstants());
-      Assert.assertEquals("Latest commit should be " + newCommitTime, newCommitTime,
-          timeline.lastInstant().get().getTimestamp());
-      assertEquals("Must contain " + expRecordsInThisCommit + " records", expRecordsInThisCommit,
-          HoodieClientTestUtils.readCommit(basePath, sqlContext, timeline, newCommitTime).count());
+      assertEquals(expTotalCommits, timeline.findInstantsAfter(initCommitTime, Integer.MAX_VALUE).countInstants(),
+          "Expecting " + expTotalCommits + " commits.");
+      assertEquals(newCommitTime, timeline.lastInstant().get().getTimestamp(),
+          "Latest commit should be " + newCommitTime);
+      assertEquals(expRecordsInThisCommit, HoodieClientTestUtils.readCommit(basePath, sqlContext, timeline, newCommitTime).count(),
+          "Must contain " + expRecordsInThisCommit + " records");
 
       // Check the entire dataset has all records still
       String[] fullPartitionPaths = new String[dataGen.getPartitionPaths().length];
       for (int i = 0; i < fullPartitionPaths.length; i++) {
         fullPartitionPaths[i] = String.format("%s/%s/*", basePath, dataGen.getPartitionPaths()[i]);
       }
-      assertEquals("Must contain " + expTotalRecords + " records", expTotalRecords,
-          HoodieClientTestUtils.read(jsc, basePath, sqlContext, fs, fullPartitionPaths).count());
+      assertEquals(expTotalRecords, HoodieClientTestUtils.read(jsc, basePath, sqlContext, fs, fullPartitionPaths).count(),
+          "Must contain " + expTotalRecords + " records");
 
       // Check that the incremental consumption from prevCommitTime
-      assertEquals("Incremental consumption from " + prevCommitTime + " should give all records in latest commit",
-          HoodieClientTestUtils.readCommit(basePath, sqlContext, timeline, newCommitTime).count(),
-          HoodieClientTestUtils.readSince(basePath, sqlContext, timeline, prevCommitTime).count());
+      assertEquals(HoodieClientTestUtils.readCommit(basePath, sqlContext, timeline, newCommitTime).count(),
+          HoodieClientTestUtils.readSince(basePath, sqlContext, timeline, prevCommitTime).count(),
+          "Incremental consumption from " + prevCommitTime + " should give all records in latest commit");
       if (commitTimesBetweenPrevAndNew.isPresent()) {
         commitTimesBetweenPrevAndNew.get().forEach(ct -> {
-          assertEquals("Incremental consumption from " + ct + " should give all records in latest commit",
-              HoodieClientTestUtils.readCommit(basePath, sqlContext, timeline, newCommitTime).count(),
-              HoodieClientTestUtils.readSince(basePath, sqlContext, timeline, ct).count());
+          assertEquals(HoodieClientTestUtils.readCommit(basePath, sqlContext, timeline, newCommitTime).count(),
+              HoodieClientTestUtils.readSince(basePath, sqlContext, timeline, ct).count(),
+              "Incremental consumption from " + ct + " should give all records in latest commit");
         });
       }
     }
@@ -540,26 +539,26 @@ public class TestHoodieClientBase extends HoodieClientTestHarness {
     HoodieTimeline timeline = new HoodieActiveTimeline(metaClient).getCommitTimeline();
 
     if (assertForCommit) {
-      assertEquals("Expecting 3 commits.", 3,
-          timeline.findInstantsAfter(initCommitTime, Integer.MAX_VALUE).countInstants());
-      Assert.assertEquals("Latest commit should be " + newCommitTime, newCommitTime,
-          timeline.lastInstant().get().getTimestamp());
-      assertEquals("Must contain " + expRecordsInThisCommit + " records", expRecordsInThisCommit,
-          HoodieClientTestUtils.readCommit(basePath, sqlContext, timeline, newCommitTime).count());
+      assertEquals(3, timeline.findInstantsAfter(initCommitTime, Integer.MAX_VALUE).countInstants(),
+          "Expecting 3 commits.");
+      assertEquals(newCommitTime, timeline.lastInstant().get().getTimestamp(),
+          "Latest commit should be " + newCommitTime);
+      assertEquals(expRecordsInThisCommit, HoodieClientTestUtils.readCommit(basePath, sqlContext, timeline, newCommitTime).count(),
+          "Must contain " + expRecordsInThisCommit + " records");
 
       // Check the entire dataset has all records still
       String[] fullPartitionPaths = new String[dataGen.getPartitionPaths().length];
       for (int i = 0; i < fullPartitionPaths.length; i++) {
         fullPartitionPaths[i] = String.format("%s/%s/*", basePath, dataGen.getPartitionPaths()[i]);
       }
-      assertEquals("Must contain " + expTotalRecords + " records", expTotalRecords,
-          HoodieClientTestUtils.read(jsc, basePath, sqlContext, fs, fullPartitionPaths).count());
+      assertEquals(expTotalRecords, HoodieClientTestUtils.read(jsc, basePath, sqlContext, fs, fullPartitionPaths).count(),
+          "Must contain " + expTotalRecords + " records");
 
       // Check that the incremental consumption from prevCommitTime
-      assertEquals("Incremental consumption from " + prevCommitTime + " should give no records in latest commit,"
-              + " since it is a delete operation",
-          HoodieClientTestUtils.readCommit(basePath, sqlContext, timeline, newCommitTime).count(),
-          HoodieClientTestUtils.readSince(basePath, sqlContext, timeline, prevCommitTime).count());
+      assertEquals(HoodieClientTestUtils.readCommit(basePath, sqlContext, timeline, newCommitTime).count(),
+          HoodieClientTestUtils.readSince(basePath, sqlContext, timeline, prevCommitTime).count(),
+          "Incremental consumption from " + prevCommitTime + " should give no records in latest commit,"
+              + " since it is a delete operation");
     }
     return result;
   }

--- a/hudi-client/src/test/java/org/apache/hudi/client/TestHoodieClientOnCopyOnWriteStorage.java
+++ b/hudi-client/src/test/java/org/apache/hudi/client/TestHoodieClientOnCopyOnWriteStorage.java
@@ -18,7 +18,6 @@
 
 package org.apache.hudi.client;
 
-import java.util.HashSet;
 import org.apache.hudi.common.HoodieClientTestUtils;
 import org.apache.hudi.common.HoodieTestDataGenerator;
 import org.apache.hudi.common.TestRawTripPayload;
@@ -49,15 +48,14 @@ import org.apache.hudi.exception.HoodieIOException;
 import org.apache.hudi.index.HoodieIndex;
 import org.apache.hudi.index.HoodieIndex.IndexType;
 import org.apache.hudi.table.HoodieTable;
+import org.apache.hudi.table.action.commit.WriteHelper;
 
 import org.apache.avro.generic.GenericRecord;
 import org.apache.hadoop.fs.Path;
-import org.apache.hudi.table.action.commit.WriteHelper;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.apache.spark.api.java.JavaRDD;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -65,6 +63,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -75,10 +74,10 @@ import static org.apache.hudi.common.HoodieTestDataGenerator.NULL_SCHEMA;
 import static org.apache.hudi.common.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
 import static org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion.VERSION_0;
 import static org.apache.hudi.common.util.ParquetUtils.readRowKeysFromParquet;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -154,11 +153,11 @@ public class TestHoodieClientOnCopyOnWriteStorage extends TestHoodieClientBase {
       JavaRDD<WriteStatus> result = insertFirstBatch(cfg, client, newCommitTime, prevCommitTime, numRecords, writeFn,
           isPrepped, false, numRecords);
 
-      assertFalse("If Autocommit is false, then commit should not be made automatically",
-          HoodieTestUtils.doesCommitExist(basePath, newCommitTime));
-      assertTrue("Commit should succeed", client.commit(newCommitTime, result));
-      assertTrue("After explicit commit, commit file should be created",
-          HoodieTestUtils.doesCommitExist(basePath, newCommitTime));
+      assertFalse(HoodieTestUtils.doesCommitExist(basePath, newCommitTime),
+          "If Autocommit is false, then commit should not be made automatically");
+      assertTrue(client.commit(newCommitTime, result), "Commit should succeed");
+      assertTrue(HoodieTestUtils.doesCommitExist(basePath, newCommitTime),
+          "After explicit commit, commit file should be created");
     }
   }
 
@@ -251,7 +250,7 @@ public class TestHoodieClientOnCopyOnWriteStorage extends TestHoodieClientBase {
       if (!partitionToKeys.containsKey(partitionPath)) {
         partitionToKeys.put(partitionPath, new HashSet<>());
       }
-      assertFalse("key " + key + " is duplicate within partition " + partitionPath, partitionToKeys.get(partitionPath).contains(key));
+      assertFalse(partitionToKeys.get(partitionPath).contains(key), "key " + key + " is duplicate within partition " + partitionPath);
       partitionToKeys.get(partitionPath).add(key);
     }
   }
@@ -326,8 +325,8 @@ public class TestHoodieClientOnCopyOnWriteStorage extends TestHoodieClientBase {
     for (int i = 0; i < fullPartitionPaths.length; i++) {
       fullPartitionPaths[i] = String.format("%s/%s/*", basePath, dataGen.getPartitionPaths()[i]);
     }
-    assertEquals("Must contain " + 200 + " records", 200,
-        HoodieClientTestUtils.read(jsc, basePath, sqlContext, fs, fullPartitionPaths).count());
+    assertEquals(200, HoodieClientTestUtils.read(jsc, basePath, sqlContext, fs, fullPartitionPaths).count(),
+        "Must contain " + 200 + " records");
 
     // Perform Delete again on upgraded dataset.
     prevCommitTime = newCommitTime;
@@ -340,17 +339,17 @@ public class TestHoodieClientOnCopyOnWriteStorage extends TestHoodieClientBase {
 
     HoodieActiveTimeline activeTimeline = new HoodieActiveTimeline(metaClient, false);
     List<HoodieInstant> instants = activeTimeline.getCommitTimeline().getInstants().collect(Collectors.toList());
-    Assert.assertEquals(5, instants.size());
-    Assert.assertEquals(new HoodieInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "001"),
+    assertEquals(5, instants.size());
+    assertEquals(new HoodieInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "001"),
         instants.get(0));
-    Assert.assertEquals(new HoodieInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "004"),
+    assertEquals(new HoodieInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "004"),
         instants.get(1));
     // New Format should have all states of instants
-    Assert.assertEquals(new HoodieInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.COMMIT_ACTION, "006"),
+    assertEquals(new HoodieInstant(HoodieInstant.State.REQUESTED, HoodieTimeline.COMMIT_ACTION, "006"),
         instants.get(2));
-    Assert.assertEquals(new HoodieInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, "006"),
+    assertEquals(new HoodieInstant(HoodieInstant.State.INFLIGHT, HoodieTimeline.COMMIT_ACTION, "006"),
         instants.get(3));
-    Assert.assertEquals(new HoodieInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "006"),
+    assertEquals(new HoodieInstant(HoodieInstant.State.COMPLETED, HoodieTimeline.COMMIT_ACTION, "006"),
         instants.get(4));
   }
 
@@ -425,8 +424,8 @@ public class TestHoodieClientOnCopyOnWriteStorage extends TestHoodieClientBase {
     for (int i = 0; i < fullPartitionPaths.length; i++) {
       fullPartitionPaths[i] = String.format("%s/%s/*", basePath, dataGen.getPartitionPaths()[i]);
     }
-    assertEquals("Must contain 100 records", 100,
-        HoodieClientTestUtils.read(jsc, basePath, sqlContext, fs, fullPartitionPaths).count());
+    assertEquals(100, HoodieClientTestUtils.read(jsc, basePath, sqlContext, fs, fullPartitionPaths).count(),
+        "Must contain 100 records");
 
     /**
      * Write 2. Updates with different partition
@@ -448,8 +447,8 @@ public class TestHoodieClientOnCopyOnWriteStorage extends TestHoodieClientBase {
     for (int i = 0; i < fullPartitionPaths.length; i++) {
       fullPartitionPaths[i] = String.format("%s/%s/*", basePath, dataGen.getPartitionPaths()[i]);
     }
-    assertEquals("Must contain 100 records", 100,
-        HoodieClientTestUtils.read(jsc, basePath, sqlContext, fs, fullPartitionPaths).count());
+    assertEquals(100, HoodieClientTestUtils.read(jsc, basePath, sqlContext, fs, fullPartitionPaths).count(),
+        "Must contain 100 records");
   }
 
   /**
@@ -476,12 +475,11 @@ public class TestHoodieClientOnCopyOnWriteStorage extends TestHoodieClientBase {
 
     assertNoWriteErrors(statuses);
 
-    assertEquals("Just 1 file needs to be added.", 1, statuses.size());
+    assertEquals(1, statuses.size(), "Just 1 file needs to be added.");
     String file1 = statuses.get(0).getFileId();
-    Assert.assertEquals("file should contain 100 records",
+    assertEquals(100,
         readRowKeysFromParquet(jsc.hadoopConfiguration(), new Path(basePath, statuses.get(0).getStat().getPath()))
-            .size(),
-        100);
+            .size(), "file should contain 100 records");
 
     // Update + Inserts such that they just expand file1
     String commitTime2 = "002";
@@ -496,18 +494,18 @@ public class TestHoodieClientOnCopyOnWriteStorage extends TestHoodieClientBase {
     statuses = client.upsert(insertAndUpdatesRDD2, commitTime2).collect();
     assertNoWriteErrors(statuses);
 
-    assertEquals("Just 1 file needs to be updated.", 1, statuses.size());
-    assertEquals("Existing file should be expanded", file1, statuses.get(0).getFileId());
-    assertEquals("Existing file should be expanded", commitTime1, statuses.get(0).getStat().getPrevCommit());
+    assertEquals(1, statuses.size(), "Just 1 file needs to be updated.");
+    assertEquals(file1, statuses.get(0).getFileId(), "Existing file should be expanded");
+    assertEquals(commitTime1, statuses.get(0).getStat().getPrevCommit(), "Existing file should be expanded");
     Path newFile = new Path(basePath, statuses.get(0).getStat().getPath());
-    assertEquals("file should contain 140 records", readRowKeysFromParquet(jsc.hadoopConfiguration(), newFile).size(),
-        140);
+    assertEquals(140, readRowKeysFromParquet(jsc.hadoopConfiguration(), newFile).size(),
+        "file should contain 140 records");
 
     List<GenericRecord> records = ParquetUtils.readAvroRecords(jsc.hadoopConfiguration(), newFile);
     for (GenericRecord record : records) {
       String recordKey = record.get(HoodieRecord.RECORD_KEY_METADATA_FIELD).toString();
-      assertEquals("only expect commit2", commitTime2, record.get(HoodieRecord.COMMIT_TIME_METADATA_FIELD).toString());
-      assertTrue("key expected to be part of commit2", keys2.contains(recordKey) || keys1.contains(recordKey));
+      assertEquals(commitTime2, record.get(HoodieRecord.COMMIT_TIME_METADATA_FIELD).toString(), "only expect commit2");
+      assertTrue(keys2.contains(recordKey) || keys1.contains(recordKey), "key expected to be part of commit2");
     }
 
     // update + inserts such that file1 is updated and expanded, a new file2 is created.
@@ -522,7 +520,7 @@ public class TestHoodieClientOnCopyOnWriteStorage extends TestHoodieClientBase {
     statuses = client.upsert(insertAndUpdatesRDD3, commitTime3).collect();
     assertNoWriteErrors(statuses);
 
-    assertEquals("2 files needs to be committed.", 2, statuses.size());
+    assertEquals(2, statuses.size(), "2 files needs to be committed.");
     HoodieTableMetaClient metadata = new HoodieTableMetaClient(jsc.hadoopConfiguration(), basePath);
 
     HoodieTable table = getHoodieTable(metadata, config);
@@ -533,7 +531,7 @@ public class TestHoodieClientOnCopyOnWriteStorage extends TestHoodieClientBase {
     int numTotalUpdatesInCommit3 = 0;
     for (HoodieBaseFile file : files) {
       if (file.getFileName().contains(file1)) {
-        assertEquals("Existing file should be expanded", commitTime3, file.getCommitTime());
+        assertEquals(commitTime3, file.getCommitTime(), "Existing file should be expanded");
         records = ParquetUtils.readAvroRecords(jsc.hadoopConfiguration(), new Path(file.getPath()));
         for (GenericRecord record : records) {
           String recordKey = record.get(HoodieRecord.RECORD_KEY_METADATA_FIELD).toString();
@@ -547,21 +545,21 @@ public class TestHoodieClientOnCopyOnWriteStorage extends TestHoodieClientBase {
             }
           }
         }
-        assertEquals("All keys added in commit 2 must be updated in commit3 correctly", 0, keys2.size());
+        assertEquals(0, keys2.size(), "All keys added in commit 2 must be updated in commit3 correctly");
       } else {
-        assertEquals("New file must be written for commit 3", commitTime3, file.getCommitTime());
+        assertEquals(commitTime3, file.getCommitTime(), "New file must be written for commit 3");
         records = ParquetUtils.readAvroRecords(jsc.hadoopConfiguration(), new Path(file.getPath()));
         for (GenericRecord record : records) {
           String recordKey = record.get(HoodieRecord.RECORD_KEY_METADATA_FIELD).toString();
-          assertEquals("only expect commit3", commitTime3,
-              record.get(HoodieRecord.COMMIT_TIME_METADATA_FIELD).toString());
-          assertTrue("key expected to be part of commit3", keys3.contains(recordKey));
+          assertEquals(commitTime3, record.get(HoodieRecord.COMMIT_TIME_METADATA_FIELD).toString(),
+              "only expect commit3");
+          assertTrue(keys3.contains(recordKey), "key expected to be part of commit3");
         }
         numTotalInsertsInCommit3 += records.size();
       }
     }
-    assertEquals("Total updates in commit3 must add up", inserts2.size(), numTotalUpdatesInCommit3);
-    assertEquals("Total inserts in commit3 must add up", keys3.size(), numTotalInsertsInCommit3);
+    assertEquals(numTotalUpdatesInCommit3, inserts2.size(), "Total updates in commit3 must add up");
+    assertEquals(numTotalInsertsInCommit3, keys3.size(), "Total inserts in commit3 must add up");
   }
 
   /**
@@ -588,12 +586,11 @@ public class TestHoodieClientOnCopyOnWriteStorage extends TestHoodieClientBase {
     assertNoWriteErrors(statuses);
     assertPartitionMetadata(new String[] {testPartitionPath}, fs);
 
-    assertEquals("Just 1 file needs to be added.", 1, statuses.size());
+    assertEquals(1, statuses.size(), "Just 1 file needs to be added.");
     String file1 = statuses.get(0).getFileId();
-    assertEquals("file should contain 100 records",
+    assertEquals(100,
         readRowKeysFromParquet(jsc.hadoopConfiguration(), new Path(basePath, statuses.get(0).getStat().getPath()))
-            .size(),
-        100);
+            .size(), "file should contain 100 records");
 
     // Second, set of Inserts should just expand file1
     String commitTime2 = "002";
@@ -604,21 +601,21 @@ public class TestHoodieClientOnCopyOnWriteStorage extends TestHoodieClientBase {
     statuses = client.insert(insertRecordsRDD2, commitTime2).collect();
     assertNoWriteErrors(statuses);
 
-    assertEquals("Just 1 file needs to be updated.", 1, statuses.size());
-    assertEquals("Existing file should be expanded", file1, statuses.get(0).getFileId());
-    assertEquals("Existing file should be expanded", commitTime1, statuses.get(0).getStat().getPrevCommit());
+    assertEquals(1, statuses.size(), "Just 1 file needs to be updated.");
+    assertEquals(file1, statuses.get(0).getFileId(), "Existing file should be expanded");
+    assertEquals(commitTime1, statuses.get(0).getStat().getPrevCommit(), "Existing file should be expanded");
     Path newFile = new Path(basePath, statuses.get(0).getStat().getPath());
-    assertEquals("file should contain 140 records", readRowKeysFromParquet(jsc.hadoopConfiguration(), newFile).size(),
-        140);
+    assertEquals(140, readRowKeysFromParquet(jsc.hadoopConfiguration(), newFile).size(),
+        "file should contain 140 records");
 
     List<GenericRecord> records = ParquetUtils.readAvroRecords(jsc.hadoopConfiguration(), newFile);
     for (GenericRecord record : records) {
       String recordKey = record.get(HoodieRecord.RECORD_KEY_METADATA_FIELD).toString();
       String recCommitTime = record.get(HoodieRecord.COMMIT_TIME_METADATA_FIELD).toString();
-      assertTrue("Record expected to be part of commit 1 or commit2",
-          commitTime1.equals(recCommitTime) || commitTime2.equals(recCommitTime));
-      assertTrue("key expected to be part of commit 1 or commit2",
-          keys2.contains(recordKey) || keys1.contains(recordKey));
+      assertTrue(commitTime1.equals(recCommitTime) || commitTime2.equals(recCommitTime),
+          "Record expected to be part of commit 1 or commit2");
+      assertTrue(keys2.contains(recordKey) || keys1.contains(recordKey),
+          "key expected to be part of commit 1 or commit2");
     }
 
     // Lots of inserts such that file1 is updated and expanded, a new file2 is created.
@@ -628,22 +625,22 @@ public class TestHoodieClientOnCopyOnWriteStorage extends TestHoodieClientBase {
     JavaRDD<HoodieRecord> insertRecordsRDD3 = jsc.parallelize(insert3, 1);
     statuses = client.insert(insertRecordsRDD3, commitTime3).collect();
     assertNoWriteErrors(statuses);
-    assertEquals("2 files needs to be committed.", 2, statuses.size());
+    assertEquals(2, statuses.size(), "2 files needs to be committed.");
 
     HoodieTableMetaClient metaClient = new HoodieTableMetaClient(jsc.hadoopConfiguration(), basePath);
     HoodieTable table = getHoodieTable(metaClient, config);
     List<HoodieBaseFile> files = table.getBaseFileOnlyView()
         .getLatestBaseFilesBeforeOrOn(testPartitionPath, commitTime3).collect(Collectors.toList());
-    assertEquals("Total of 2 valid data files", 2, files.size());
+    assertEquals(2, files.size(), "Total of 2 valid data files");
 
     int totalInserts = 0;
     for (HoodieBaseFile file : files) {
-      assertEquals("All files must be at commit 3", commitTime3, file.getCommitTime());
+      assertEquals(commitTime3, file.getCommitTime(), "All files must be at commit 3");
       records = ParquetUtils.readAvroRecords(jsc.hadoopConfiguration(), new Path(file.getPath()));
       totalInserts += records.size();
     }
-    assertEquals("Total number of records must add up", totalInserts,
-        inserts1.size() + inserts2.size() + insert3.size());
+    assertEquals(totalInserts, inserts1.size() + inserts2.size() + insert3.size(),
+        "Total number of records must add up");
   }
 
   /**
@@ -670,12 +667,11 @@ public class TestHoodieClientOnCopyOnWriteStorage extends TestHoodieClientBase {
 
     assertNoWriteErrors(statuses);
 
-    assertEquals("Just 1 file needs to be added.", 1, statuses.size());
+    assertEquals(1, statuses.size(), "Just 1 file needs to be added.");
     String file1 = statuses.get(0).getFileId();
-    Assert.assertEquals("file should contain 100 records",
+    assertEquals(100,
         readRowKeysFromParquet(jsc.hadoopConfiguration(), new Path(basePath, statuses.get(0).getStat().getPath()))
-            .size(),
-        100);
+            .size(), "file should contain 100 records");
 
     // Delete 20 among 100 inserted
     testDeletes(client, inserts1, 20, file1, "002", 80, keysSoFar);
@@ -701,15 +697,16 @@ public class TestHoodieClientOnCopyOnWriteStorage extends TestHoodieClientBase {
     JavaRDD<HoodieKey> deleteKeys3 = jsc.parallelize(hoodieKeysToDelete3, 1);
     statuses = client.delete(deleteKeys3, commitTime6).collect();
     assertNoWriteErrors(statuses);
-    assertEquals("Just 0 write status for delete.", 0, statuses.size());
+    assertEquals(0, statuses.size(), "Just 0 write status for delete.");
 
     // Check the entire dataset has all records still
     String[] fullPartitionPaths = new String[dataGen.getPartitionPaths().length];
     for (int i = 0; i < fullPartitionPaths.length; i++) {
       fullPartitionPaths[i] = String.format("%s/%s/*", basePath, dataGen.getPartitionPaths()[i]);
     }
-    assertEquals("Must contain " + 150 + " records", 150,
-        HoodieClientTestUtils.read(jsc, basePath, sqlContext, fs, fullPartitionPaths).count());
+    assertEquals(150,
+        HoodieClientTestUtils.read(jsc, basePath, sqlContext, fs, fullPartitionPaths).count(),
+        "Must contain " + 150 + " records");
 
     // delete another batch. previous delete commit should have persisted the schema. If not,
     // this will throw exception
@@ -735,8 +732,9 @@ public class TestHoodieClientOnCopyOnWriteStorage extends TestHoodieClientBase {
     for (int i = 0; i < fullPartitionPaths.length; i++) {
       fullPartitionPaths[i] = String.format("%s/%s/*", basePath, dataGen.getPartitionPaths()[i]);
     }
-    assertEquals("Must contain " + expectedTotalRecords + " records", expectedTotalRecords,
-        HoodieClientTestUtils.read(jsc, basePath, sqlContext, fs, fullPartitionPaths).count());
+    assertEquals(expectedTotalRecords,
+        HoodieClientTestUtils.read(jsc, basePath, sqlContext, fs, fullPartitionPaths).count(),
+        "Must contain " + expectedTotalRecords + " records");
     return Pair.of(keys, inserts);
   }
 
@@ -751,26 +749,28 @@ public class TestHoodieClientOnCopyOnWriteStorage extends TestHoodieClientBase {
 
     assertNoWriteErrors(statuses);
 
-    assertEquals("Just 1 file needs to be added.", 1, statuses.size());
-    assertEquals("Existing file should be expanded", existingFile, statuses.get(0).getFileId());
+    assertEquals(1, statuses.size(), "Just 1 file needs to be added.");
+    assertEquals(existingFile, statuses.get(0).getFileId(), "Existing file should be expanded");
 
     // Check the entire dataset has all records still
     String[] fullPartitionPaths = new String[dataGen.getPartitionPaths().length];
     for (int i = 0; i < fullPartitionPaths.length; i++) {
       fullPartitionPaths[i] = String.format("%s/%s/*", basePath, dataGen.getPartitionPaths()[i]);
     }
-    assertEquals("Must contain " + exepctedRecords + " records", exepctedRecords,
-        HoodieClientTestUtils.read(jsc, basePath, sqlContext, fs, fullPartitionPaths).count());
+    assertEquals(exepctedRecords,
+        HoodieClientTestUtils.read(jsc, basePath, sqlContext, fs, fullPartitionPaths).count(),
+        "Must contain " + exepctedRecords + " records");
 
     Path newFile = new Path(basePath, statuses.get(0).getStat().getPath());
-    assertEquals("file should contain 110 records", readRowKeysFromParquet(jsc.hadoopConfiguration(), newFile).size(),
-        exepctedRecords);
+    assertEquals(exepctedRecords,
+        readRowKeysFromParquet(jsc.hadoopConfiguration(), newFile).size(),
+        "file should contain 110 records");
 
     List<GenericRecord> records = ParquetUtils.readAvroRecords(jsc.hadoopConfiguration(), newFile);
     for (GenericRecord record : records) {
       String recordKey = record.get(HoodieRecord.RECORD_KEY_METADATA_FIELD).toString();
-      assertTrue("key expected to be part of " + instantTime, keys.contains(recordKey));
-      assertFalse("Key deleted", hoodieKeysToDelete.contains(recordKey));
+      assertTrue(keys.contains(recordKey), "key expected to be part of " + instantTime);
+      assertFalse(hoodieKeysToDelete.contains(recordKey), "Key deleted");
     }
   }
 
@@ -795,12 +795,9 @@ public class TestHoodieClientOnCopyOnWriteStorage extends TestHoodieClientBase {
     List<HoodieKey> hoodieKeysToDelete = HoodieClientTestUtils
         .getKeysToDelete(HoodieClientTestUtils.getHoodieKeys(dummyInserts), 20);
     JavaRDD<HoodieKey> deleteKeys = jsc.parallelize(hoodieKeysToDelete, 1);
-    try {
+    assertThrows(HoodieIOException.class, () -> {
       client.delete(deleteKeys, commitTime1).collect();
-      fail("Should have thrown Exception");
-    } catch (HoodieIOException e) {
-      // ignore
-    }
+    }, "Should have thrown Exception");
   }
 
   /**
@@ -822,9 +819,9 @@ public class TestHoodieClientOnCopyOnWriteStorage extends TestHoodieClientBase {
 
       JavaRDD<WriteStatus> result = client.bulkInsert(writeRecords, instantTime);
 
-      assertTrue("Commit should succeed", client.commit(instantTime, result));
-      assertTrue("After explicit commit, commit file should be created",
-          HoodieTestUtils.doesCommitExist(basePath, instantTime));
+      assertTrue(client.commit(instantTime, result), "Commit should succeed");
+      assertTrue(HoodieTestUtils.doesCommitExist(basePath, instantTime),
+          "After explicit commit, commit file should be created");
 
       // Get parquet file paths from commit metadata
       String actionType = metaClient.getCommitActionType();
@@ -868,9 +865,9 @@ public class TestHoodieClientOnCopyOnWriteStorage extends TestHoodieClientBase {
 
     JavaRDD<WriteStatus> result = client.bulkInsert(writeRecords, instantTime);
 
-    assertTrue("Commit should succeed", client.commit(instantTime, result));
-    assertTrue("After explicit commit, commit file should be created",
-        HoodieTestUtils.doesCommitExist(basePath, instantTime));
+    assertTrue(client.commit(instantTime, result), "Commit should succeed");
+    assertTrue(HoodieTestUtils.doesCommitExist(basePath, instantTime),
+        "After explicit commit, commit file should be created");
 
     // Read from commit file
     String filename = HoodieTestUtils.getCommitFilePath(basePath, instantTime);
@@ -888,7 +885,7 @@ public class TestHoodieClientOnCopyOnWriteStorage extends TestHoodieClientBase {
         inserts += stat.getValue().getInserts();
       }
     }
-    Assert.assertEquals(inserts, 200);
+    assertEquals(200, inserts);
 
     // Update + Inserts such that they just expand file1
     instantTime = "001";
@@ -898,9 +895,9 @@ public class TestHoodieClientOnCopyOnWriteStorage extends TestHoodieClientBase {
     writeRecords = jsc.parallelize(records, 1);
     result = client.upsert(writeRecords, instantTime);
 
-    assertTrue("Commit should succeed", client.commit(instantTime, result));
-    assertTrue("After explicit commit, commit file should be created",
-        HoodieTestUtils.doesCommitExist(basePath, instantTime));
+    assertTrue(client.commit(instantTime, result), "Commit should succeed");
+    assertTrue(HoodieTestUtils.doesCommitExist(basePath, instantTime),
+        "After explicit commit, commit file should be created");
 
     // Read from commit file
     filename = HoodieTestUtils.getCommitFilePath(basePath, instantTime);
@@ -919,8 +916,8 @@ public class TestHoodieClientOnCopyOnWriteStorage extends TestHoodieClientBase {
         upserts += stat.getValue().getUpserts();
       }
     }
-    Assert.assertEquals(inserts, 200);
-    Assert.assertEquals(upserts, 200);
+    assertEquals(200, inserts);
+    assertEquals(200, upserts);
 
   }
 
@@ -937,9 +934,9 @@ public class TestHoodieClientOnCopyOnWriteStorage extends TestHoodieClientBase {
 
     // Delete orphan marker and commit should succeed
     metaClient.getFs().delete(result.getKey(), false);
-    assertTrue("Commit should succeed", client.commit(instantTime, result.getRight()));
-    assertTrue("After explicit commit, commit file should be created",
-        HoodieTestUtils.doesCommitExist(basePath, instantTime));
+    assertTrue(client.commit(instantTime, result.getRight()), "Commit should succeed");
+    assertTrue(HoodieTestUtils.doesCommitExist(basePath, instantTime),
+        "After explicit commit, commit file should be created");
     // Marker directory must be removed
     assertFalse(metaClient.getFs().exists(new Path(metaClient.getMarkerFolderPath(instantTime))));
   }
@@ -954,8 +951,8 @@ public class TestHoodieClientOnCopyOnWriteStorage extends TestHoodieClientBase {
 
     // Rollback of this commit should succeed
     client.rollback(instantTime);
-    assertFalse("After explicit rollback, commit file should not be present",
-        HoodieTestUtils.doesCommitExist(basePath, instantTime));
+    assertFalse(HoodieTestUtils.doesCommitExist(basePath, instantTime),
+        "After explicit rollback, commit file should not be present");
     // Marker directory must be removed after rollback
     assertFalse(metaClient.getFs().exists(new Path(metaClient.getMarkerFolderPath(instantTime))));
   }
@@ -984,12 +981,10 @@ public class TestHoodieClientOnCopyOnWriteStorage extends TestHoodieClientBase {
     metaClient.getFs().create(markerFilePath);
     LOG.info("Created a dummy marker path=" + markerFilePath);
 
-    try {
+    Exception e = assertThrows(HoodieCommitException.class, () -> {
       client.commit(instantTime, result);
-      fail("Commit should fail due to consistency check");
-    } catch (HoodieCommitException cme) {
-      assertTrue(cme.getCause() instanceof HoodieIOException);
-    }
+    }, "Commit should fail due to consistency check");
+    assertTrue(e.getCause() instanceof HoodieIOException);
     return Pair.of(markerFilePath, result);
   }
 

--- a/hudi-client/src/test/java/org/apache/hudi/client/TestHoodieReadClient.java
+++ b/hudi-client/src/test/java/org/apache/hudi/client/TestHoodieReadClient.java
@@ -28,7 +28,7 @@ import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.sql.AnalysisException;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -36,7 +36,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @SuppressWarnings("unchecked")
 /**
@@ -79,11 +80,13 @@ public class TestHoodieReadClient extends TestHoodieClientBase {
         });
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testReadROViewFailsWithoutSqlContext() {
     HoodieReadClient readClient = new HoodieReadClient(jsc, getConfig());
     JavaRDD<HoodieKey> recordsRDD = jsc.parallelize(new ArrayList<>(), 1);
-    readClient.readROView(recordsRDD, 1);
+    assertThrows(IllegalStateException.class, () -> {
+      readClient.readROView(recordsRDD, 1);
+    });
   }
 
   /**
@@ -131,14 +134,11 @@ public class TestHoodieReadClient extends TestHoodieClientBase {
       assertEquals(75, rows.count());
 
       JavaRDD<HoodieKey> keysWithoutPaths = keyToPathPair.filter(keyPath -> !keyPath._2.isPresent())
-              .map(keyPath -> keyPath._1);
+          .map(keyPath -> keyPath._1);
 
-      try {
+      assertThrows(AnalysisException.class, () -> {
         anotherReadClient.readROView(keysWithoutPaths, 1);
-      } catch (Exception e) {
-        // data frame reader throws exception for empty records. ignore the error.
-        assertEquals(e.getClass(), AnalysisException.class);
-      }
+      });
 
       // Actual tests of getPendingCompactions method are in TestAsyncCompaction
       // This is just testing empty list

--- a/hudi-client/src/test/java/org/apache/hudi/client/TestMultiFS.java
+++ b/hudi-client/src/test/java/org/apache/hudi/client/TestMultiFS.java
@@ -39,13 +39,13 @@ import org.apache.log4j.Logger;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestMultiFS extends HoodieClientTestHarness {
 
@@ -54,14 +54,14 @@ public class TestMultiFS extends HoodieClientTestHarness {
   protected String tableName = "hoodie_rt";
   private String tableType = HoodieTableType.COPY_ON_WRITE.name();
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     initSparkContexts();
     initDFS();
     initTestDataGenerator();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     cleanupSparkContexts();
     cleanupDFS();
@@ -103,7 +103,7 @@ public class TestMultiFS extends HoodieClientTestHarness {
       HoodieTableMetaClient metaClient = new HoodieTableMetaClient(fs.getConf(), dfsBasePath);
       HoodieTimeline timeline = new HoodieActiveTimeline(metaClient).getCommitTimeline();
       Dataset<Row> readRecords = HoodieClientTestUtils.readCommit(dfsBasePath, sqlContext, timeline, readCommitTime);
-      assertEquals("Should contain 100 records", readRecords.count(), records.size());
+      assertEquals(readRecords.count(), records.size(), "Should contain 100 records");
 
       // Write to local
       HoodieTableMetaClient.initTableType(jsc.hadoopConfiguration(), tablePath, HoodieTableType.valueOf(tableType),
@@ -122,7 +122,7 @@ public class TestMultiFS extends HoodieClientTestHarness {
       timeline = new HoodieActiveTimeline(metaClient).getCommitTimeline();
       Dataset<Row> localReadRecords =
           HoodieClientTestUtils.readCommit(tablePath, sqlContext, timeline, writeCommitTime);
-      assertEquals("Should contain 100 records", localReadRecords.count(), localRecords.size());
+      assertEquals(localReadRecords.count(), localRecords.size(), "Should contain 100 records");
     }
   }
 }

--- a/hudi-client/src/test/java/org/apache/hudi/client/TestTableSchemaEvolution.java
+++ b/hudi-client/src/test/java/org/apache/hudi/client/TestTableSchemaEvolution.java
@@ -18,8 +18,6 @@
 
 package org.apache.hudi.client;
 
-import org.apache.avro.Schema;
-import org.apache.avro.generic.GenericRecord;
 import org.apache.hudi.avro.HoodieAvroUtils;
 import org.apache.hudi.common.HoodieClientTestUtils;
 import org.apache.hudi.common.HoodieTestDataGenerator;
@@ -36,9 +34,12 @@ import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.exception.HoodieInsertException;
 import org.apache.hudi.exception.HoodieUpsertException;
 import org.apache.hudi.index.HoodieIndex.IndexType;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.List;
@@ -51,10 +52,10 @@ import static org.apache.hudi.common.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA
 import static org.apache.hudi.common.HoodieTestDataGenerator.TRIP_SCHEMA_PREFIX;
 import static org.apache.hudi.common.HoodieTestDataGenerator.TRIP_SCHEMA_SUFFIX;
 import static org.apache.hudi.common.table.timeline.versioning.TimelineLayoutVersion.VERSION_1;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestTableSchemaEvolution extends TestHoodieClientBase {
   private final String initCommitTime = "000";
@@ -73,60 +74,60 @@ public class TestTableSchemaEvolution extends TestHoodieClientBase {
   public static final String TRIP_EXAMPLE_SCHEMA_DEVOLVED = TRIP_SCHEMA_PREFIX + MAP_TYPE_SCHEMA + FARE_NESTED_SCHEMA
       + TRIP_SCHEMA_SUFFIX;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     initResources();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     cleanupSparkContexts();
   }
 
   @Test
   public void testSchemaCompatibilityBasic() throws Exception {
-    assertTrue("Same schema is compatible",
-               TableSchemaResolver.isSchemaCompatible(TRIP_EXAMPLE_SCHEMA, TRIP_EXAMPLE_SCHEMA));
+    assertTrue(TableSchemaResolver.isSchemaCompatible(TRIP_EXAMPLE_SCHEMA, TRIP_EXAMPLE_SCHEMA),
+        "Same schema is compatible");
 
-    String reorderedSchema = TRIP_SCHEMA_PREFIX  + TIP_NESTED_SCHEMA + FARE_NESTED_SCHEMA
+    String reorderedSchema = TRIP_SCHEMA_PREFIX + TIP_NESTED_SCHEMA + FARE_NESTED_SCHEMA
         + MAP_TYPE_SCHEMA + TRIP_SCHEMA_SUFFIX;
-    assertTrue("Reordered fields are compatible",
-        TableSchemaResolver.isSchemaCompatible(TRIP_EXAMPLE_SCHEMA, reorderedSchema));
-    assertTrue("Reordered fields are compatible",
-        TableSchemaResolver.isSchemaCompatible(reorderedSchema, TRIP_EXAMPLE_SCHEMA));
+    assertTrue(TableSchemaResolver.isSchemaCompatible(TRIP_EXAMPLE_SCHEMA, reorderedSchema),
+        "Reordered fields are compatible");
+    assertTrue(TableSchemaResolver.isSchemaCompatible(reorderedSchema, TRIP_EXAMPLE_SCHEMA),
+        "Reordered fields are compatible");
 
     String renamedSchema = TRIP_EXAMPLE_SCHEMA.replace("tip_history", "tip_future");
-    assertFalse("Renamed fields are not compatible",
-        TableSchemaResolver.isSchemaCompatible(TRIP_EXAMPLE_SCHEMA, renamedSchema));
+    assertFalse(TableSchemaResolver.isSchemaCompatible(TRIP_EXAMPLE_SCHEMA, renamedSchema),
+        "Renamed fields are not compatible");
 
-    assertFalse("Deleted single field is not compatible",
-        TableSchemaResolver.isSchemaCompatible(TRIP_EXAMPLE_SCHEMA, TRIP_EXAMPLE_SCHEMA_DEVOLVED));
-    String deletedMultipleFieldSchema = TRIP_SCHEMA_PREFIX  + TIP_NESTED_SCHEMA + TRIP_SCHEMA_SUFFIX;
-    assertFalse("Deleted multiple fields are not compatible",
-        TableSchemaResolver.isSchemaCompatible(TRIP_EXAMPLE_SCHEMA, deletedMultipleFieldSchema));
+    assertFalse(TableSchemaResolver.isSchemaCompatible(TRIP_EXAMPLE_SCHEMA, TRIP_EXAMPLE_SCHEMA_DEVOLVED),
+        "Deleted single field is not compatible");
+    String deletedMultipleFieldSchema = TRIP_SCHEMA_PREFIX + TIP_NESTED_SCHEMA + TRIP_SCHEMA_SUFFIX;
+    assertFalse(TableSchemaResolver.isSchemaCompatible(TRIP_EXAMPLE_SCHEMA, deletedMultipleFieldSchema),
+        "Deleted multiple fields are not compatible");
 
     String renamedRecordSchema = TRIP_EXAMPLE_SCHEMA.replace("triprec", "triprec_renamed");
-    assertFalse("Renamed record name is not compatible",
-        TableSchemaResolver.isSchemaCompatible(TRIP_EXAMPLE_SCHEMA, renamedRecordSchema));
+    assertFalse(TableSchemaResolver.isSchemaCompatible(TRIP_EXAMPLE_SCHEMA, renamedRecordSchema),
+        "Renamed record name is not compatible");
 
     String swappedFieldSchema = TRIP_SCHEMA_PREFIX + MAP_TYPE_SCHEMA.replace("city_to_state", "fare")
         + FARE_NESTED_SCHEMA.replace("fare", "city_to_state") + TIP_NESTED_SCHEMA + TRIP_SCHEMA_SUFFIX;
-    assertFalse("Swapped fields are not compatible",
-        TableSchemaResolver.isSchemaCompatible(TRIP_EXAMPLE_SCHEMA, swappedFieldSchema));
+    assertFalse(TableSchemaResolver.isSchemaCompatible(TRIP_EXAMPLE_SCHEMA, swappedFieldSchema),
+        "Swapped fields are not compatible");
 
     String typeChangeSchema = TRIP_SCHEMA_PREFIX + MAP_TYPE_SCHEMA + FARE_NESTED_SCHEMA
         + TIP_NESTED_SCHEMA.replace("string", "boolean") + TRIP_SCHEMA_SUFFIX;
-    assertFalse("Field type change is not compatible",
-        TableSchemaResolver.isSchemaCompatible(TRIP_EXAMPLE_SCHEMA, typeChangeSchema));
+    assertFalse(TableSchemaResolver.isSchemaCompatible(TRIP_EXAMPLE_SCHEMA, typeChangeSchema),
+        "Field type change is not compatible");
 
-    assertTrue("Added field with default is compatible (Evolved Schema)",
-        TableSchemaResolver.isSchemaCompatible(TRIP_EXAMPLE_SCHEMA, TRIP_EXAMPLE_SCHEMA_EVOLVED));
+    assertTrue(TableSchemaResolver.isSchemaCompatible(TRIP_EXAMPLE_SCHEMA, TRIP_EXAMPLE_SCHEMA_EVOLVED),
+        "Added field with default is compatible (Evolved Schema)");
 
     String multipleAddedFieldSchema = TRIP_SCHEMA_PREFIX + MAP_TYPE_SCHEMA + FARE_NESTED_SCHEMA
         + TIP_NESTED_SCHEMA + EXTRA_FIELD_SCHEMA + EXTRA_FIELD_SCHEMA.replace("new_field", "new_new_field")
         + TRIP_SCHEMA_SUFFIX;
-    assertTrue("Multiple added fields with defauls are compatible",
-        TableSchemaResolver.isSchemaCompatible(TRIP_EXAMPLE_SCHEMA, multipleAddedFieldSchema));
+    assertTrue(TableSchemaResolver.isSchemaCompatible(TRIP_EXAMPLE_SCHEMA, multipleAddedFieldSchema),
+        "Multiple added fields with defauls are compatible");
   }
 
   @Test

--- a/hudi-client/src/test/java/org/apache/hudi/common/HoodieClientTestHarness.java
+++ b/hudi-client/src/test/java/org/apache/hudi/common/HoodieClientTestHarness.java
@@ -23,6 +23,7 @@ import org.apache.hudi.common.fs.FSUtils;
 import org.apache.hudi.common.minicluster.HdfsTestService;
 import org.apache.hudi.common.model.HoodieTestUtils;
 import org.apache.hudi.common.table.HoodieTableMetaClient;
+import org.apache.hudi.common.testutils.HoodieCommonTestHarnessJunit5;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -44,7 +45,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 /**
  * The test harness for resource initialization and cleanup.
  */
-public abstract class HoodieClientTestHarness extends HoodieCommonTestHarness implements Serializable {
+public abstract class HoodieClientTestHarness extends HoodieCommonTestHarnessJunit5 implements Serializable {
 
   private static final Logger LOG = LoggerFactory.getLogger(HoodieClientTestHarness.class);
 

--- a/hudi-client/src/test/java/org/apache/hudi/execution/TestBoundedInMemoryExecutor.java
+++ b/hudi-client/src/test/java/org/apache/hudi/execution/TestBoundedInMemoryExecutor.java
@@ -28,16 +28,17 @@ import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.execution.LazyInsertIterable.HoodieInsertValueGenResult;
 
 import org.apache.avro.generic.IndexedRecord;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 import scala.Tuple2;
 
 import static org.apache.hudi.execution.LazyInsertIterable.getTransformFunction;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -45,12 +46,12 @@ public class TestBoundedInMemoryExecutor extends HoodieClientTestHarness {
 
   private final String instantTime = HoodieActiveTimeline.createNewInstantTime();
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     initTestDataGenerator();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     cleanupTestDataGenerator();
   }
@@ -73,7 +74,8 @@ public class TestBoundedInMemoryExecutor extends HoodieClientTestHarness {
           }
 
           @Override
-          protected void finish() {}
+          protected void finish() {
+          }
 
           @Override
           protected Integer getResult() {
@@ -87,9 +89,9 @@ public class TestBoundedInMemoryExecutor extends HoodieClientTestHarness {
           getTransformFunction(HoodieTestDataGenerator.AVRO_SCHEMA));
       int result = executor.execute();
       // It should buffer and write 100 records
-      Assert.assertEquals(result, 100);
+      assertEquals(100, result);
       // There should be no remaining records in the buffer
-      Assert.assertFalse(executor.isRemaining());
+      assertFalse(executor.isRemaining());
     } finally {
       if (executor != null) {
         executor.shutdownNow();

--- a/hudi-client/src/test/java/org/apache/hudi/execution/TestBoundedInMemoryQueue.java
+++ b/hudi-client/src/test/java/org/apache/hudi/execution/TestBoundedInMemoryQueue.java
@@ -34,10 +34,10 @@ import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.execution.LazyInsertIterable.HoodieInsertValueGenResult;
 
 import org.apache.avro.generic.IndexedRecord;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -54,6 +54,9 @@ import java.util.stream.IntStream;
 import scala.Tuple2;
 
 import static org.apache.hudi.execution.LazyInsertIterable.getTransformFunction;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -61,13 +64,13 @@ public class TestBoundedInMemoryQueue extends HoodieClientTestHarness {
 
   private final String instantTime = HoodieActiveTimeline.createNewInstantTime();
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     initTestDataGenerator();
     initExecutorServiceWithFixedThreadPool(2);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     cleanupTestDataGenerator();
     cleanupExecutorService();
@@ -76,7 +79,8 @@ public class TestBoundedInMemoryQueue extends HoodieClientTestHarness {
   // Test to ensure that we are reading all records from queue iterator in the same order
   // without any exceptions.
   @SuppressWarnings("unchecked")
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testRecordReading() throws Exception {
     final int numRecords = 128;
     final List<HoodieRecord> hoodieRecords = dataGen.generateInserts(instantTime, numRecords);
@@ -96,15 +100,15 @@ public class TestBoundedInMemoryQueue extends HoodieClientTestHarness {
           originalRecord.getData().getInsertValue(HoodieTestDataGenerator.AVRO_SCHEMA);
       final HoodieInsertValueGenResult<HoodieRecord> payload = queue.iterator().next();
       // Ensure that record ordering is guaranteed.
-      Assert.assertEquals(originalRecord, payload.record);
+      assertEquals(originalRecord, payload.record);
       // cached insert value matches the expected insert value.
-      Assert.assertEquals(originalInsertValue,
+      assertEquals(originalInsertValue,
           payload.record.getData().getInsertValue(HoodieTestDataGenerator.AVRO_SCHEMA));
       recordsRead++;
     }
-    Assert.assertFalse(queue.iterator().hasNext() || originalRecordIterator.hasNext());
+    assertFalse(queue.iterator().hasNext() || originalRecordIterator.hasNext());
     // all the records should be read successfully.
-    Assert.assertEquals(numRecords, recordsRead);
+    assertEquals(numRecords, recordsRead);
     // should not throw any exceptions.
     resFuture.get();
   }
@@ -113,7 +117,8 @@ public class TestBoundedInMemoryQueue extends HoodieClientTestHarness {
    * Test to ensure that we are reading all records from queue iterator when we have multiple producers.
    */
   @SuppressWarnings("unchecked")
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testCompositeProducerRecordReading() throws Exception {
     final int numRecords = 1000;
     final int numProducers = 40;
@@ -129,7 +134,7 @@ public class TestBoundedInMemoryQueue extends HoodieClientTestHarness {
       List<HoodieRecord> pRecs = dataGen.generateInserts(instantTime, numRecords);
       int j = 0;
       for (HoodieRecord r : pRecs) {
-        Assert.assertTrue(!keyToProducerAndIndexMap.containsKey(r.getRecordKey()));
+        assertFalse(keyToProducerAndIndexMap.containsKey(r.getRecordKey()));
         keyToProducerAndIndexMap.put(r.getRecordKey(), new Tuple2<>(i, j));
         j++;
       }
@@ -192,12 +197,12 @@ public class TestBoundedInMemoryQueue extends HoodieClientTestHarness {
       countMap.put(producerPos._1(), countMap.get(producerPos._1()) + 1);
       lastSeenMap.put(producerPos._1(), lastSeenPos + 1);
       // Ensure we are seeing the next record generated
-      Assert.assertEquals(lastSeenPos + 1, producerPos._2().intValue());
+      assertEquals(lastSeenPos + 1, producerPos._2().intValue());
     }
 
     for (int i = 0; i < numProducers; i++) {
       // Ensure we have seen all the records for each producers
-      Assert.assertEquals(Integer.valueOf(numRecords), countMap.get(i));
+      assertEquals(Integer.valueOf(numRecords), countMap.get(i));
     }
 
     // Ensure Close future is done
@@ -206,7 +211,8 @@ public class TestBoundedInMemoryQueue extends HoodieClientTestHarness {
 
   // Test to ensure that record queueing is throttled when we hit memory limit.
   @SuppressWarnings("unchecked")
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testMemoryLimitForBuffering() throws Exception {
     final int numRecords = 128;
     final List<HoodieRecord> hoodieRecords = dataGen.generateInserts(instantTime, numRecords);
@@ -229,14 +235,14 @@ public class TestBoundedInMemoryQueue extends HoodieClientTestHarness {
     while (!isQueueFull(queue.rateLimiter)) {
       Thread.sleep(10);
     }
-    Assert.assertEquals(0, queue.rateLimiter.availablePermits());
-    Assert.assertEquals(recordLimit, queue.currentRateLimit);
-    Assert.assertEquals(recordLimit, queue.size());
-    Assert.assertEquals(recordLimit - 1, queue.samplingRecordCounter.get());
+    assertEquals(0, queue.rateLimiter.availablePermits());
+    assertEquals(recordLimit, queue.currentRateLimit);
+    assertEquals(recordLimit, queue.size());
+    assertEquals(recordLimit - 1, queue.samplingRecordCounter.get());
 
     // try to read 2 records.
-    Assert.assertEquals(hoodieRecords.get(0), queue.iterator().next().record);
-    Assert.assertEquals(hoodieRecords.get(1), queue.iterator().next().record);
+    assertEquals(hoodieRecords.get(0), queue.iterator().next().record);
+    assertEquals(hoodieRecords.get(1), queue.iterator().next().record);
 
     // waiting for permits to expire.
     while (!isQueueFull(queue.rateLimiter)) {
@@ -245,17 +251,18 @@ public class TestBoundedInMemoryQueue extends HoodieClientTestHarness {
     // No change is expected in rate limit or number of queued records. We only expect
     // queueing thread to read
     // 2 more records into the queue.
-    Assert.assertEquals(0, queue.rateLimiter.availablePermits());
-    Assert.assertEquals(recordLimit, queue.currentRateLimit);
-    Assert.assertEquals(recordLimit, queue.size());
-    Assert.assertEquals(recordLimit - 1 + 2, queue.samplingRecordCounter.get());
+    assertEquals(0, queue.rateLimiter.availablePermits());
+    assertEquals(recordLimit, queue.currentRateLimit);
+    assertEquals(recordLimit, queue.size());
+    assertEquals(recordLimit - 1 + 2, queue.samplingRecordCounter.get());
   }
 
   // Test to ensure that exception in either queueing thread or BufferedIterator-reader thread
   // is propagated to
   // another thread.
   @SuppressWarnings("unchecked")
-  @Test(timeout = 60000)
+  @Test
+  @Timeout(value = 60)
   public void testException() throws Exception {
     final int numRecords = 256;
     final List<HoodieRecord> hoodieRecords = dataGen.generateInserts(instantTime, numRecords);
@@ -285,13 +292,10 @@ public class TestBoundedInMemoryQueue extends HoodieClientTestHarness {
     // notify queueing thread of an exception and ensure that it exits.
     final Exception e = new Exception("Failing it :)");
     queue1.markAsFailed(e);
-    try {
-      resFuture.get();
-      Assert.fail("exception is expected");
-    } catch (ExecutionException e1) {
-      Assert.assertEquals(HoodieException.class, e1.getCause().getClass());
-      Assert.assertEquals(e, e1.getCause().getCause());
-    }
+    final Throwable thrown1 = assertThrows(ExecutionException.class, resFuture::get,
+        "exception is expected");
+    assertEquals(HoodieException.class, thrown1.getCause().getClass());
+    assertEquals(e, thrown1.getCause().getCause());
 
     // second let us raise an exception while doing record queueing. this exception should get
     // propagated to
@@ -314,19 +318,14 @@ public class TestBoundedInMemoryQueue extends HoodieClientTestHarness {
       return true;
     });
 
-    try {
+    final Throwable thrown2 = assertThrows(Exception.class, () -> {
       queue2.iterator().hasNext();
-      Assert.fail("exception is expected");
-    } catch (Exception e1) {
-      Assert.assertEquals(expectedException, e1.getCause());
-    }
+    }, "exception is expected");
+    assertEquals(expectedException, thrown2.getCause());
     // queueing thread should also have exited. make sure that it is not running.
-    try {
-      res.get();
-      Assert.fail("exception is expected");
-    } catch (ExecutionException e2) {
-      Assert.assertEquals(expectedException, e2.getCause());
-    }
+    final Throwable thrown3 = assertThrows(ExecutionException.class, res::get,
+        "exception is expected");
+    assertEquals(expectedException, thrown3.getCause());
   }
 
   private boolean isQueueFull(Semaphore rateLimiter) {

--- a/hudi-client/src/test/java/org/apache/hudi/index/TestHBaseQPSResourceAllocator.java
+++ b/hudi-client/src/test/java/org/apache/hudi/index/TestHBaseQPSResourceAllocator.java
@@ -32,19 +32,20 @@ import org.apache.hudi.index.hbase.HBaseIndexQPSResourceAllocator;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseTestingUtility;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestHBaseQPSResourceAllocator extends HoodieClientTestHarness {
 
-  private static String tableName = "test_table";
+  private static final String TABLE_NAME = "test_table";
+  private static final String QPS_TEST_SUFFIX_PATH = "qps_test_suffix";
   private HBaseTestingUtility utility;
   private Configuration hbaseConfig;
-  private static String QPS_TEST_SUFFIX_PATH = "qps_test_suffix";
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     utility = new HBaseTestingUtility();
     utility.startMiniCluster();
@@ -52,12 +53,12 @@ public class TestHBaseQPSResourceAllocator extends HoodieClientTestHarness {
     initSparkContexts("TestQPSResourceAllocator");
 
     initPath();
-    basePath = folder.getRoot().getAbsolutePath() + QPS_TEST_SUFFIX_PATH;
+    basePath = tempDir.resolve(QPS_TEST_SUFFIX_PATH).toAbsolutePath().toString();
     // Initialize table
     initMetaClient();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     cleanupSparkContexts();
     cleanupMetaClient();
@@ -71,9 +72,9 @@ public class TestHBaseQPSResourceAllocator extends HoodieClientTestHarness {
     HoodieWriteConfig config = getConfig(Option.empty());
     HBaseIndex index = new HBaseIndex(config);
     HBaseIndexQPSResourceAllocator hBaseIndexQPSResourceAllocator = index.createQPSResourceAllocator(config);
-    Assert.assertEquals(hBaseIndexQPSResourceAllocator.getClass().getName(),
+    assertEquals(hBaseIndexQPSResourceAllocator.getClass().getName(),
         DefaultHBaseQPSResourceAllocator.class.getName());
-    Assert.assertEquals(config.getHbaseIndexQPSFraction(),
+    assertEquals(config.getHbaseIndexQPSFraction(),
         hBaseIndexQPSResourceAllocator.acquireQPSResources(config.getHbaseIndexQPSFraction(), 100), 0.0f);
   }
 
@@ -82,9 +83,9 @@ public class TestHBaseQPSResourceAllocator extends HoodieClientTestHarness {
     HoodieWriteConfig config = getConfig(Option.of(HoodieHBaseIndexConfig.DEFAULT_HBASE_INDEX_QPS_ALLOCATOR_CLASS));
     HBaseIndex index = new HBaseIndex(config);
     HBaseIndexQPSResourceAllocator hBaseIndexQPSResourceAllocator = index.createQPSResourceAllocator(config);
-    Assert.assertEquals(hBaseIndexQPSResourceAllocator.getClass().getName(),
+    assertEquals(hBaseIndexQPSResourceAllocator.getClass().getName(),
         DefaultHBaseQPSResourceAllocator.class.getName());
-    Assert.assertEquals(config.getHbaseIndexQPSFraction(),
+    assertEquals(config.getHbaseIndexQPSFraction(),
         hBaseIndexQPSResourceAllocator.acquireQPSResources(config.getHbaseIndexQPSFraction(), 100), 0.0f);
   }
 
@@ -93,9 +94,9 @@ public class TestHBaseQPSResourceAllocator extends HoodieClientTestHarness {
     HoodieWriteConfig config = getConfig(Option.of("InvalidResourceAllocatorClassName"));
     HBaseIndex index = new HBaseIndex(config);
     HBaseIndexQPSResourceAllocator hBaseIndexQPSResourceAllocator = index.createQPSResourceAllocator(config);
-    Assert.assertEquals(hBaseIndexQPSResourceAllocator.getClass().getName(),
+    assertEquals(hBaseIndexQPSResourceAllocator.getClass().getName(),
         DefaultHBaseQPSResourceAllocator.class.getName());
-    Assert.assertEquals(config.getHbaseIndexQPSFraction(),
+    assertEquals(config.getHbaseIndexQPSFraction(),
         hBaseIndexQPSResourceAllocator.acquireQPSResources(config.getHbaseIndexQPSFraction(), 100), 0.0f);
   }
 
@@ -117,7 +118,7 @@ public class TestHBaseQPSResourceAllocator extends HoodieClientTestHarness {
   private HoodieHBaseIndexConfig getConfigWithResourceAllocator(Option<String> resourceAllocatorClass) {
     HoodieHBaseIndexConfig.Builder builder = new HoodieHBaseIndexConfig.Builder()
         .hbaseZkPort(Integer.parseInt(hbaseConfig.get("hbase.zookeeper.property.clientPort")))
-        .hbaseZkQuorum(hbaseConfig.get("hbase.zookeeper.quorum")).hbaseTableName(tableName).hbaseIndexGetBatchSize(100);
+        .hbaseZkQuorum(hbaseConfig.get("hbase.zookeeper.quorum")).hbaseTableName(TABLE_NAME).hbaseIndexGetBatchSize(100);
     if (resourceAllocatorClass.isPresent()) {
       builder.withQPSResourceAllocatorType(resourceAllocatorClass.get());
     }

--- a/hudi-client/src/test/java/org/apache/hudi/index/bloom/TestHoodieGlobalBloomIndex.java
+++ b/hudi-client/src/test/java/org/apache/hudi/index/bloom/TestHoodieGlobalBloomIndex.java
@@ -36,12 +36,14 @@ import org.apache.hudi.table.HoodieTable;
 import org.apache.avro.Schema;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaRDD;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -53,12 +55,12 @@ import java.util.stream.Collectors;
 
 import scala.Tuple2;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestHoodieGlobalBloomIndex extends HoodieClientTestHarness {
 
@@ -67,7 +69,7 @@ public class TestHoodieGlobalBloomIndex extends HoodieClientTestHarness {
   public TestHoodieGlobalBloomIndex() {
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     initSparkContexts("TestHoodieGlobalBloomIndex");
     initPath();
@@ -77,7 +79,7 @@ public class TestHoodieGlobalBloomIndex extends HoodieClientTestHarness {
     initMetaClient();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     cleanupSparkContexts();
     cleanupMetaClient();
@@ -93,12 +95,12 @@ public class TestHoodieGlobalBloomIndex extends HoodieClientTestHarness {
     // "2016/04/01": 1 file (2_0_20160401010101.parquet)
     // "2015/03/12": 3 files (1_0_20150312101010.parquet, 3_0_20150312101010.parquet,
     // 4_0_20150312101010.parquet)
-    new File(basePath + "/2016/01/21").mkdirs();
-    new File(basePath + "/2016/01/21/" + HoodiePartitionMetadata.HOODIE_PARTITION_METAFILE).createNewFile();
-    new File(basePath + "/2016/04/01").mkdirs();
-    new File(basePath + "/2016/04/01/" + HoodiePartitionMetadata.HOODIE_PARTITION_METAFILE).createNewFile();
-    new File(basePath + "/2015/03/12").mkdirs();
-    new File(basePath + "/2015/03/12/" + HoodiePartitionMetadata.HOODIE_PARTITION_METAFILE).createNewFile();
+    Path dir1 = Files.createDirectories(Paths.get(basePath, "2016", "01", "21"));
+    Files.createFile(dir1.resolve(HoodiePartitionMetadata.HOODIE_PARTITION_METAFILE));
+    Path dir2 = Files.createDirectories(Paths.get(basePath, "2016", "04", "01"));
+    Files.createFile(dir2.resolve(HoodiePartitionMetadata.HOODIE_PARTITION_METAFILE));
+    Path dir3 = Files.createDirectories(Paths.get(basePath, "2015", "03", "12"));
+    Files.createFile(dir3.resolve(HoodiePartitionMetadata.HOODIE_PARTITION_METAFILE));
 
     TestRawTripPayload rowChange1 =
         new TestRawTripPayload("{\"_row_key\":\"000\",\"time\":\"2016-01-31T03:16:41.415Z\",\"number\":12}");
@@ -133,16 +135,16 @@ public class TestHoodieGlobalBloomIndex extends HoodieClientTestHarness {
     // partitions will NOT be respected by this loadInvolvedFiles(...) call
     List<Tuple2<String, BloomIndexFileInfo>> filesList = index.loadInvolvedFiles(partitions, jsc, table);
     // Still 0, as no valid commit
-    assertEquals(filesList.size(), 0);
+    assertEquals(0, filesList.size());
 
     // Add some commits
-    new File(basePath + "/.hoodie").mkdirs();
-    new File(basePath + "/.hoodie/20160401010101.commit").createNewFile();
-    new File(basePath + "/.hoodie/20150312101010.commit").createNewFile();
+    Path hoodieDir = Files.createDirectories(Paths.get(basePath, ".hoodie"));
+    Files.createFile(hoodieDir.resolve("20160401010101.commit"));
+    Files.createFile(hoodieDir.resolve("20150312101010.commit"));
 
     table = HoodieTable.create(metaClient, config, jsc);
     filesList = index.loadInvolvedFiles(partitions, jsc, table);
-    assertEquals(filesList.size(), 4);
+    assertEquals(4, filesList.size());
 
     Map<String, BloomIndexFileInfo> filesMap = toFileMap(filesList);
     // key ranges checks
@@ -213,12 +215,12 @@ public class TestHoodieGlobalBloomIndex extends HoodieClientTestHarness {
     // "2016/04/01": 1 file (2_0_20160401010101.parquet)
     // "2015/03/12": 3 files (1_0_20150312101010.parquet, 3_0_20150312101010.parquet,
     // 4_0_20150312101010.parquet)
-    new File(basePath + "/2016/01/21").mkdirs();
-    new File(basePath + "/2016/01/21/" + HoodiePartitionMetadata.HOODIE_PARTITION_METAFILE).createNewFile();
-    new File(basePath + "/2016/04/01").mkdirs();
-    new File(basePath + "/2016/04/01/" + HoodiePartitionMetadata.HOODIE_PARTITION_METAFILE).createNewFile();
-    new File(basePath + "/2015/03/12").mkdirs();
-    new File(basePath + "/2015/03/12/" + HoodiePartitionMetadata.HOODIE_PARTITION_METAFILE).createNewFile();
+    Path dir1 = Files.createDirectories(Paths.get(basePath, "2016", "01", "21"));
+    Files.createFile(dir1.resolve(HoodiePartitionMetadata.HOODIE_PARTITION_METAFILE));
+    Path dir2 = Files.createDirectories(Paths.get(basePath, "2016", "04", "01"));
+    Files.createFile(dir2.resolve(HoodiePartitionMetadata.HOODIE_PARTITION_METAFILE));
+    Path dir3 = Files.createDirectories(Paths.get(basePath, "2015", "03", "12"));
+    Files.createFile(dir3.resolve(HoodiePartitionMetadata.HOODIE_PARTITION_METAFILE));
 
     TestRawTripPayload rowChange1 =
         new TestRawTripPayload("{\"_row_key\":\"000\",\"time\":\"2016-01-31T03:16:41.415Z\",\"number\":12}");
@@ -262,7 +264,7 @@ public class TestHoodieGlobalBloomIndex extends HoodieClientTestHarness {
     HoodieTable table = HoodieTable.create(metaClient, config, jsc);
 
     // Add some commits
-    new File(basePath + "/.hoodie").mkdirs();
+    Files.createDirectories(Paths.get(basePath, ".hoodie"));
 
     // partitions will NOT be respected by this loadInvolvedFiles(...) call
     JavaRDD<HoodieRecord> taggedRecordRDD = index.tagLocation(recordRDD, jsc, table);
@@ -305,8 +307,8 @@ public class TestHoodieGlobalBloomIndex extends HoodieClientTestHarness {
 
     // Create the original partition, and put a record, along with the meta file
     // "2016/01/31": 1 file (1_0_20160131101010.parquet)
-    new File(basePath + "/2016/01/31").mkdirs();
-    new File(basePath + "/2016/01/31/" + HoodiePartitionMetadata.HOODIE_PARTITION_METAFILE).createNewFile();
+    Path dir = Files.createDirectories(Paths.get(basePath, "2016", "01", "31"));
+    Files.createFile(dir.resolve(HoodiePartitionMetadata.HOODIE_PARTITION_METAFILE));
 
     // this record will be saved in table and will be tagged to an empty record
     TestRawTripPayload originalPayload =
@@ -347,7 +349,7 @@ public class TestHoodieGlobalBloomIndex extends HoodieClientTestHarness {
     HoodieTable table = HoodieTable.create(metaClient, config, jsc);
 
     // Add some commits
-    new File(basePath + "/.hoodie").mkdirs();
+    Files.createDirectories(Paths.get(basePath, ".hoodie"));
 
     // test against incoming record with a different partition
     JavaRDD<HoodieRecord> recordRDD = jsc.parallelize(Collections.singletonList(incomingRecord));

--- a/hudi-client/src/test/java/org/apache/hudi/io/TestHoodieCommitArchiveLog.java
+++ b/hudi-client/src/test/java/org/apache/hudi/io/TestHoodieCommitArchiveLog.java
@@ -35,9 +35,9 @@ import org.apache.hudi.table.HoodieTimelineArchiveLog;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -47,16 +47,16 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestHoodieCommitArchiveLog extends HoodieClientTestHarness {
 
   private Configuration hadoopConf;
   private HoodieTableMetaClient metaClient;
 
-  @Before
+  @BeforeEach
   public void init() throws Exception {
     initDFS();
     initPath();
@@ -67,7 +67,7 @@ public class TestHoodieCommitArchiveLog extends HoodieClientTestHarness {
     metaClient = HoodieTestUtils.init(hadoopConf, basePath);
   }
 
-  @After
+  @AfterEach
   public void clean() throws IOException {
     cleanupDFS();
     cleanupSparkContexts();
@@ -137,7 +137,7 @@ public class TestHoodieCommitArchiveLog extends HoodieClientTestHarness {
     metaClient = HoodieTableMetaClient.reload(metaClient);
     HoodieTimeline timeline = metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants();
 
-    assertEquals("Loaded 6 commits and the count should match", 6, timeline.countInstants());
+    assertEquals(6, timeline.countInstants(), "Loaded 6 commits and the count should match");
 
     HoodieTestUtils.createCleanFiles(metaClient, basePath, "100", dfs.getConf());
     HoodieTestUtils.createCleanFiles(metaClient, basePath, "101", dfs.getConf());
@@ -151,7 +151,7 @@ public class TestHoodieCommitArchiveLog extends HoodieClientTestHarness {
     timeline = metaClient.getActiveTimeline().reload().getAllCommitsTimeline().filterCompletedInstants();
     List<HoodieInstant> originalCommits = timeline.getInstants().collect(Collectors.toList());
 
-    assertEquals("Loaded 6 commits and the count should match", 12, timeline.countInstants());
+    assertEquals(12, timeline.countInstants(), "Loaded 6 commits and the count should match");
 
     // verify in-flight instants before archive
     verifyInflightInstants(metaClient, 2);
@@ -168,42 +168,42 @@ public class TestHoodieCommitArchiveLog extends HoodieClientTestHarness {
     // Check compaction instants
     List<HoodieInstant> instants = metaClient.scanHoodieInstantsFromFileSystem(
         new Path(metaClient.getMetaAuxiliaryPath()), HoodieActiveTimeline.VALID_EXTENSIONS_IN_ACTIVE_TIMELINE, false);
-    assertEquals("Should delete all compaction instants < 104", 4, instants.size());
-    assertFalse("Requested Compaction must be absent for 100",
-        instants.contains(new HoodieInstant(State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, "100")));
-    assertFalse("Inflight Compaction must be absent for 100",
-        instants.contains(new HoodieInstant(State.INFLIGHT, HoodieTimeline.COMPACTION_ACTION, "100")));
-    assertFalse("Requested Compaction must be absent for 101",
-        instants.contains(new HoodieInstant(State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, "101")));
-    assertFalse("Inflight Compaction must be absent for 101",
-        instants.contains(new HoodieInstant(State.INFLIGHT, HoodieTimeline.COMPACTION_ACTION, "101")));
-    assertFalse("Requested Compaction must be absent for 102",
-        instants.contains(new HoodieInstant(State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, "102")));
-    assertFalse("Inflight Compaction must be absent for 102",
-        instants.contains(new HoodieInstant(State.INFLIGHT, HoodieTimeline.COMPACTION_ACTION, "102")));
-    assertFalse("Requested Compaction must be absent for 103",
-        instants.contains(new HoodieInstant(State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, "103")));
-    assertFalse("Inflight Compaction must be absent for 103",
-        instants.contains(new HoodieInstant(State.INFLIGHT, HoodieTimeline.COMPACTION_ACTION, "103")));
-    assertTrue("Requested Compaction must be present for 104",
-        instants.contains(new HoodieInstant(State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, "104")));
-    assertTrue("Inflight Compaction must be present for 104",
-        instants.contains(new HoodieInstant(State.INFLIGHT, HoodieTimeline.COMPACTION_ACTION, "104")));
-    assertTrue("Requested Compaction must be present for 105",
-        instants.contains(new HoodieInstant(State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, "105")));
-    assertTrue("Inflight Compaction must be present for 105",
-        instants.contains(new HoodieInstant(State.INFLIGHT, HoodieTimeline.COMPACTION_ACTION, "105")));
+    assertEquals(4, instants.size(), "Should delete all compaction instants < 104");
+    assertFalse(instants.contains(new HoodieInstant(State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, "100")),
+        "Requested Compaction must be absent for 100");
+    assertFalse(instants.contains(new HoodieInstant(State.INFLIGHT, HoodieTimeline.COMPACTION_ACTION, "100")),
+        "Inflight Compaction must be absent for 100");
+    assertFalse(instants.contains(new HoodieInstant(State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, "101")),
+        "Requested Compaction must be absent for 101");
+    assertFalse(instants.contains(new HoodieInstant(State.INFLIGHT, HoodieTimeline.COMPACTION_ACTION, "101")),
+        "Inflight Compaction must be absent for 101");
+    assertFalse(instants.contains(new HoodieInstant(State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, "102")),
+        "Requested Compaction must be absent for 102");
+    assertFalse(instants.contains(new HoodieInstant(State.INFLIGHT, HoodieTimeline.COMPACTION_ACTION, "102")),
+        "Inflight Compaction must be absent for 102");
+    assertFalse(instants.contains(new HoodieInstant(State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, "103")),
+        "Requested Compaction must be absent for 103");
+    assertFalse(instants.contains(new HoodieInstant(State.INFLIGHT, HoodieTimeline.COMPACTION_ACTION, "103")),
+        "Inflight Compaction must be absent for 103");
+    assertTrue(instants.contains(new HoodieInstant(State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, "104")),
+        "Requested Compaction must be present for 104");
+    assertTrue(instants.contains(new HoodieInstant(State.INFLIGHT, HoodieTimeline.COMPACTION_ACTION, "104")),
+        "Inflight Compaction must be present for 104");
+    assertTrue(instants.contains(new HoodieInstant(State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, "105")),
+        "Requested Compaction must be present for 105");
+    assertTrue(instants.contains(new HoodieInstant(State.INFLIGHT, HoodieTimeline.COMPACTION_ACTION, "105")),
+        "Inflight Compaction must be present for 105");
 
     // read the file
     HoodieArchivedTimeline archivedTimeline = new HoodieArchivedTimeline(metaClient);
-    assertEquals("Total archived records and total read records are the same count",
-            24, archivedTimeline.countInstants());
+    assertEquals(24, archivedTimeline.countInstants(),
+        "Total archived records and total read records are the same count");
 
     //make sure the archived commits are the same as the (originalcommits - commitsleft)
     Set<String> readCommits =
-            archivedTimeline.getInstants().map(HoodieInstant::getTimestamp).collect(Collectors.toSet());
-    assertEquals("Read commits map should match the originalCommits - commitsLoadedFromArchival",
-            originalCommits.stream().map(HoodieInstant::getTimestamp).collect(Collectors.toSet()), readCommits);
+        archivedTimeline.getInstants().map(HoodieInstant::getTimestamp).collect(Collectors.toSet());
+    assertEquals(originalCommits.stream().map(HoodieInstant::getTimestamp).collect(Collectors.toSet()), readCommits,
+        "Read commits map should match the originalCommits - commitsLoadedFromArchival");
 
     // verify in-flight instants after archive
     verifyInflightInstants(metaClient, 2);
@@ -247,31 +247,31 @@ public class TestHoodieCommitArchiveLog extends HoodieClientTestHarness {
     HoodieTestDataGenerator.createCommitFile(basePath, "103", dfs.getConf());
 
     HoodieTimeline timeline = metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants();
-    assertEquals("Loaded 4 commits and the count should match", 4, timeline.countInstants());
+    assertEquals(4, timeline.countInstants(), "Loaded 4 commits and the count should match");
     boolean result = archiveLog.archiveIfRequired(jsc);
     assertTrue(result);
     timeline = metaClient.getActiveTimeline().reload().getCommitsTimeline().filterCompletedInstants();
-    assertEquals("Should not archive commits when maxCommitsToKeep is 5", 4, timeline.countInstants());
+    assertEquals(4, timeline.countInstants(), "Should not archive commits when maxCommitsToKeep is 5");
 
     List<HoodieInstant> instants = metaClient.scanHoodieInstantsFromFileSystem(
         new Path(metaClient.getMetaAuxiliaryPath()), HoodieActiveTimeline.VALID_EXTENSIONS_IN_ACTIVE_TIMELINE, false);
-    assertEquals("Should not delete any aux compaction files when maxCommitsToKeep is 5", 8, instants.size());
-    assertTrue("Requested Compaction must be present for 100",
-        instants.contains(new HoodieInstant(State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, "100")));
-    assertTrue("Inflight Compaction must be present for 100",
-        instants.contains(new HoodieInstant(State.INFLIGHT, HoodieTimeline.COMPACTION_ACTION, "100")));
-    assertTrue("Requested Compaction must be present for 101",
-        instants.contains(new HoodieInstant(State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, "101")));
-    assertTrue("Inflight Compaction must be present for 101",
-        instants.contains(new HoodieInstant(State.INFLIGHT, HoodieTimeline.COMPACTION_ACTION, "101")));
-    assertTrue("Requested Compaction must be present for 102",
-        instants.contains(new HoodieInstant(State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, "102")));
-    assertTrue("Inflight Compaction must be present for 102",
-        instants.contains(new HoodieInstant(State.INFLIGHT, HoodieTimeline.COMPACTION_ACTION, "102")));
-    assertTrue("Requested Compaction must be present for 103",
-        instants.contains(new HoodieInstant(State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, "103")));
-    assertTrue("Inflight Compaction must be present for 103",
-        instants.contains(new HoodieInstant(State.INFLIGHT, HoodieTimeline.COMPACTION_ACTION, "103")));
+    assertEquals(8, instants.size(), "Should not delete any aux compaction files when maxCommitsToKeep is 5");
+    assertTrue(instants.contains(new HoodieInstant(State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, "100")),
+        "Requested Compaction must be present for 100");
+    assertTrue(instants.contains(new HoodieInstant(State.INFLIGHT, HoodieTimeline.COMPACTION_ACTION, "100")),
+        "Inflight Compaction must be present for 100");
+    assertTrue(instants.contains(new HoodieInstant(State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, "101")),
+        "Requested Compaction must be present for 101");
+    assertTrue(instants.contains(new HoodieInstant(State.INFLIGHT, HoodieTimeline.COMPACTION_ACTION, "101")),
+        "Inflight Compaction must be present for 101");
+    assertTrue(instants.contains(new HoodieInstant(State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, "102")),
+        "Requested Compaction must be present for 102");
+    assertTrue(instants.contains(new HoodieInstant(State.INFLIGHT, HoodieTimeline.COMPACTION_ACTION, "102")),
+        "Inflight Compaction must be present for 102");
+    assertTrue(instants.contains(new HoodieInstant(State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, "103")),
+        "Requested Compaction must be present for 103");
+    assertTrue(instants.contains(new HoodieInstant(State.INFLIGHT, HoodieTimeline.COMPACTION_ACTION, "103")),
+        "Inflight Compaction must be present for 103");
   }
 
   @Test
@@ -290,14 +290,14 @@ public class TestHoodieCommitArchiveLog extends HoodieClientTestHarness {
     HoodieTestDataGenerator.createCommitFile(basePath, "105", dfs.getConf());
 
     HoodieTimeline timeline = metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants();
-    assertEquals("Loaded 6 commits and the count should match", 6, timeline.countInstants());
+    assertEquals(6, timeline.countInstants(), "Loaded 6 commits and the count should match");
     boolean result = archiveLog.archiveIfRequired(jsc);
     assertTrue(result);
     timeline = metaClient.getActiveTimeline().reload().getCommitsTimeline().filterCompletedInstants();
-    assertTrue("Archived commits should always be safe", timeline.containsOrBeforeTimelineStarts("100"));
-    assertTrue("Archived commits should always be safe", timeline.containsOrBeforeTimelineStarts("101"));
-    assertTrue("Archived commits should always be safe", timeline.containsOrBeforeTimelineStarts("102"));
-    assertTrue("Archived commits should always be safe", timeline.containsOrBeforeTimelineStarts("103"));
+    assertTrue(timeline.containsOrBeforeTimelineStarts("100"), "Archived commits should always be safe");
+    assertTrue(timeline.containsOrBeforeTimelineStarts("101"), "Archived commits should always be safe");
+    assertTrue(timeline.containsOrBeforeTimelineStarts("102"), "Archived commits should always be safe");
+    assertTrue(timeline.containsOrBeforeTimelineStarts("103"), "Archived commits should always be safe");
   }
 
   @Test
@@ -317,19 +317,18 @@ public class TestHoodieCommitArchiveLog extends HoodieClientTestHarness {
     HoodieTestDataGenerator.createCommitFile(basePath, "105", dfs.getConf());
 
     HoodieTimeline timeline = metaClient.getActiveTimeline().getCommitsTimeline().filterCompletedInstants();
-    assertEquals("Loaded 6 commits and the count should match", 6, timeline.countInstants());
+    assertEquals(6, timeline.countInstants(), "Loaded 6 commits and the count should match");
     boolean result = archiveLog.archiveIfRequired(jsc);
     assertTrue(result);
     timeline = metaClient.getActiveTimeline().reload().getCommitsTimeline().filterCompletedInstants();
-    assertEquals(
-        "Since we have a savepoint at 101, we should never archive any commit after 101 (we only archive 100)", 5,
-        timeline.countInstants());
-    assertTrue("Archived commits should always be safe",
-        timeline.containsInstant(new HoodieInstant(false, HoodieTimeline.COMMIT_ACTION, "101")));
-    assertTrue("Archived commits should always be safe",
-        timeline.containsInstant(new HoodieInstant(false, HoodieTimeline.COMMIT_ACTION, "102")));
-    assertTrue("Archived commits should always be safe",
-        timeline.containsInstant(new HoodieInstant(false, HoodieTimeline.COMMIT_ACTION, "103")));
+    assertEquals(5, timeline.countInstants(),
+        "Since we have a savepoint at 101, we should never archive any commit after 101 (we only archive 100)");
+    assertTrue(timeline.containsInstant(new HoodieInstant(false, HoodieTimeline.COMMIT_ACTION, "101")),
+        "Archived commits should always be safe");
+    assertTrue(timeline.containsInstant(new HoodieInstant(false, HoodieTimeline.COMMIT_ACTION, "102")),
+        "Archived commits should always be safe");
+    assertTrue(timeline.containsInstant(new HoodieInstant(false, HoodieTimeline.COMMIT_ACTION, "103")),
+        "Archived commits should always be safe");
   }
 
   @Test
@@ -354,28 +353,29 @@ public class TestHoodieCommitArchiveLog extends HoodieClientTestHarness {
     HoodieTestDataGenerator.createCommitFile(basePath, "107", dfs.getConf());
 
     HoodieTimeline timeline = metaClient.getActiveTimeline().getCommitsAndCompactionTimeline();
-    assertEquals("Loaded 6 commits and the count should match", 8, timeline.countInstants());
+    assertEquals(8, timeline.countInstants(), "Loaded 6 commits and the count should match");
     boolean result = archiveLog.archiveIfRequired(jsc);
     assertTrue(result);
     timeline = metaClient.getActiveTimeline().reload().getCommitsAndCompactionTimeline();
-    assertFalse("Instants before oldest pending compaction can be removed",
-        timeline.containsInstant(new HoodieInstant(false, HoodieTimeline.COMMIT_ACTION, "100")));
-    assertEquals("Since we have a pending compaction at 101, we should never archive any commit "
-        + "after 101 (we only archive 100)", 7, timeline.countInstants());
-    assertTrue("Requested Compaction must still be present",
-        timeline.containsInstant(new HoodieInstant(State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, "101")));
-    assertTrue("Instants greater than oldest pending compaction must be present",
-        timeline.containsInstant(new HoodieInstant(false, HoodieTimeline.COMMIT_ACTION, "102")));
-    assertTrue("Instants greater than oldest pending compaction must be present",
-        timeline.containsInstant(new HoodieInstant(false, HoodieTimeline.COMMIT_ACTION, "103")));
-    assertTrue("Instants greater than oldest pending compaction must be present",
-        timeline.containsInstant(new HoodieInstant(State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, "104")));
-    assertTrue("Instants greater than oldest pending compaction must be present",
-        timeline.containsInstant(new HoodieInstant(false, HoodieTimeline.COMMIT_ACTION, "105")));
-    assertTrue("Instants greater than oldest pending compaction must be present",
-        timeline.containsInstant(new HoodieInstant(false, HoodieTimeline.COMMIT_ACTION, "106")));
-    assertTrue("Instants greater than oldest pending compaction must be present",
-        timeline.containsInstant(new HoodieInstant(false, HoodieTimeline.COMMIT_ACTION, "107")));
+    assertFalse(timeline.containsInstant(new HoodieInstant(false, HoodieTimeline.COMMIT_ACTION, "100")),
+        "Instants before oldest pending compaction can be removed");
+    assertEquals(7, timeline.countInstants(),
+        "Since we have a pending compaction at 101, we should never archive any commit "
+            + "after 101 (we only archive 100)");
+    assertTrue(timeline.containsInstant(new HoodieInstant(State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, "101")),
+        "Requested Compaction must still be present");
+    assertTrue(timeline.containsInstant(new HoodieInstant(false, HoodieTimeline.COMMIT_ACTION, "102")),
+        "Instants greater than oldest pending compaction must be present");
+    assertTrue(timeline.containsInstant(new HoodieInstant(false, HoodieTimeline.COMMIT_ACTION, "103")),
+        "Instants greater than oldest pending compaction must be present");
+    assertTrue(timeline.containsInstant(new HoodieInstant(State.REQUESTED, HoodieTimeline.COMPACTION_ACTION, "104")),
+        "Instants greater than oldest pending compaction must be present");
+    assertTrue(timeline.containsInstant(new HoodieInstant(false, HoodieTimeline.COMMIT_ACTION, "105")),
+        "Instants greater than oldest pending compaction must be present");
+    assertTrue(timeline.containsInstant(new HoodieInstant(false, HoodieTimeline.COMMIT_ACTION, "106")),
+        "Instants greater than oldest pending compaction must be present");
+    assertTrue(timeline.containsInstant(new HoodieInstant(false, HoodieTimeline.COMMIT_ACTION, "107")),
+        "Instants greater than oldest pending compaction must be present");
   }
 
   @Test
@@ -412,8 +412,8 @@ public class TestHoodieCommitArchiveLog extends HoodieClientTestHarness {
   private void verifyInflightInstants(HoodieTableMetaClient metaClient, int expectedTotalInstants) {
     HoodieTimeline timeline = metaClient.getActiveTimeline().reload()
         .getTimelineOfActions(Collections.singleton(HoodieTimeline.CLEAN_ACTION)).filterInflights();
-    assertEquals("Loaded inflight clean actions and the count should match", expectedTotalInstants,
-        timeline.countInstants());
+    assertEquals(expectedTotalInstants, timeline.countInstants(),
+        "Loaded inflight clean actions and the count should match");
   }
 
   @Test

--- a/hudi-client/src/test/java/org/apache/hudi/io/TestHoodieMergeHandle.java
+++ b/hudi-client/src/test/java/org/apache/hudi/io/TestHoodieMergeHandle.java
@@ -39,22 +39,23 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings("unchecked")
 public class TestHoodieMergeHandle extends HoodieClientTestHarness {
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     initSparkContexts("TestHoodieMergeHandle");
     initPath();
@@ -63,7 +64,7 @@ public class TestHoodieMergeHandle extends HoodieClientTestHarness {
     initMetaClient();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     cleanupFileSystem();
     cleanupTestDataGenerator();
@@ -110,11 +111,12 @@ public class TestHoodieMergeHandle extends HoodieClientTestHarness {
       // verify that there is a commit
       metaClient = HoodieTableMetaClient.reload(metaClient);
       HoodieTimeline timeline = new HoodieActiveTimeline(metaClient).getCommitTimeline();
-      assertEquals("Expecting a single commit.", 1,
-          timeline.findInstantsAfter("000", Integer.MAX_VALUE).countInstants());
-      Assert.assertEquals("Latest commit should be 001", newCommitTime, timeline.lastInstant().get().getTimestamp());
-      assertEquals("Must contain 44 records", records.size(),
-          HoodieClientTestUtils.readCommit(basePath, sqlContext, timeline, newCommitTime).count());
+      assertEquals(1, timeline.findInstantsAfter("000", Integer.MAX_VALUE).countInstants(),
+          "Expecting a single commit.");
+      assertEquals(newCommitTime, timeline.lastInstant().get().getTimestamp(), "Latest commit should be 001");
+      assertEquals(records.size(),
+          HoodieClientTestUtils.readCommit(basePath, sqlContext, timeline, newCommitTime).count(),
+          "Must contain 44 records");
 
       /**
        * Write 2 (insert) This will do a bulk insert of 1 record with the same row_key as record1 in the previous insert
@@ -135,10 +137,10 @@ public class TestHoodieMergeHandle extends HoodieClientTestHarness {
       // verify that there are 2 commits
       metaClient = HoodieTableMetaClient.reload(metaClient);
       timeline = new HoodieActiveTimeline(metaClient).getCommitTimeline();
-      assertEquals("Expecting two commits.", 2, timeline.findInstantsAfter("000", Integer.MAX_VALUE).countInstants());
-      Assert.assertEquals("Latest commit should be 002", newCommitTime, timeline.lastInstant().get().getTimestamp());
+      assertEquals(2, timeline.findInstantsAfter("000", Integer.MAX_VALUE).countInstants(), "Expecting two commits.");
+      assertEquals(newCommitTime, timeline.lastInstant().get().getTimestamp(), "Latest commit should be 002");
       Dataset<Row> dataSet = getRecords();
-      assertEquals("Must contain 45 records", 45, dataSet.count());
+      assertEquals(45, dataSet.count(), "Must contain 45 records");
 
       /**
        * Write 3 (insert) This will bulk insert 2 new completely new records. At this point, we will have 2 files with
@@ -155,10 +157,10 @@ public class TestHoodieMergeHandle extends HoodieClientTestHarness {
       // verify that there are now 3 commits
       metaClient = HoodieTableMetaClient.reload(metaClient);
       timeline = new HoodieActiveTimeline(metaClient).getCommitTimeline();
-      assertEquals("Expecting three commits.", 3, timeline.findInstantsAfter("000", Integer.MAX_VALUE).countInstants());
-      Assert.assertEquals("Latest commit should be 003", newCommitTime, timeline.lastInstant().get().getTimestamp());
+      assertEquals(3, timeline.findInstantsAfter("000", Integer.MAX_VALUE).countInstants(), "Expecting three commits.");
+      assertEquals(newCommitTime, timeline.lastInstant().get().getTimestamp(), "Latest commit should be 003");
       dataSet = getRecords();
-      assertEquals("Must contain 47 records", 47, dataSet.count());
+      assertEquals(47, dataSet.count(), "Must contain 47 records");
 
       /**
        * Write 4 (updates) This will generate 2 upsert records with id1 and id2. The rider and driver names in the
@@ -185,12 +187,12 @@ public class TestHoodieMergeHandle extends HoodieClientTestHarness {
 
       // verify there are now 4 commits
       timeline = new HoodieActiveTimeline(metaClient).getCommitTimeline();
-      assertEquals("Expecting four commits.", 4, timeline.findInstantsAfter("000", Integer.MAX_VALUE).countInstants());
-      Assert.assertEquals("Latest commit should be 004", timeline.lastInstant().get().getTimestamp(), newCommitTime);
+      assertEquals(4, timeline.findInstantsAfter("000", Integer.MAX_VALUE).countInstants(), "Expecting four commits.");
+      assertEquals(timeline.lastInstant().get().getTimestamp(), newCommitTime, "Latest commit should be 004");
 
       // Check the entire dataset has 47 records still
       dataSet = getRecords();
-      assertEquals("Must contain 47 records", 47, dataSet.count());
+      assertEquals(47, dataSet.count(), "Must contain 47 records");
       Row[] rows = (Row[]) dataSet.collect();
       int record1Count = 0;
       int record2Count = 0;
@@ -233,19 +235,18 @@ public class TestHoodieMergeHandle extends HoodieClientTestHarness {
       List<WriteStatus> statuses = writeClient.insert(recordsRDD, newCommitTime).collect();
 
       // All records should be inserts into new parquet
-      Assert.assertTrue(statuses.stream()
+      assertTrue(statuses.stream()
           .filter(status -> status.getStat().getPrevCommit() != HoodieWriteStat.NULL_COMMIT).count() > 0);
       // Num writes should be equal to the number of records inserted
-      Assert.assertEquals(
-          (long) statuses.stream().map(status -> status.getStat().getNumWrites()).reduce((a, b) -> a + b).get(), 100);
+      assertEquals(100,
+          (long) statuses.stream().map(status -> status.getStat().getNumWrites()).reduce((a, b) -> a + b).get());
       // Num update writes should be equal to the number of records updated
-      Assert.assertEquals(
-          (long) statuses.stream().map(status -> status.getStat().getNumUpdateWrites()).reduce((a, b) -> a + b).get(),
-          0);
+      assertEquals(0,
+          (long) statuses.stream().map(status -> status.getStat().getNumUpdateWrites()).reduce((a, b) -> a + b).get());
       // Num update writes should be equal to the number of insert records converted to updates as part of small file
       // handling
-      Assert.assertEquals(
-          (long) statuses.stream().map(status -> status.getStat().getNumInserts()).reduce((a, b) -> a + b).get(), 100);
+      assertEquals(100,
+          (long) statuses.stream().map(status -> status.getStat().getNumInserts()).reduce((a, b) -> a + b).get());
 
       // Update all the 100 records
       metaClient = HoodieTableMetaClient.reload(metaClient);
@@ -258,20 +259,18 @@ public class TestHoodieMergeHandle extends HoodieClientTestHarness {
       statuses = writeClient.upsert(updatedRecordsRDD, newCommitTime).collect();
 
       // All records should be upserts into existing parquet
-      Assert.assertEquals(
-          statuses.stream().filter(status -> status.getStat().getPrevCommit() == HoodieWriteStat.NULL_COMMIT).count(),
-          0);
+      assertEquals(0,
+          statuses.stream().filter(status -> status.getStat().getPrevCommit() == HoodieWriteStat.NULL_COMMIT).count());
       // Num writes should be equal to the number of records inserted
-      Assert.assertEquals(
-          (long) statuses.stream().map(status -> status.getStat().getNumWrites()).reduce((a, b) -> a + b).get(), 100);
+      assertEquals(100,
+          (long) statuses.stream().map(status -> status.getStat().getNumWrites()).reduce((a, b) -> a + b).get());
       // Num update writes should be equal to the number of records updated
-      Assert.assertEquals(
-          (long) statuses.stream().map(status -> status.getStat().getNumUpdateWrites()).reduce((a, b) -> a + b).get(),
-          100);
+      assertEquals(100,
+          (long) statuses.stream().map(status -> status.getStat().getNumUpdateWrites()).reduce((a, b) -> a + b).get());
       // Num update writes should be equal to the number of insert records converted to updates as part of small file
       // handling
-      Assert.assertEquals(
-          (long) statuses.stream().map(status -> status.getStat().getNumInserts()).reduce((a, b) -> a + b).get(), 0);
+      assertEquals(0,
+          (long) statuses.stream().map(status -> status.getStat().getNumInserts()).reduce((a, b) -> a + b).get());
 
       newCommitTime = "102";
       writeClient.startCommitWithTime(newCommitTime);
@@ -282,24 +281,23 @@ public class TestHoodieMergeHandle extends HoodieClientTestHarness {
       statuses = writeClient.upsert(allRecordsRDD, newCommitTime).collect();
 
       // All records should be upserts into existing parquet (with inserts as updates small file handled)
-      Assert.assertEquals((long) statuses.stream()
-          .filter(status -> status.getStat().getPrevCommit() == HoodieWriteStat.NULL_COMMIT).count(), 0);
+      assertEquals(0, (long) statuses.stream()
+          .filter(status -> status.getStat().getPrevCommit() == HoodieWriteStat.NULL_COMMIT).count());
       // Num writes should be equal to the total number of records written
-      Assert.assertEquals(
-          (long) statuses.stream().map(status -> status.getStat().getNumWrites()).reduce((a, b) -> a + b).get(), 200);
+      assertEquals(200,
+          (long) statuses.stream().map(status -> status.getStat().getNumWrites()).reduce((a, b) -> a + b).get());
       // Num update writes should be equal to the number of records updated (including inserts converted as updates)
-      Assert.assertEquals(
-          (long) statuses.stream().map(status -> status.getStat().getNumUpdateWrites()).reduce((a, b) -> a + b).get(),
-          100);
+      assertEquals(100,
+          (long) statuses.stream().map(status -> status.getStat().getNumUpdateWrites()).reduce((a, b) -> a + b).get());
       // Num update writes should be equal to the number of insert records converted to updates as part of small file
       // handling
-      Assert.assertEquals(
-          (long) statuses.stream().map(status -> status.getStat().getNumInserts()).reduce((a, b) -> a + b).get(), 100);
+      assertEquals(100,
+          (long) statuses.stream().map(status -> status.getStat().getNumInserts()).reduce((a, b) -> a + b).get());
       // Verify all records have location set
       statuses.forEach(writeStatus -> {
         writeStatus.getWrittenRecords().forEach(r -> {
           // Ensure New Location is set
-          Assert.assertTrue(r.getNewLocation().isPresent());
+          assertTrue(r.getNewLocation().isPresent());
         });
       });
     }
@@ -309,7 +307,7 @@ public class TestHoodieMergeHandle extends HoodieClientTestHarness {
     // Check the entire dataset has 8 records still
     String[] fullPartitionPaths = new String[dataGen.getPartitionPaths().length];
     for (int i = 0; i < fullPartitionPaths.length; i++) {
-      fullPartitionPaths[i] = String.format("%s/%s/*", basePath, dataGen.getPartitionPaths()[i]);
+      fullPartitionPaths[i] = Paths.get(basePath, dataGen.getPartitionPaths()[i], "*").toString();
     }
     Dataset<Row> dataSet = HoodieClientTestUtils.read(jsc, basePath, sqlContext, fs, fullPartitionPaths);
     return dataSet;
@@ -323,7 +321,7 @@ public class TestHoodieMergeHandle extends HoodieClientTestHarness {
   void assertNoWriteErrors(List<WriteStatus> statuses) {
     // Verify there are no errors
     for (WriteStatus status : statuses) {
-      assertFalse("Errors found in write of " + status.getFileId(), status.hasErrors());
+      assertFalse(status.hasErrors(), "Errors found in write of " + status.getFileId());
     }
   }
 

--- a/hudi-client/src/test/java/org/apache/hudi/io/storage/TestHoodieStorageWriterFactory.java
+++ b/hudi-client/src/test/java/org/apache/hudi/io/storage/TestHoodieStorageWriterFactory.java
@@ -26,12 +26,12 @@ import org.apache.hudi.table.HoodieTable;
 
 import org.apache.avro.generic.IndexedRecord;
 import org.apache.hadoop.fs.Path;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for {@link HoodieStorageWriterFactory}.
@@ -48,17 +48,14 @@ public class TestHoodieStorageWriterFactory extends TestHoodieClientBase {
     SparkTaskContextSupplier supplier = new SparkTaskContextSupplier();
     HoodieStorageWriter<IndexedRecord> parquetWriter = HoodieStorageWriterFactory.getStorageWriter(instantTime,
         parquetPath, table, cfg, HoodieTestDataGenerator.AVRO_SCHEMA, supplier);
-    Assert.assertTrue(parquetWriter instanceof HoodieParquetWriter);
+    assertTrue(parquetWriter instanceof HoodieParquetWriter);
 
     // other file format exception.
     final Path logPath = new Path(basePath + "/partition/path/f.b51192a8-574b-4a85-b246-bcfec03ac8bf_100.log.2_1-0-1");
-    try {
+    final Throwable thrown = assertThrows(UnsupportedOperationException.class, () -> {
       HoodieStorageWriter<IndexedRecord> logWriter = HoodieStorageWriterFactory.getStorageWriter(instantTime, logPath,
           table, cfg, HoodieTestDataGenerator.AVRO_SCHEMA, supplier);
-      fail("should fail since log storage writer is not supported yet.");
-    } catch (Exception e) {
-      Assert.assertTrue(e instanceof UnsupportedOperationException);
-      Assert.assertTrue(e.getMessage().contains("format not supported yet."));
-    }
+    }, "should fail since log storage writer is not supported yet.");
+    assertTrue(thrown.getMessage().contains("format not supported yet."));
   }
 }

--- a/hudi-client/src/test/java/org/apache/hudi/table/TestConsistencyGuard.java
+++ b/hudi-client/src/test/java/org/apache/hudi/table/TestConsistencyGuard.java
@@ -25,22 +25,24 @@ import org.apache.hudi.common.fs.ConsistencyGuardConfig;
 import org.apache.hudi.common.fs.FailSafeConsistencyGuard;
 
 import org.apache.hadoop.fs.Path;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.concurrent.TimeoutException;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 public class TestConsistencyGuard extends HoodieClientTestHarness {
 
-  @Before
+  @BeforeEach
   public void setup() {
     initPath();
     initFileSystemWithDefaultConfiguration();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     cleanupFileSystem();
   }
@@ -65,35 +67,43 @@ public class TestConsistencyGuard extends HoodieClientTestHarness {
         .asList(basePath + "/partition/path/f1_1-0-1_000.parquet", basePath + "/partition/path/f2_1-0-1_000.parquet"));
   }
 
-  @Test(expected = TimeoutException.class)
+  @Test
   public void testCheckFailingAppear() throws Exception {
     HoodieClientTestUtils.fakeDataFile(basePath, "partition/path", "000", "f1");
     ConsistencyGuard passing = new FailSafeConsistencyGuard(fs, getConsistencyGuardConfig());
-    passing.waitTillAllFilesAppear(basePath + "/partition/path", Arrays
-        .asList(basePath + "/partition/path/f1_1-0-2_000.parquet", basePath + "/partition/path/f2_1-0-2_000.parquet"));
+    assertThrows(TimeoutException.class, () -> {
+      passing.waitTillAllFilesAppear(basePath + "/partition/path", Arrays
+          .asList(basePath + "/partition/path/f1_1-0-2_000.parquet", basePath + "/partition/path/f2_1-0-2_000.parquet"));
+    });
   }
 
-  @Test(expected = TimeoutException.class)
+  @Test
   public void testCheckFailingAppears() throws Exception {
     HoodieClientTestUtils.fakeDataFile(basePath, "partition/path", "000", "f1");
     ConsistencyGuard passing = new FailSafeConsistencyGuard(fs, getConsistencyGuardConfig());
-    passing.waitTillFileAppears(new Path(basePath + "/partition/path/f1_1-0-2_000.parquet"));
+    assertThrows(TimeoutException.class, () -> {
+      passing.waitTillFileAppears(new Path(basePath + "/partition/path/f1_1-0-2_000.parquet"));
+    });
   }
 
-  @Test(expected = TimeoutException.class)
+  @Test
   public void testCheckFailingDisappear() throws Exception {
     HoodieClientTestUtils.fakeDataFile(basePath, "partition/path", "000", "f1");
     ConsistencyGuard passing = new FailSafeConsistencyGuard(fs, getConsistencyGuardConfig());
-    passing.waitTillAllFilesDisappear(basePath + "/partition/path", Arrays
-        .asList(basePath + "/partition/path/f1_1-0-1_000.parquet", basePath + "/partition/path/f2_1-0-2_000.parquet"));
+    assertThrows(TimeoutException.class, () -> {
+      passing.waitTillAllFilesDisappear(basePath + "/partition/path", Arrays
+          .asList(basePath + "/partition/path/f1_1-0-1_000.parquet", basePath + "/partition/path/f2_1-0-2_000.parquet"));
+    });
   }
 
-  @Test(expected = TimeoutException.class)
+  @Test
   public void testCheckFailingDisappears() throws Exception {
     HoodieClientTestUtils.fakeDataFile(basePath, "partition/path", "000", "f1");
     HoodieClientTestUtils.fakeDataFile(basePath, "partition/path", "000", "f1");
     ConsistencyGuard passing = new FailSafeConsistencyGuard(fs, getConsistencyGuardConfig());
-    passing.waitTillFileDisappears(new Path(basePath + "/partition/path/f1_1-0-1_000.parquet"));
+    assertThrows(TimeoutException.class, () -> {
+      passing.waitTillFileDisappears(new Path(basePath + "/partition/path/f1_1-0-1_000.parquet"));
+    });
   }
 
   private ConsistencyGuardConfig getConsistencyGuardConfig() {

--- a/hudi-client/src/test/java/org/apache/hudi/table/TestMergeOnReadTable.java
+++ b/hudi-client/src/test/java/org/apache/hudi/table/TestMergeOnReadTable.java
@@ -18,8 +18,6 @@
 
 package org.apache.hudi.table;
 
-import org.apache.hadoop.mapred.FileInputFormat;
-import org.apache.hadoop.mapred.JobConf;
 import org.apache.hudi.client.HoodieReadClient;
 import org.apache.hudi.client.HoodieWriteClient;
 import org.apache.hudi.client.WriteStatus;
@@ -57,23 +55,27 @@ import org.apache.hudi.hadoop.HoodieParquetInputFormat;
 import org.apache.hudi.hadoop.realtime.HoodieParquetRealtimeInputFormat;
 import org.apache.hudi.index.HoodieIndex;
 import org.apache.hudi.index.HoodieIndex.IndexType;
+import org.apache.hudi.table.action.deltacommit.DeleteDeltaCommitActionExecutor;
+import org.apache.hudi.table.action.deltacommit.DeltaCommitActionExecutor;
 
 import org.apache.avro.generic.GenericRecord;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
-import org.apache.hudi.table.action.deltacommit.DeltaCommitActionExecutor;
-import org.apache.hudi.table.action.deltacommit.DeleteDeltaCommitActionExecutor;
+import org.apache.hadoop.mapred.FileInputFormat;
+import org.apache.hadoop.mapred.JobConf;
 import org.apache.spark.api.java.JavaRDD;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -82,9 +84,9 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.apache.hudi.common.HoodieTestDataGenerator.TRIP_EXAMPLE_SCHEMA;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestMergeOnReadTable extends HoodieClientTestHarness {
 
@@ -94,7 +96,7 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
   private HoodieParquetRealtimeInputFormat rtInputFormat;
   private JobConf rtJobConf;
 
-  @Before
+  @BeforeEach
   public void init() throws IOException {
     initDFS();
     initSparkContexts("TestHoodieMergeOnReadTable");
@@ -114,7 +116,7 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
     rtInputFormat.setConf(rtJobConf);
   }
 
-  @After
+  @AfterEach
   public void clean() throws IOException {
     cleanupDFS();
     cleanupSparkContexts();
@@ -159,13 +161,13 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
       // verify that there is a commit
       metaClient = HoodieTableMetaClient.reload(metaClient);
       HoodieTimeline timeline = metaClient.getCommitTimeline().filterCompletedInstants();
-      assertEquals("Expecting a single commit.", 1,
-          timeline.findInstantsAfter("000", Integer.MAX_VALUE).countInstants());
+      assertEquals(1, timeline.findInstantsAfter("000", Integer.MAX_VALUE).countInstants(),
+          "Expecting a single commit.");
       String latestCompactionCommitTime = timeline.lastInstant().get().getTimestamp();
       assertTrue(HoodieTimeline.compareTimestamps("000", latestCompactionCommitTime, HoodieTimeline.LESSER));
 
-      assertEquals("Must contain 200 records", 200,
-          HoodieClientTestUtils.readSince(basePath, sqlContext, timeline, "000").count());
+      assertEquals(200, HoodieClientTestUtils.readSince(basePath, sqlContext, timeline, "000").count(),
+          "Must contain 200 records");
     }
   }
 
@@ -310,7 +312,7 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
 
       Option<HoodieInstant> deltaCommit = metaClient.getActiveTimeline().getDeltaCommitTimeline().firstInstant();
       assertTrue(deltaCommit.isPresent());
-      assertEquals("Delta commit should be 001", "001", deltaCommit.get().getTimestamp());
+      assertEquals("001", deltaCommit.get().getTimestamp(), "Delta commit should be 001");
 
       Option<HoodieInstant> commit = metaClient.getActiveTimeline().getCommitTimeline().firstInstant();
       assertFalse(commit.isPresent());
@@ -323,8 +325,8 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
 
       roView = new HoodieTableFileSystemView(metaClient, hoodieTable.getCompletedCommitsTimeline(), allFiles);
       dataFilesToRead = roView.getLatestBaseFiles();
-      assertTrue("should list the parquet files we wrote in the delta commit",
-          dataFilesToRead.findAny().isPresent());
+      assertTrue(dataFilesToRead.findAny().isPresent(),
+          "should list the parquet files we wrote in the delta commit");
 
       /**
        * Write 2 (only updates, written to .log file)
@@ -352,7 +354,7 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
       metaClient = HoodieTableMetaClient.reload(metaClient);
       deltaCommit = metaClient.getActiveTimeline().getDeltaCommitTimeline().lastInstant();
       assertTrue(deltaCommit.isPresent());
-      assertEquals("Latest Delta commit should be 004", "004", deltaCommit.get().getTimestamp());
+      assertEquals("004", deltaCommit.get().getTimestamp(), "Latest Delta commit should be 004");
 
       commit = metaClient.getActiveTimeline().getCommitTimeline().firstInstant();
       assertFalse(commit.isPresent());
@@ -365,7 +367,7 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
       List<String> dataFiles = roView.getLatestBaseFiles().map(HoodieBaseFile::getPath).collect(Collectors.toList());
       List<GenericRecord> recordsRead = HoodieMergeOnReadTestUtils.getRecordsUsingInputFormat(dataFiles, basePath);
       // Wrote 20 records and deleted 20 records, so remaining 20-20 = 0
-      assertEquals("Must contain 0 records", 0, recordsRead.size());
+      assertEquals(0, recordsRead.size(), "Must contain 0 records");
     }
   }
 
@@ -394,7 +396,7 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
       HoodieTableMetaClient metaClient = new HoodieTableMetaClient(jsc.hadoopConfiguration(), cfg.getBasePath());
       Option<HoodieInstant> commit = metaClient.getActiveTimeline().getCommitTimeline().firstInstant();
       assertTrue(commit.isPresent());
-      assertEquals("commit should be 001", "001", commit.get().getTimestamp());
+      assertEquals("001", commit.get().getTimestamp(), "commit should be 001");
 
       /**
        * Write 2 (updates)
@@ -451,7 +453,7 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
 
       Option<HoodieInstant> deltaCommit = metaClient.getActiveTimeline().getDeltaCommitTimeline().firstInstant();
       assertTrue(deltaCommit.isPresent());
-      assertEquals("Delta commit should be 001", "001", deltaCommit.get().getTimestamp());
+      assertEquals("001", deltaCommit.get().getTimestamp(), "Delta commit should be 001");
 
       Option<HoodieInstant> commit = metaClient.getActiveTimeline().getCommitTimeline().firstInstant();
       assertFalse(commit.isPresent());
@@ -464,8 +466,8 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
 
       roView = new HoodieTableFileSystemView(metaClient, hoodieTable.getCompletedCommitsTimeline(), allFiles);
       dataFilesToRead = roView.getLatestBaseFiles();
-      assertTrue("should list the parquet files we wrote in the delta commit",
-          dataFilesToRead.findAny().isPresent());
+      assertTrue(dataFilesToRead.findAny().isPresent(),
+          "should list the parquet files we wrote in the delta commit");
 
       /**
        * Write 2 (inserts + updates - testing failed delta commit)
@@ -491,11 +493,11 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
         secondClient.rollback(commitTime1);
         allFiles = HoodieTestUtils.listAllDataFilesInPath(metaClient.getFs(), cfg.getBasePath());
         // After rollback, there should be no parquet file with the failed commit time
-        Assert.assertEquals(Arrays.stream(allFiles)
-            .filter(file -> file.getPath().getName().contains(commitTime1)).count(), 0);
+        assertEquals(0, Arrays.stream(allFiles)
+            .filter(file -> file.getPath().getName().contains(commitTime1)).count());
         dataFiles = roView.getLatestBaseFiles().map(HoodieBaseFile::getPath).collect(Collectors.toList());
         recordsRead = HoodieMergeOnReadTestUtils.getRecordsUsingInputFormat(dataFiles, basePath);
-        assertEquals(recordsRead.size(), 200);
+        assertEquals(200, recordsRead.size());
       }
 
       /**
@@ -511,7 +513,7 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
 
         List<String> dataFiles = roView.getLatestBaseFiles().map(HoodieBaseFile::getPath).collect(Collectors.toList());
         List<GenericRecord> recordsRead = HoodieMergeOnReadTestUtils.getRecordsUsingInputFormat(dataFiles, basePath);
-        assertEquals(recordsRead.size(), 200);
+        assertEquals(200, recordsRead.size());
 
         writeRecords = jsc.parallelize(copyOfRecords, 1);
         writeStatusJavaRDD = thirdClient.upsert(writeRecords, commitTime2);
@@ -524,8 +526,8 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
         thirdClient.rollback(commitTime2);
         allFiles = HoodieTestUtils.listAllDataFilesInPath(metaClient.getFs(), cfg.getBasePath());
         // After rollback, there should be no parquet file with the failed commit time
-        Assert.assertEquals(Arrays.stream(allFiles)
-            .filter(file -> file.getPath().getName().contains(commitTime2)).count(), 0);
+        assertEquals(0, Arrays.stream(allFiles)
+            .filter(file -> file.getPath().getName().contains(commitTime2)).count());
 
         metaClient = HoodieTableMetaClient.reload(metaClient);
         hoodieTable = HoodieTable.create(metaClient, cfg, jsc);
@@ -533,7 +535,7 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
         dataFiles = roView.getLatestBaseFiles().map(HoodieBaseFile::getPath).collect(Collectors.toList());
         recordsRead = HoodieMergeOnReadTestUtils.getRecordsUsingInputFormat(dataFiles, basePath);
         // check that the number of records read is still correct after rollback operation
-        assertEquals(recordsRead.size(), 200);
+        assertEquals(200, recordsRead.size());
 
         // Test compaction commit rollback
         /**
@@ -598,7 +600,7 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
 
       Option<HoodieInstant> deltaCommit = metaClient.getActiveTimeline().getDeltaCommitTimeline().firstInstant();
       assertTrue(deltaCommit.isPresent());
-      assertEquals("Delta commit should be 001", "001", deltaCommit.get().getTimestamp());
+      assertEquals("001", deltaCommit.get().getTimestamp(), "Delta commit should be 001");
 
       Option<HoodieInstant> commit = metaClient.getActiveTimeline().getCommitTimeline().firstInstant();
       assertFalse(commit.isPresent());
@@ -611,8 +613,8 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
 
       roView = new HoodieTableFileSystemView(metaClient, hoodieTable.getCompletedCommitsTimeline(), allFiles);
       dataFilesToRead = roView.getLatestBaseFiles();
-      assertTrue("Should list the parquet files we wrote in the delta commit",
-          dataFilesToRead.findAny().isPresent());
+      assertTrue(dataFilesToRead.findAny().isPresent(),
+          "Should list the parquet files we wrote in the delta commit");
 
       /**
        * Write 2 (inserts + updates)
@@ -628,7 +630,7 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
 
       List<String> dataFiles = roView.getLatestBaseFiles().map(hf -> hf.getPath()).collect(Collectors.toList());
       List<GenericRecord> recordsRead = HoodieMergeOnReadTestUtils.getRecordsUsingInputFormat(dataFiles, basePath);
-      assertEquals(recordsRead.size(), 200);
+      assertEquals(200, recordsRead.size());
 
       statuses = nClient.upsert(jsc.parallelize(copyOfRecords, 1), newCommitTime).collect();
       // Verify there are no errors
@@ -761,7 +763,7 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
 
       Option<HoodieInstant> deltaCommit = metaClient.getActiveTimeline().getDeltaCommitTimeline().firstInstant();
       assertTrue(deltaCommit.isPresent());
-      assertEquals("Delta commit should be 001", "001", deltaCommit.get().getTimestamp());
+      assertEquals("001", deltaCommit.get().getTimestamp(), "Delta commit should be 001");
 
       Option<HoodieInstant> commit = metaClient.getActiveTimeline().getCommitTimeline().firstInstant();
       assertFalse(commit.isPresent());
@@ -776,8 +778,8 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
       roView = new HoodieTableFileSystemView(metaClient, hoodieTable.getCompletedCommitsTimeline(), allFiles);
       dataFilesToRead = roView.getLatestBaseFiles();
       List<HoodieBaseFile> dataFilesList = dataFilesToRead.collect(Collectors.toList());
-      assertTrue("Should list the parquet files we wrote in the delta commit",
-          dataFilesList.size() > 0);
+      assertTrue(dataFilesList.size() > 0,
+          "Should list the parquet files we wrote in the delta commit");
 
       /**
        * Write 2 (only updates + inserts, written to .log file + correction of existing parquet file size)
@@ -795,7 +797,7 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
       metaClient = HoodieTableMetaClient.reload(metaClient);
       deltaCommit = metaClient.getActiveTimeline().getDeltaCommitTimeline().lastInstant();
       assertTrue(deltaCommit.isPresent());
-      assertEquals("Latest Delta commit should be 002", "002", deltaCommit.get().getTimestamp());
+      assertEquals("002", deltaCommit.get().getTimestamp(), "Latest Delta commit should be 002");
 
       commit = metaClient.getActiveTimeline().getCommitTimeline().firstInstant();
       assertFalse(commit.isPresent());
@@ -813,7 +815,7 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
       List<String> dataFiles = roView.getLatestBaseFiles().map(HoodieBaseFile::getPath).collect(Collectors.toList());
       List<GenericRecord> recordsRead = HoodieMergeOnReadTestUtils.getRecordsUsingInputFormat(dataFiles, basePath);
       // Wrote 20 records in 2 batches
-      assertEquals("Must contain 40 records", 40, recordsRead.size());
+      assertEquals(40, recordsRead.size(), "Must contain 40 records");
     }
   }
 
@@ -855,7 +857,7 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
         List<FileSlice> groupedLogFiles =
             table.getSliceView().getLatestFileSlices(partitionPath).collect(Collectors.toList());
         for (FileSlice fileSlice : groupedLogFiles) {
-          assertEquals("There should be 1 log file written for every data file", 1, fileSlice.getLogFiles().count());
+          assertEquals(1, fileSlice.getLogFiles().count(), "There should be 1 log file written for every data file");
         }
       }
 
@@ -874,14 +876,15 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
       table = HoodieTable.create(metaClient, config, jsc);
       HoodieActiveTimeline timeline = metaClient.getActiveTimeline();
 
-      assertTrue("Compaction commit should be > than last insert", HoodieTimeline
-          .compareTimestamps(timeline.lastInstant().get().getTimestamp(), newCommitTime, HoodieTimeline.GREATER));
+      assertTrue(HoodieTimeline
+              .compareTimestamps(timeline.lastInstant().get().getTimestamp(), newCommitTime, HoodieTimeline.GREATER),
+          "Compaction commit should be > than last insert");
 
       for (String partitionPath : dataGen.getPartitionPaths()) {
         List<FileSlice> groupedLogFiles =
             table.getSliceView().getLatestFileSlices(partitionPath).collect(Collectors.toList());
         for (FileSlice slice : groupedLogFiles) {
-          assertEquals("After compaction there should be no log files visible on a full view", 0, slice.getLogFiles().count());
+          assertEquals(0, slice.getLogFiles().count(), "After compaction there should be no log files visible on a full view");
         }
         List<WriteStatus> writeStatuses = result.collect();
         assertTrue(writeStatuses.stream().anyMatch(writeStatus -> writeStatus.getStat().getPartitionPath().contentEquals(partitionPath)));
@@ -911,23 +914,23 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
       for (String partitionPath : dataGen.getPartitionPaths()) {
         assertEquals(0, tableRTFileSystemView.getLatestFileSlices(partitionPath)
             .filter(fileSlice -> fileSlice.getBaseFile().isPresent()).count());
-        Assert.assertTrue(tableRTFileSystemView.getLatestFileSlices(partitionPath).anyMatch(fileSlice -> fileSlice.getLogFiles().count() > 0));
+        assertTrue(tableRTFileSystemView.getLatestFileSlices(partitionPath).anyMatch(fileSlice -> fileSlice.getLogFiles().count() > 0));
         numLogFiles += tableRTFileSystemView.getLatestFileSlices(partitionPath)
             .filter(fileSlice -> fileSlice.getLogFiles().count() > 0).count();
       }
 
-      Assert.assertTrue(numLogFiles > 0);
+      assertTrue(numLogFiles > 0);
       // Do a compaction
       String instantTime = writeClient.scheduleCompaction(Option.empty()).get().toString();
       statuses = writeClient.compact(instantTime);
       assertEquals(statuses.map(status -> status.getStat().getPath().contains("parquet")).count(), numLogFiles);
-      Assert.assertEquals(statuses.count(), numLogFiles);
+      assertEquals(statuses.count(), numLogFiles);
       writeClient.commitCompaction(instantTime, statuses, Option.empty());
     }
   }
 
   @Test
-  public void testInsertsGeneratedIntoLogFilesRollback() throws Exception {
+  public void testInsertsGeneratedIntoLogFilesRollback(@TempDir java.nio.file.Path tempFolder) throws Exception {
     // insert 100 records
     // Setting IndexType to be InMemory to simulate Global Index nature
     HoodieWriteConfig config = getConfigBuilder(false, IndexType.INMEMORY).build();
@@ -942,14 +945,14 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
       List<WriteStatus> writeStatuses = statuses.collect();
 
       // Ensure that inserts are written to only log files
-      Assert.assertEquals(
-          writeStatuses.stream().filter(writeStatus -> !writeStatus.getStat().getPath().contains("log")).count(), 0);
-      Assert.assertTrue(
+      assertEquals(0,
+          writeStatuses.stream().filter(writeStatus -> !writeStatus.getStat().getPath().contains("log")).count());
+      assertTrue(
           writeStatuses.stream().anyMatch(writeStatus -> writeStatus.getStat().getPath().contains("log")));
 
       // rollback a failed commit
       boolean rollback = writeClient.rollback(newCommitTime);
-      Assert.assertTrue(rollback);
+      assertTrue(rollback);
       newCommitTime = "101";
       writeClient.startCommitWithTime(newCommitTime);
 
@@ -972,9 +975,7 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
       // Save the .commit file to local directory.
       // Rollback will be called twice to test the case where rollback failed first time and retried.
       // We got the "BaseCommitTime cannot be null" exception before the fix
-      TemporaryFolder folder = new TemporaryFolder();
-      folder.create();
-      File file = folder.newFile();
+      File file = Files.createTempFile(tempFolder, null, null).toFile();
       metaClient.getFs().copyToLocalFile(new Path(metaClient.getMetaPath(), fileName),
           new Path(file.getAbsolutePath()));
       writeClient.rollback(newCommitTime);
@@ -985,8 +986,8 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
 
       long numLogFiles = 0;
       for (String partitionPath : dataGen.getPartitionPaths()) {
-        Assert.assertTrue(tableRTFileSystemView.getLatestFileSlices(partitionPath).noneMatch(fileSlice -> fileSlice.getBaseFile().isPresent()));
-        Assert.assertTrue(tableRTFileSystemView.getLatestFileSlices(partitionPath).noneMatch(fileSlice -> fileSlice.getLogFiles().count() > 0));
+        assertTrue(tableRTFileSystemView.getLatestFileSlices(partitionPath).noneMatch(fileSlice -> fileSlice.getBaseFile().isPresent()));
+        assertTrue(tableRTFileSystemView.getLatestFileSlices(partitionPath).noneMatch(fileSlice -> fileSlice.getLogFiles().count() > 0));
         numLogFiles += tableRTFileSystemView.getLatestFileSlices(partitionPath)
             .filter(fileSlice -> fileSlice.getLogFiles().count() > 0).count();
       }
@@ -996,7 +997,6 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
       Thread.sleep(1000);
       // Rollback again to pretend the first rollback failed partially. This should not error our
       writeClient.rollback(newCommitTime);
-      folder.delete();
     }
   }
 
@@ -1022,19 +1022,19 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
 
       long numLogFiles = 0;
       for (String partitionPath : dataGen.getPartitionPaths()) {
-        Assert.assertTrue(tableRTFileSystemView.getLatestFileSlices(partitionPath).noneMatch(fileSlice -> fileSlice.getBaseFile().isPresent()));
-        Assert.assertTrue(tableRTFileSystemView.getLatestFileSlices(partitionPath).anyMatch(fileSlice -> fileSlice.getLogFiles().count() > 0));
+        assertTrue(tableRTFileSystemView.getLatestFileSlices(partitionPath).noneMatch(fileSlice -> fileSlice.getBaseFile().isPresent()));
+        assertTrue(tableRTFileSystemView.getLatestFileSlices(partitionPath).anyMatch(fileSlice -> fileSlice.getLogFiles().count() > 0));
         numLogFiles += tableRTFileSystemView.getLatestFileSlices(partitionPath)
             .filter(fileSlice -> fileSlice.getLogFiles().count() > 0).count();
       }
 
-      Assert.assertTrue(numLogFiles > 0);
+      assertTrue(numLogFiles > 0);
       // Do a compaction
       newCommitTime = writeClient.scheduleCompaction(Option.empty()).get().toString();
       statuses = writeClient.compact(newCommitTime);
       // Ensure all log files have been compacted into parquet files
       assertEquals(statuses.map(status -> status.getStat().getPath().contains("parquet")).count(), numLogFiles);
-      Assert.assertEquals(statuses.count(), numLogFiles);
+      assertEquals(statuses.count(), numLogFiles);
       writeClient.commitCompaction(newCommitTime, statuses, Option.empty());
       // Trigger a rollback of compaction
       writeClient.rollback(newCommitTime);
@@ -1044,8 +1044,8 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
       Option<HoodieInstant> lastInstant = ((SyncableFileSystemView) tableRTFileSystemView).getLastInstant();
       System.out.println("Last Instant =" + lastInstant);
       for (String partitionPath : dataGen.getPartitionPaths()) {
-        Assert.assertTrue(tableRTFileSystemView.getLatestFileSlices(partitionPath).noneMatch(fileSlice -> fileSlice.getBaseFile().isPresent()));
-        Assert.assertTrue(tableRTFileSystemView.getLatestFileSlices(partitionPath).anyMatch(fileSlice -> fileSlice.getLogFiles().count() > 0));
+        assertTrue(tableRTFileSystemView.getLatestFileSlices(partitionPath).noneMatch(fileSlice -> fileSlice.getBaseFile().isPresent()));
+        assertTrue(tableRTFileSystemView.getLatestFileSlices(partitionPath).anyMatch(fileSlice -> fileSlice.getLogFiles().count() > 0));
       }
     }
   }
@@ -1077,7 +1077,7 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
       JavaRDD<HoodieRecord> writeRecords = jsc.parallelize(records, 1);
 
       JavaRDD<WriteStatus> statuses = client.insert(writeRecords, instantTime);
-      assertTrue("Commit should succeed", client.commit(instantTime, statuses));
+      assertTrue(client.commit(instantTime, statuses), "Commit should succeed");
 
       // Read from commit file
       table = HoodieTable.create(cfg, jsc);
@@ -1094,14 +1094,14 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
           inserts += stat.getValue().getInserts();
         }
       }
-      Assert.assertEquals(inserts, 200);
+      assertEquals(200, inserts);
 
       instantTime = "002";
       client.startCommitWithTime(instantTime);
       records = dataGen.generateUpdates(instantTime, records);
       writeRecords = jsc.parallelize(records, 1);
       statuses = client.upsert(writeRecords, instantTime);
-      assertTrue("Commit should succeed", client.commit(instantTime, statuses));
+      assertTrue(client.commit(instantTime, statuses), "Commit should succeed");
 
       // Read from commit file
       table = HoodieTable.create(cfg, jsc);
@@ -1122,8 +1122,8 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
         }
       }
 
-      Assert.assertEquals(inserts, 200);
-      Assert.assertEquals(upserts, 200);
+      assertEquals(200, inserts);
+      assertEquals(200, upserts);
 
       client.rollback(instantTime);
 
@@ -1145,8 +1145,8 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
           upserts += stat.getValue().getUpserts();
         }
       }
-      Assert.assertEquals(inserts, 200);
-      Assert.assertEquals(upserts, 0);
+      assertEquals(200, inserts);
+      assertEquals(0, upserts);
     }
   }
 
@@ -1168,7 +1168,7 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
       JavaRDD<HoodieRecord> writeRecords = jsc.parallelize(records, 1);
 
       JavaRDD<WriteStatus> statuses = client.insert(writeRecords, instantTime);
-      assertTrue("Commit should succeed", client.commit(instantTime, statuses));
+      assertTrue(client.commit(instantTime, statuses), "Commit should succeed");
 
       // Read from commit file
       HoodieTable table = HoodieTable.create(cfg, jsc);
@@ -1188,7 +1188,7 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
           fileIdToUpsertsMap.put(stat.getKey(), stat.getValue().getUpserts());
         }
       }
-      Assert.assertEquals(inserts, 200);
+      assertEquals(200, inserts);
 
       instantTime = "001";
       client.startCommitWithTime(instantTime);
@@ -1197,7 +1197,7 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
       records.addAll(dataGen.generateInserts(instantTime, 200));
       writeRecords = jsc.parallelize(records, 1);
       statuses = client.upsert(writeRecords, instantTime);
-      assertTrue("Commit should succeed", client.commit(instantTime, statuses));
+      assertTrue(client.commit(instantTime, statuses), "Commit should succeed");
 
       // Read from commit file
       table = HoodieTable.create(cfg, jsc);
@@ -1221,8 +1221,8 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
         }
       }
 
-      Assert.assertEquals(inserts, 400);
-      Assert.assertEquals(upserts, 200);
+      assertEquals(400, inserts);
+      assertEquals(200, upserts);
 
       // Test small file handling after compaction
       instantTime = "002";
@@ -1243,8 +1243,8 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
       // Ensure that the rolling stats from the extra metadata of delta commits is copied over to the compaction commit
       for (Map.Entry<String, Map<String, HoodieRollingStat>> entry : rollingStatMetadata.getPartitionToRollingStats()
           .entrySet()) {
-        Assert.assertTrue(rollingStatMetadata1.getPartitionToRollingStats().containsKey(entry.getKey()));
-        Assert.assertEquals(rollingStatMetadata1.getPartitionToRollingStats().get(entry.getKey()).size(),
+        assertTrue(rollingStatMetadata1.getPartitionToRollingStats().containsKey(entry.getKey()));
+        assertEquals(rollingStatMetadata1.getPartitionToRollingStats().get(entry.getKey()).size(),
             entry.getValue().size());
       }
 
@@ -1256,7 +1256,7 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
       records.addAll(dataGen.generateInserts(instantTime, 200));
       writeRecords = jsc.parallelize(records, 1);
       statuses = client.upsert(writeRecords, instantTime);
-      assertTrue("Commit should succeed", client.commit(instantTime, statuses));
+      assertTrue(client.commit(instantTime, statuses), "Commit should succeed");
 
       // Read from commit file
       table = HoodieTable.create(cfg, jsc);
@@ -1279,8 +1279,8 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
         }
       }
 
-      Assert.assertEquals(inserts, 600);
-      Assert.assertEquals(upserts, 600);
+      assertEquals(600, inserts);
+      assertEquals(600, upserts);
     }
   }
 
@@ -1309,21 +1309,21 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
 
       Option<HoodieInstant> deltaCommit = metaClient.getActiveTimeline().getDeltaCommitTimeline().firstInstant();
       assertTrue(deltaCommit.isPresent());
-      assertEquals("Delta commit should be 001", "001", deltaCommit.get().getTimestamp());
+      assertEquals("001", deltaCommit.get().getTimestamp(), "Delta commit should be 001");
 
       Option<HoodieInstant> commit = metaClient.getActiveTimeline().getCommitTimeline().firstInstant();
       assertFalse(commit.isPresent());
 
       FileStatus[] allFiles = HoodieTestUtils.listAllDataFilesInPath(metaClient.getFs(), cfg.getBasePath());
       BaseFileOnlyView roView =
-              new HoodieTableFileSystemView(metaClient, metaClient.getCommitTimeline().filterCompletedInstants(), allFiles);
+          new HoodieTableFileSystemView(metaClient, metaClient.getCommitTimeline().filterCompletedInstants(), allFiles);
       Stream<HoodieBaseFile> dataFilesToRead = roView.getLatestBaseFiles();
       assertFalse(dataFilesToRead.findAny().isPresent());
 
       roView = new HoodieTableFileSystemView(metaClient, hoodieTable.getCompletedCommitsTimeline(), allFiles);
       dataFilesToRead = roView.getLatestBaseFiles();
-      assertTrue("should list the parquet files we wrote in the delta commit",
-              dataFilesToRead.findAny().isPresent());
+      assertTrue(dataFilesToRead.findAny().isPresent(),
+          "should list the parquet files we wrote in the delta commit");
 
       /**
        * Write 2 (only updates, written to .log file)
@@ -1386,7 +1386,7 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
   private void assertNoWriteErrors(List<WriteStatus> statuses) {
     // Verify there are no errors
     for (WriteStatus status : statuses) {
-      assertFalse("Errors found in write of " + status.getFileId(), status.hasErrors());
+      assertFalse(status.hasErrors(), "Errors found in write of " + status.getFileId());
     }
   }
   
@@ -1402,21 +1402,21 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
 
     Option<HoodieInstant> deltaCommit = metaClient.getActiveTimeline().getDeltaCommitTimeline().lastInstant();
     assertTrue(deltaCommit.isPresent());
-    Assert.assertEquals("Delta commit should be specified value", commitTime, deltaCommit.get().getTimestamp());
+    assertEquals(commitTime, deltaCommit.get().getTimestamp(), "Delta commit should be specified value");
 
     Option<HoodieInstant> commit = metaClient.getActiveTimeline().getCommitTimeline().lastInstant();
     assertFalse(commit.isPresent());
 
     FileStatus[] allFiles = HoodieTestUtils.listAllDataFilesInPath(metaClient.getFs(), cfg.getBasePath());
     BaseFileOnlyView roView =
-            new HoodieTableFileSystemView(metaClient, metaClient.getCommitTimeline().filterCompletedInstants(), allFiles);
+        new HoodieTableFileSystemView(metaClient, metaClient.getCommitTimeline().filterCompletedInstants(), allFiles);
     Stream<HoodieBaseFile> dataFilesToRead = roView.getLatestBaseFiles();
     assertTrue(!dataFilesToRead.findAny().isPresent());
 
     roView = new HoodieTableFileSystemView(metaClient, hoodieTable.getCompletedCommitsTimeline(), allFiles);
     dataFilesToRead = roView.getLatestBaseFiles();
-    assertTrue("should list the parquet files we wrote in the delta commit",
-            dataFilesToRead.findAny().isPresent());
+    assertTrue(dataFilesToRead.findAny().isPresent(),
+        "should list the parquet files we wrote in the delta commit");
     return allFiles;
   }
 
@@ -1435,8 +1435,8 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
     metaClient = HoodieTableMetaClient.reload(metaClient);
     Option<HoodieInstant> deltaCommit = metaClient.getActiveTimeline().getDeltaCommitTimeline().lastInstant();
     assertTrue(deltaCommit.isPresent());
-    assertEquals("Latest Delta commit should match specified time",
-            commitTime, deltaCommit.get().getTimestamp());
+    assertEquals(commitTime, deltaCommit.get().getTimestamp(),
+        "Latest Delta commit should match specified time");
 
     Option<HoodieInstant> commit = metaClient.getActiveTimeline().getCommitTimeline().firstInstant();
     assertFalse(commit.isPresent());
@@ -1452,7 +1452,7 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
           throws Exception {
     HoodieTestUtils.init(jsc.hadoopConfiguration(), basePath, HoodieTableType.MERGE_ON_READ);
     setupIncremental(roJobConf, startCommitTime, numCommitsToPull, stopAtCompaction);
-    FileInputFormat.setInputPaths(roJobConf, basePath + "/" + partitionPath);
+    FileInputFormat.setInputPaths(roJobConf, Paths.get(basePath, partitionPath).toString());
     return roInputFormat.listStatus(roJobConf);
   }
 
@@ -1465,7 +1465,7 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
           throws Exception {
     HoodieTestUtils.init(jsc.hadoopConfiguration(), basePath, HoodieTableType.MERGE_ON_READ);
     setupIncremental(rtJobConf, startCommitTime, numCommitsToPull, false);
-    FileInputFormat.setInputPaths(rtJobConf, basePath + "/" + partitionPath);
+    FileInputFormat.setInputPaths(rtJobConf, Paths.get(basePath, partitionPath).toString());
     return rtInputFormat.listStatus(rtJobConf);
   }
 
@@ -1492,9 +1492,9 @@ public class TestMergeOnReadTable extends HoodieClientTestHarness {
                                         JobConf jobConf, int expectedRecords, String... expectedCommits) {
 
     assertEquals(expectedNumFiles, files.length);
-    Set<String> expectedCommitsSet = Arrays.asList(expectedCommits).stream().collect(Collectors.toSet());
+    Set<String> expectedCommitsSet = Arrays.stream(expectedCommits).collect(Collectors.toSet());
     List<GenericRecord> records = HoodieMergeOnReadTestUtils.getRecordsUsingInputFormat(
-            Arrays.asList(basePath + "/" + partitionPath), basePath, jobConf, inputFormat);
+        Collections.singletonList(Paths.get(basePath, partitionPath).toString()), basePath, jobConf, inputFormat);
     assertEquals(expectedRecords, records.size());
     Set<String> actualCommits = records.stream().map(r ->
             r.get(HoodieRecord.COMMIT_TIME_METADATA_FIELD).toString()).collect(Collectors.toSet());

--- a/hudi-client/src/test/java/org/apache/hudi/table/action/commit/TestUpsertPartitioner.java
+++ b/hudi-client/src/test/java/org/apache/hudi/table/action/commit/TestUpsertPartitioner.java
@@ -18,10 +18,6 @@
 
 package org.apache.hudi.table.action.commit;
 
-import static org.junit.Assert.assertEquals;
-
-import java.util.ArrayList;
-import java.util.List;
 import org.apache.hudi.common.HoodieClientTestHarness;
 import org.apache.hudi.common.HoodieClientTestUtils;
 import org.apache.hudi.common.HoodieTestDataGenerator;
@@ -36,18 +32,25 @@ import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.table.HoodieCopyOnWriteTable;
 import org.apache.hudi.table.HoodieTable;
 import org.apache.hudi.table.WorkloadProfile;
+
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import scala.Tuple2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestUpsertPartitioner extends HoodieClientTestHarness {
 
   private static final Logger LOG = LogManager.getLogger(TestUpsertPartitioner.class);
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     initSparkContexts("TestUpsertPartitioner");
     initPath();
@@ -56,7 +59,7 @@ public class TestUpsertPartitioner extends HoodieClientTestHarness {
     initFileSystem();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     cleanupSparkContexts();
     cleanupMetaClient();
@@ -89,8 +92,9 @@ public class TestUpsertPartitioner extends HoodieClientTestHarness {
     records.addAll(updateRecords);
     WorkloadProfile profile = new WorkloadProfile(jsc.parallelize(records));
     UpsertPartitioner partitioner = new UpsertPartitioner(profile, jsc, table, config);
-    assertEquals("Update record should have gone to the 1 update partition", 0, partitioner.getPartition(
-        new Tuple2<>(updateRecords.get(0).getKey(), Option.ofNullable(updateRecords.get(0).getCurrentLocation()))));
+    assertEquals(0, partitioner.getPartition(
+        new Tuple2<>(updateRecords.get(0).getKey(), Option.ofNullable(updateRecords.get(0).getCurrentLocation()))),
+        "Update record should have gone to the 1 update partition");
     return partitioner;
   }
 
@@ -100,7 +104,7 @@ public class TestUpsertPartitioner extends HoodieClientTestHarness {
     // Inserts + Updates... Check all updates go together & inserts subsplit
     UpsertPartitioner partitioner = getUpsertPartitioner(0, 200, 100, 1024, testPartitionPath, false);
     List<InsertBucket> insertBuckets = partitioner.getInsertBuckets(testPartitionPath);
-    assertEquals("Total of 2 insert buckets", 2, insertBuckets.size());
+    assertEquals(2, insertBuckets.size(), "Total of 2 insert buckets");
   }
 
   @Test
@@ -111,33 +115,33 @@ public class TestUpsertPartitioner extends HoodieClientTestHarness {
     UpsertPartitioner partitioner = getUpsertPartitioner(1000 * 1024, 400, 100, 800 * 1024, testPartitionPath, false);
     List<InsertBucket> insertBuckets = partitioner.getInsertBuckets(testPartitionPath);
 
-    assertEquals("Should have 3 partitions", 3, partitioner.numPartitions());
-    assertEquals("Bucket 0 is UPDATE", BucketType.UPDATE,
-        partitioner.getBucketInfo(0).bucketType);
-    assertEquals("Bucket 1 is INSERT", BucketType.INSERT,
-        partitioner.getBucketInfo(1).bucketType);
-    assertEquals("Bucket 2 is INSERT", BucketType.INSERT,
-        partitioner.getBucketInfo(2).bucketType);
-    assertEquals("Total of 3 insert buckets", 3, insertBuckets.size());
-    assertEquals("First insert bucket must be same as update bucket", 0, insertBuckets.get(0).bucketNumber);
-    assertEquals("First insert bucket should have weight 0.5", 0.5, insertBuckets.get(0).weight, 0.01);
+    assertEquals(3, partitioner.numPartitions(), "Should have 3 partitions");
+    assertEquals(BucketType.UPDATE, partitioner.getBucketInfo(0).bucketType,
+        "Bucket 0 is UPDATE");
+    assertEquals(BucketType.INSERT, partitioner.getBucketInfo(1).bucketType,
+        "Bucket 1 is INSERT");
+    assertEquals(BucketType.INSERT, partitioner.getBucketInfo(2).bucketType,
+        "Bucket 2 is INSERT");
+    assertEquals(3, insertBuckets.size(), "Total of 3 insert buckets");
+    assertEquals(0, insertBuckets.get(0).bucketNumber, "First insert bucket must be same as update bucket");
+    assertEquals(0.5, insertBuckets.get(0).weight, 0.01, "First insert bucket should have weight 0.5");
 
     // Now with insert split size auto tuned
     partitioner = getUpsertPartitioner(1000 * 1024, 2400, 100, 800 * 1024, testPartitionPath, true);
     insertBuckets = partitioner.getInsertBuckets(testPartitionPath);
 
-    assertEquals("Should have 4 partitions", 4, partitioner.numPartitions());
-    assertEquals("Bucket 0 is UPDATE", BucketType.UPDATE,
-        partitioner.getBucketInfo(0).bucketType);
-    assertEquals("Bucket 1 is INSERT", BucketType.INSERT,
-        partitioner.getBucketInfo(1).bucketType);
-    assertEquals("Bucket 2 is INSERT", BucketType.INSERT,
-        partitioner.getBucketInfo(2).bucketType);
-    assertEquals("Bucket 3 is INSERT", BucketType.INSERT,
-        partitioner.getBucketInfo(3).bucketType);
-    assertEquals("Total of 4 insert buckets", 4, insertBuckets.size());
-    assertEquals("First insert bucket must be same as update bucket", 0, insertBuckets.get(0).bucketNumber);
-    assertEquals("First insert bucket should have weight 0.5", 200.0 / 2400, insertBuckets.get(0).weight, 0.01);
+    assertEquals(4, partitioner.numPartitions(), "Should have 4 partitions");
+    assertEquals(BucketType.UPDATE, partitioner.getBucketInfo(0).bucketType,
+        "Bucket 0 is UPDATE");
+    assertEquals(BucketType.INSERT, partitioner.getBucketInfo(1).bucketType,
+        "Bucket 1 is INSERT");
+    assertEquals(BucketType.INSERT, partitioner.getBucketInfo(2).bucketType,
+        "Bucket 2 is INSERT");
+    assertEquals(BucketType.INSERT, partitioner.getBucketInfo(3).bucketType,
+        "Bucket 3 is INSERT");
+    assertEquals(4, insertBuckets.size(), "Total of 4 insert buckets");
+    assertEquals(0, insertBuckets.get(0).bucketNumber, "First insert bucket must be same as update bucket");
+    assertEquals(200.0 / 2400, insertBuckets.get(0).weight, 0.01, "First insert bucket should have weight 0.5");
   }
 
   private HoodieWriteConfig.Builder makeHoodieClientConfigBuilder() throws Exception {

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableMetaClient.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/TestHoodieTableMetaClient.java
@@ -50,9 +50,11 @@ public class TestHoodieTableMetaClient extends HoodieCommonTestHarnessJunit5 {
 
   @Test
   public void checkMetadata() {
-    assertEquals(HoodieTestUtils.RAW_TRIPS_TEST_NAME, metaClient.getTableConfig().getTableName(), "Table name should be raw_trips");
+    assertEquals(HoodieTestUtils.RAW_TRIPS_TEST_NAME, metaClient.getTableConfig().getTableName(),
+        "Table name should be raw_trips");
     assertEquals(basePath, metaClient.getBasePath(), "Basepath should be the one assigned");
-    assertEquals(basePath + "/.hoodie", metaClient.getMetaPath(), "Metapath should be ${basepath}/.hoodie");
+    assertEquals(basePath + "/.hoodie", metaClient.getMetaPath(),
+        "Metapath should be ${basepath}/.hoodie");
   }
 
   @Test
@@ -67,8 +69,10 @@ public class TestHoodieTableMetaClient extends HoodieCommonTestHarnessJunit5 {
     commitTimeline.saveAsComplete(instant, Option.of("test-detail".getBytes()));
     commitTimeline = commitTimeline.reload();
     HoodieInstant completedInstant = HoodieTimeline.getCompletedInstant(instant);
-    assertEquals(completedInstant, commitTimeline.getInstants().findFirst().get(), "Commit should be 1 and completed");
-    assertArrayEquals("test-detail".getBytes(), commitTimeline.getInstantDetails(completedInstant).get(), "Commit value should be \"test-detail\"");
+    assertEquals(completedInstant, commitTimeline.getInstants().findFirst().get(),
+        "Commit should be 1 and completed");
+    assertArrayEquals("test-detail".getBytes(), commitTimeline.getInstantDetails(completedInstant).get(),
+        "Commit value should be \"test-detail\"");
   }
 
   @Test
@@ -90,8 +94,10 @@ public class TestHoodieTableMetaClient extends HoodieCommonTestHarnessJunit5 {
     activeTimeline = activeTimeline.reload();
     activeCommitTimeline = activeTimeline.getCommitTimeline();
     assertFalse(activeCommitTimeline.empty(), "Should be the 1 commit we made");
-    assertEquals(completedInstant, activeCommitTimeline.getInstants().findFirst().get(), "Commit should be 1");
-    assertArrayEquals("test-detail".getBytes(), activeCommitTimeline.getInstantDetails(completedInstant).get(), "Commit value should be \"test-detail\"");
+    assertEquals(completedInstant, activeCommitTimeline.getInstants().findFirst().get(),
+        "Commit should be 1");
+    assertArrayEquals("test-detail".getBytes(), activeCommitTimeline.getInstantDetails(completedInstant).get(),
+        "Commit value should be \"test-detail\"");
   }
 
   @Test

--- a/hudi-common/src/test/java/org/apache/hudi/common/table/view/TestHoodieTableFileSystemView.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/table/view/TestHoodieTableFileSystemView.java
@@ -288,7 +288,8 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarnessJunit5
     refreshFsView();
     List<FileSlice> slices = rtView.getLatestFileSlices(partitionPath).collect(Collectors.toList());
     assertEquals(1, slices.size(), "Expected latest file-slices");
-    assertEquals(compactionRequestedTime, slices.get(0).getBaseInstantTime(), "Base-Instant must be compaction Instant");
+    assertEquals(compactionRequestedTime, slices.get(0).getBaseInstantTime(),
+        "Base-Instant must be compaction Instant");
     assertFalse(slices.get(0).getBaseFile().isPresent(), "Latest File Slice must not have data-file");
     assertEquals(0, slices.get(0).getLogFiles().count(), "Latest File Slice must not have any log-files");
 
@@ -328,7 +329,8 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarnessJunit5
     } else {
       assertFalse(fileSlice.getBaseFile().isPresent(), "No data-file expected as it was not created");
     }
-    assertEquals(instantTime1, fileSlice.getBaseInstantTime(), "Base Instant of penultimate file-slice must be base instant");
+    assertEquals(instantTime1, fileSlice.getBaseInstantTime(),
+        "Base Instant of penultimate file-slice must be base instant");
     List<HoodieLogFile> logFiles = fileSlice.getLogFiles().collect(Collectors.toList());
     assertEquals(4, logFiles.size(), "Log files must include those after compaction request");
     assertEquals(fileName4, logFiles.get(0).getFileName(), "Log File Order check");
@@ -342,7 +344,8 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarnessJunit5
     fileSlice = fileSliceList.get(0);
     assertEquals(fileId, fileSlice.getFileId());
     assertFalse(fileSlice.getBaseFile().isPresent(), "No data-file expected in latest file-slice");
-    assertEquals(compactionRequestedTime, fileSlice.getBaseInstantTime(), "Compaction requested instant must be base instant");
+    assertEquals(compactionRequestedTime, fileSlice.getBaseInstantTime(),
+        "Compaction requested instant must be base instant");
     logFiles = fileSlice.getLogFiles().collect(Collectors.toList());
     assertEquals(2, logFiles.size(), "Log files must include only those after compaction request");
     assertEquals(fileName4, logFiles.get(0).getFileName(), "Log File Order check");
@@ -457,7 +460,8 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarnessJunit5
           "Orphan File Slice with log-file check data-file");
       logFiles = orphanFileSliceWithLogFile.getLogFiles().collect(Collectors.toList());
       assertEquals(1, logFiles.size(), "Orphan File Slice with log-file check data-file");
-      assertEquals(orphanLogFileName, logFiles.get(0).getFileName(), "Orphan File Slice with log-file check data-file");
+      assertEquals(orphanLogFileName, logFiles.get(0).getFileName(),
+          "Orphan File Slice with log-file check data-file");
       assertEquals(inflightDeltaInstantTime, inflightFileSliceWithLogFile.getBaseInstantTime(),
           "Inflight File Slice with log-file check base-commit");
       assertFalse(inflightFileSliceWithLogFile.getBaseFile().isPresent(),
@@ -1115,7 +1119,8 @@ public class TestHoodieTableFileSystemView extends HoodieCommonTestHarnessJunit5
       fileSlice = fileSliceList.get(0);
       assertEquals(fileId, fileSlice.getFileId());
       assertFalse(fileSlice.getBaseFile().isPresent(), "No data-file expected in latest file-slice");
-      assertEquals(compactionRequestedTime, fileSlice.getBaseInstantTime(), "Compaction requested instant must be base instant");
+      assertEquals(compactionRequestedTime, fileSlice.getBaseInstantTime(),
+          "Compaction requested instant must be base instant");
       logFiles = fileSlice.getLogFiles().collect(Collectors.toList());
       assertEquals(2, logFiles.size(), "Log files must include only those after compaction request");
       assertEquals(fileName4, logFiles.get(0).getFileName(), "Log File Order check");


### PR DESCRIPTION
Migrate all `HoodieClientTestHarness` subclasses, residing in hudi-cli, hudi-client, and hudi-utilities

Follows #1530 

### Migration status (after merging)

| Package | JUnit 5 lib | API migration | Restructure packages |
| --- | --- | --- | --- |
| `hudi-cli` | ✅ | ✅ | - |
| `hudi-client` | ✅ | 🚧 | - |
| `hudi-common` | ✅ | 🚧 | 🚧 |
| `hudi-hadoop-mr` | ✅ | ✅ | - |
| `hudi-hive-sync` | ✅ | ✅ | - |
| `hudi-integ-test` | ✅ | ✅  | N.A. |
| `hudi-spark` | ✅ | ✅ | - |
| `hudi-timeline-service` | ✅ | ✅ | - |
| `hudi-utilities` | ✅ | 🚧 | - |

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.