### PR TITLE
[WIP] [HUDI-834] Concrete signature of HoodieRecordPayload#combineAndGetUpdateValue & HoodieRecordPayload#getInsertValue

### DIFF
--- a/hudi-client/src/test/java/org/apache/hudi/common/TestRawTripPayload.java
+++ b/hudi-client/src/test/java/org/apache/hudi/common/TestRawTripPayload.java
@@ -27,7 +27,7 @@ import org.apache.hudi.common.util.Option;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.avro.Schema;
-import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.generic.GenericRecord;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -87,12 +87,12 @@ public class TestRawTripPayload implements HoodieRecordPayload<TestRawTripPayloa
   }
 
   @Override
-  public Option<IndexedRecord> combineAndGetUpdateValue(IndexedRecord oldRec, Schema schema) throws IOException {
+  public Option<GenericRecord> combineAndGetUpdateValue(GenericRecord oldRec, Schema schema) throws IOException {
     return this.getInsertValue(schema);
   }
 
   @Override
-  public Option<IndexedRecord> getInsertValue(Schema schema) throws IOException {
+  public Option<GenericRecord> getInsertValue(Schema schema) throws IOException {
     if (isDeleted) {
       return Option.empty();
     } else {

--- a/hudi-common/src/main/java/org/apache/hudi/common/HoodieJsonPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/HoodieJsonPayload.java
@@ -27,7 +27,7 @@ import org.apache.hudi.exception.HoodieException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.avro.Schema;
-import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.generic.GenericRecord;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -55,12 +55,12 @@ public class HoodieJsonPayload implements HoodieRecordPayload<HoodieJsonPayload>
   }
 
   @Override
-  public Option<IndexedRecord> combineAndGetUpdateValue(IndexedRecord oldRec, Schema schema) throws IOException {
+  public Option<GenericRecord> combineAndGetUpdateValue(GenericRecord oldRec, Schema schema) throws IOException {
     return getInsertValue(schema);
   }
 
   @Override
-  public Option<IndexedRecord> getInsertValue(Schema schema) throws IOException {
+  public Option<GenericRecord> getInsertValue(Schema schema) throws IOException {
     MercifulJsonConverter jsonConverter = new MercifulJsonConverter();
     return Option.of(jsonConverter.convert(getJsonData(), schema));
   }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/EmptyHoodieRecordPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/EmptyHoodieRecordPayload.java
@@ -22,7 +22,6 @@ import org.apache.hudi.common.util.Option;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.avro.generic.IndexedRecord;
 
 /**
  * Empty payload used for deletions.
@@ -41,12 +40,12 @@ public class EmptyHoodieRecordPayload implements HoodieRecordPayload<EmptyHoodie
   }
 
   @Override
-  public Option<IndexedRecord> combineAndGetUpdateValue(IndexedRecord currentValue, Schema schema) {
+  public Option<GenericRecord> combineAndGetUpdateValue(GenericRecord currentValue, Schema schema) {
     return Option.empty();
   }
 
   @Override
-  public Option<IndexedRecord> getInsertValue(Schema schema) {
+  public Option<GenericRecord> getInsertValue(Schema schema) {
     return Option.empty();
   }
 }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieAvroPayload.java
@@ -24,7 +24,6 @@ import org.apache.hudi.exception.HoodieIOException;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.avro.generic.IndexedRecord;
 
 import java.io.IOException;
 
@@ -56,12 +55,12 @@ public class HoodieAvroPayload implements HoodieRecordPayload<HoodieAvroPayload>
   }
 
   @Override
-  public Option<IndexedRecord> combineAndGetUpdateValue(IndexedRecord currentValue, Schema schema) throws IOException {
+  public Option<GenericRecord> combineAndGetUpdateValue(GenericRecord currentValue, Schema schema) throws IOException {
     return getInsertValue(schema);
   }
 
   @Override
-  public Option<IndexedRecord> getInsertValue(Schema schema) throws IOException {
+  public Option<GenericRecord> getInsertValue(Schema schema) throws IOException {
     if (recordBytes.length == 0) {
       return Option.empty();
     }

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/HoodieRecordPayload.java
@@ -21,7 +21,7 @@ package org.apache.hudi.common.model;
 import org.apache.hudi.common.util.Option;
 
 import org.apache.avro.Schema;
-import org.apache.avro.generic.IndexedRecord;
+import org.apache.avro.generic.GenericRecord;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -50,14 +50,14 @@ public interface HoodieRecordPayload<T extends HoodieRecordPayload> extends Seri
    * @param schema Schema used for record
    * @return new combined/merged value to be written back to storage. EMPTY to skip writing this record.
    */
-  Option<IndexedRecord> combineAndGetUpdateValue(IndexedRecord currentValue, Schema schema) throws IOException;
+  Option<GenericRecord> combineAndGetUpdateValue(GenericRecord currentValue, Schema schema) throws IOException;
 
   /**
    * Generates an avro record out of the given HoodieRecordPayload, to be written out to storage. Called when writing a
    * new value for the given HoodieKey, wherein there is no existing record in storage to be combined against. (i.e
    * insert) Return EMPTY to skip writing this record.
    */
-  Option<IndexedRecord> getInsertValue(Schema schema) throws IOException;
+  Option<GenericRecord> getInsertValue(Schema schema) throws IOException;
 
   /**
    * This method can be used to extract some metadata from HoodieRecordPayload. The metadata is passed to

--- a/hudi-common/src/main/java/org/apache/hudi/common/model/OverwriteWithLatestAvroPayload.java
+++ b/hudi-common/src/main/java/org/apache/hudi/common/model/OverwriteWithLatestAvroPayload.java
@@ -23,7 +23,6 @@ import org.apache.hudi.common.util.Option;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.avro.generic.IndexedRecord;
 
 import java.io.IOException;
 
@@ -58,14 +57,14 @@ public class OverwriteWithLatestAvroPayload extends BaseAvroPayload
   }
 
   @Override
-  public Option<IndexedRecord> combineAndGetUpdateValue(IndexedRecord currentValue, Schema schema) throws IOException {
+  public Option<GenericRecord> combineAndGetUpdateValue(GenericRecord currentValue, Schema schema) throws IOException {
 
-    Option<IndexedRecord> recordOption = getInsertValue(schema);
+    Option<GenericRecord> recordOption = getInsertValue(schema);
     if (!recordOption.isPresent()) {
       return Option.empty();
     }
 
-    GenericRecord genericRecord = (GenericRecord) recordOption.get();
+    GenericRecord genericRecord = recordOption.get();
     // combining strategy here trivially ignores currentValue on disk and writes this record
     Object deleteMarker = genericRecord.get("_hoodie_is_deleted");
     if (deleteMarker instanceof Boolean && (boolean) deleteMarker) {
@@ -76,7 +75,7 @@ public class OverwriteWithLatestAvroPayload extends BaseAvroPayload
   }
 
   @Override
-  public Option<IndexedRecord> getInsertValue(Schema schema) throws IOException {
+  public Option<GenericRecord> getInsertValue(Schema schema) throws IOException {
     return recordBytes.length == 0 ? Option.empty() : Option.of(HoodieAvroUtils.bytesToAvro(recordBytes, schema));
   }
 }

--- a/hudi-common/src/test/java/org/apache/hudi/common/model/AvroBinaryTestPayload.java
+++ b/hudi-common/src/test/java/org/apache/hudi/common/model/AvroBinaryTestPayload.java
@@ -24,7 +24,6 @@ import org.apache.hudi.exception.HoodieIOException;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.avro.generic.IndexedRecord;
 
 import java.io.IOException;
 
@@ -54,12 +53,12 @@ public class AvroBinaryTestPayload implements HoodieRecordPayload {
   }
 
   @Override
-  public Option<IndexedRecord> combineAndGetUpdateValue(IndexedRecord currentValue, Schema schema) throws IOException {
+  public Option<GenericRecord> combineAndGetUpdateValue(GenericRecord currentValue, Schema schema) throws IOException {
     return getInsertValue(schema);
   }
 
   @Override
-  public Option<IndexedRecord> getInsertValue(Schema schema) throws IOException {
+  public Option<GenericRecord> getInsertValue(Schema schema) throws IOException {
     return Option.of(HoodieAvroUtils.bytesToAvro(recordBytes, schema));
   }
 }

--- a/hudi-spark/src/main/java/org/apache/hudi/payload/AWSDmsAvroPayload.java
+++ b/hudi-spark/src/main/java/org/apache/hudi/payload/AWSDmsAvroPayload.java
@@ -23,7 +23,6 @@ import org.apache.hudi.common.util.Option;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.avro.generic.IndexedRecord;
 
 import java.io.IOException;
 
@@ -54,14 +53,13 @@ public class AWSDmsAvroPayload extends OverwriteWithLatestAvroPayload {
   }
 
   @Override
-  public Option<IndexedRecord> combineAndGetUpdateValue(IndexedRecord currentValue, Schema schema)
-      throws IOException {
-    IndexedRecord insertValue = getInsertValue(schema).get();
-    boolean delete = false;
-    if (insertValue instanceof GenericRecord) {
-      GenericRecord record = (GenericRecord) insertValue;
-      delete = record.get(OP_FIELD) != null && record.get(OP_FIELD).toString().equalsIgnoreCase("D");
-    }
+  public Option<GenericRecord> combineAndGetUpdateValue(
+      GenericRecord currentValue,
+      Schema schema
+  ) throws IOException {
+    final GenericRecord insertValue = getInsertValue(schema).get();
+    final boolean delete = insertValue.get(OP_FIELD) != null
+        && insertValue.get(OP_FIELD).toString().equalsIgnoreCase("D");
 
     return delete ? Option.empty() : Option.of(insertValue);
   }


### PR DESCRIPTION
## What is the purpose of the pull request

So far, the return type of HoodieRecordPayload#combineAndGetUpdateValue & HoodieRecordPayload#getInsertValue is effectively Option<GenericRecord>. Instead of doing unchecked cast at

org/apache/hudi/hadoop/realtime/RealtimeCompactedRecordReader.java:88

I propose we use Option<GenericRecord> as the return type of these two method, which replaces current Option<IndexedRecord>.

FYI, I encounter this ticket when trying to get rid of self type parameter in HoodieRecordPayload and found that it is a bit awkward if we don't take a self type while doing this casting. Fortunately it is the fact that we can directly concrete it.

cc @vinothchandar @leesf 

## Verify this pull request

This pull request is code refactor should be covered by existing tests.

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [ ] CI is green
