### PR TITLE
[HUDI-814] Migrate hudi-client tests to JUnit 5

### DIFF
--- a/hudi-client/src/test/java/org/apache/hudi/common/config/TestHoodieWriteConfig.java
+++ b/hudi-client/src/test/java/org/apache/hudi/common/config/TestHoodieWriteConfig.java
@@ -22,7 +22,7 @@ import org.apache.hudi.config.HoodieCompactionConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 import org.apache.hudi.config.HoodieWriteConfig.Builder;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -32,7 +32,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestHoodieWriteConfig {
 
@@ -52,8 +52,8 @@ public class TestHoodieWriteConfig {
       inputStream.close();
     }
     HoodieWriteConfig config = builder.build();
-    assertEquals(config.getMaxCommitsToKeep(), 5);
-    assertEquals(config.getMinCommitsToKeep(), 2);
+    assertEquals(5, config.getMaxCommitsToKeep());
+    assertEquals(2, config.getMinCommitsToKeep());
   }
 
   private ByteArrayOutputStream saveParamsIntoOutputStream(Map<String, String> params) throws IOException {

--- a/hudi-client/src/test/java/org/apache/hudi/index/bloom/TestBucketizedBloomCheckPartitioner.java
+++ b/hudi-client/src/test/java/org/apache/hudi/index/bloom/TestBucketizedBloomCheckPartitioner.java
@@ -20,7 +20,7 @@ package org.apache.hudi.index.bloom;
 
 import org.apache.hudi.common.util.collection.Pair;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.List;
@@ -28,9 +28,9 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestBucketizedBloomCheckPartitioner {
 
@@ -45,12 +45,12 @@ public class TestBucketizedBloomCheckPartitioner {
     };
     BucketizedBloomCheckPartitioner p = new BucketizedBloomCheckPartitioner(4, fileToComparisons, 10);
     Map<String, List<Integer>> assignments = p.getFileGroupToPartitions();
-    assertEquals("f1 should have 4 buckets", 4, assignments.get("f1").size());
-    assertEquals("f2 should have 4 buckets", 4, assignments.get("f2").size());
-    assertEquals("f3 should have 2 buckets", 2, assignments.get("f3").size());
-    assertArrayEquals("f1 spread across 3 partitions", new Integer[] {0, 0, 1, 3}, assignments.get("f1").toArray());
-    assertArrayEquals("f2 spread across 3 partitions", new Integer[] {1, 2, 2, 0}, assignments.get("f2").toArray());
-    assertArrayEquals("f3 spread across 2 partitions", new Integer[] {3, 1}, assignments.get("f3").toArray());
+    assertEquals(4, assignments.get("f1").size(), "f1 should have 4 buckets");
+    assertEquals(4, assignments.get("f2").size(), "f2 should have 4 buckets");
+    assertEquals(2, assignments.get("f3").size(), "f3 should have 2 buckets");
+    assertArrayEquals(new Integer[] {0, 0, 1, 3}, assignments.get("f1").toArray(), "f1 spread across 3 partitions");
+    assertArrayEquals(new Integer[] {1, 2, 2, 0}, assignments.get("f2").toArray(), "f2 spread across 3 partitions");
+    assertArrayEquals(new Integer[] {3, 1}, assignments.get("f3").toArray(), "f3 spread across 2 partitions");
   }
 
   @Test
@@ -78,7 +78,7 @@ public class TestBucketizedBloomCheckPartitioner {
       }
     };
     BucketizedBloomCheckPartitioner p = new BucketizedBloomCheckPartitioner(10000, comparisons1, 10);
-    assertEquals("num partitions must equal total buckets", 100, p.numPartitions());
+    assertEquals(100, p.numPartitions(), "num partitions must equal total buckets");
   }
 
   @Test
@@ -92,7 +92,7 @@ public class TestBucketizedBloomCheckPartitioner {
 
     IntStream.range(0, 100000).forEach(f -> {
       int partition = p.getPartition(Pair.of("f" + f, "value"));
-      assertTrue("partition is out of range: " + partition, 0 <= partition && partition <= 1000);
+      assertTrue(0 <= partition && partition <= 1000, "partition is out of range: " + partition);
     });
   }
 

--- a/hudi-client/src/test/java/org/apache/hudi/index/bloom/TestKeyRangeLookupTree.java
+++ b/hudi-client/src/test/java/org/apache/hudi/index/bloom/TestKeyRangeLookupTree.java
@@ -18,7 +18,7 @@
 
 package org.apache.hudi.index.bloom;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -27,7 +27,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests {@link KeyRangeLookupTree}.

--- a/hudi-client/src/test/java/org/apache/hudi/table/action/compact/strategy/TestHoodieCompactionStrategy.java
+++ b/hudi-client/src/test/java/org/apache/hudi/table/action/compact/strategy/TestHoodieCompactionStrategy.java
@@ -27,8 +27,7 @@ import org.apache.hudi.config.HoodieCompactionConfig;
 import org.apache.hudi.config.HoodieWriteConfig;
 
 import org.apache.hadoop.fs.Path;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -42,8 +41,8 @@ import java.util.Random;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestHoodieCompactionStrategy {
 
@@ -63,7 +62,7 @@ public class TestHoodieCompactionStrategy {
         .withCompactionConfig(HoodieCompactionConfig.newBuilder().withCompactionStrategy(strategy).build()).build();
     List<HoodieCompactionOperation> operations = createCompactionOperations(writeConfig, sizesMap);
     List<HoodieCompactionOperation> returned = strategy.orderAndFilter(writeConfig, operations, new ArrayList<>());
-    assertEquals("UnBounded should not re-order or filter", operations, returned);
+    assertEquals(operations, returned, "UnBounded should not re-order or filter");
   }
 
   @Test
@@ -80,13 +79,13 @@ public class TestHoodieCompactionStrategy {
     List<HoodieCompactionOperation> operations = createCompactionOperations(writeConfig, sizesMap);
     List<HoodieCompactionOperation> returned = strategy.orderAndFilter(writeConfig, operations, new ArrayList<>());
 
-    assertTrue("BoundedIOCompaction should have resulted in fewer compactions", returned.size() < operations.size());
-    assertEquals("BoundedIOCompaction should have resulted in 2 compactions being chosen", 2, returned.size());
+    assertTrue(returned.size() < operations.size(), "BoundedIOCompaction should have resulted in fewer compactions");
+    assertEquals(2, returned.size(), "BoundedIOCompaction should have resulted in 2 compactions being chosen");
     // Total size of all the log files
     Long returnedSize = returned.stream().map(s -> s.getMetrics().get(BoundedIOCompactionStrategy.TOTAL_IO_MB))
         .map(Double::longValue).reduce(Long::sum).orElse(0L);
-    assertEquals("Should chose the first 2 compactions which should result in a total IO of 690 MB", 610,
-        (long) returnedSize);
+    assertEquals(610, (long) returnedSize,
+        "Should chose the first 2 compactions which should result in a total IO of 690 MB");
   }
 
   @Test
@@ -103,14 +102,14 @@ public class TestHoodieCompactionStrategy {
     List<HoodieCompactionOperation> operations = createCompactionOperations(writeConfig, sizesMap);
     List<HoodieCompactionOperation> returned = strategy.orderAndFilter(writeConfig, operations, new ArrayList<>());
 
-    assertTrue("LogFileSizeBasedCompactionStrategy should have resulted in fewer compactions",
-        returned.size() < operations.size());
-    assertEquals("LogFileSizeBasedCompactionStrategy should have resulted in 1 compaction", 1, returned.size());
+    assertTrue(returned.size() < operations.size(),
+        "LogFileSizeBasedCompactionStrategy should have resulted in fewer compactions");
+    assertEquals(1, returned.size(), "LogFileSizeBasedCompactionStrategy should have resulted in 1 compaction");
     // Total size of all the log files
     Long returnedSize = returned.stream().map(s -> s.getMetrics().get(BoundedIOCompactionStrategy.TOTAL_IO_MB))
         .map(Double::longValue).reduce(Long::sum).orElse(0L);
-    assertEquals("Should chose the first 2 compactions which should result in a total IO of 690 MB", 1204,
-        (long) returnedSize);
+    assertEquals(1204, (long) returnedSize,
+        "Should chose the first 2 compactions which should result in a total IO of 690 MB");
   }
 
   @Test
@@ -137,14 +136,14 @@ public class TestHoodieCompactionStrategy {
     List<HoodieCompactionOperation> operations = createCompactionOperations(writeConfig, sizesMap, keyToPartitionMap);
     List<HoodieCompactionOperation> returned = strategy.orderAndFilter(writeConfig, operations, new ArrayList<>());
 
-    assertTrue("DayBasedCompactionStrategy should have resulted in fewer compactions",
-        returned.size() < operations.size());
-    Assert.assertEquals("DayBasedCompactionStrategy should have resulted in fewer compactions", returned.size(), 2);
+    assertTrue(returned.size() < operations.size(),
+        "DayBasedCompactionStrategy should have resulted in fewer compactions");
+    assertEquals(2, returned.size(), "DayBasedCompactionStrategy should have resulted in fewer compactions");
 
     int comparision = strategy.getComparator().compare(returned.get(returned.size() - 1).getPartitionPath(),
         returned.get(0).getPartitionPath());
     // Either the partition paths are sorted in descending order or they are equal
-    assertTrue("DayBasedCompactionStrategy should sort partitions in descending order", comparision >= 0);
+    assertTrue(comparision >= 0, "DayBasedCompactionStrategy should sort partitions in descending order");
   }
 
   @Test
@@ -185,15 +184,15 @@ public class TestHoodieCompactionStrategy {
     List<HoodieCompactionOperation> operations = createCompactionOperations(writeConfig, sizesMap, keyToPartitionMap);
     List<HoodieCompactionOperation> returned = strategy.orderAndFilter(writeConfig, operations, new ArrayList<>());
 
-    assertTrue("BoundedPartitionAwareCompactionStrategy should have resulted in fewer compactions",
-        returned.size() < operations.size());
-    Assert.assertEquals("BoundedPartitionAwareCompactionStrategy should have resulted in fewer compactions",
-        returned.size(), 5);
+    assertTrue(returned.size() < operations.size(),
+        "BoundedPartitionAwareCompactionStrategy should have resulted in fewer compactions");
+    assertEquals(5, returned.size(),
+        "BoundedPartitionAwareCompactionStrategy should have resulted in fewer compactions");
 
     int comparision = strategy.getComparator().compare(returned.get(returned.size() - 1).getPartitionPath(),
         returned.get(0).getPartitionPath());
     // Either the partition paths are sorted in descending order or they are equal
-    assertTrue("BoundedPartitionAwareCompactionStrategy should sort partitions in descending order", comparision >= 0);
+    assertTrue(comparision >= 0, "BoundedPartitionAwareCompactionStrategy should sort partitions in descending order");
   }
 
   @Test
@@ -234,12 +233,11 @@ public class TestHoodieCompactionStrategy {
     List<HoodieCompactionOperation> operations = createCompactionOperations(writeConfig, sizesMap, keyToPartitionMap);
     List<HoodieCompactionOperation> returned = strategy.orderAndFilter(writeConfig, operations, new ArrayList<>());
 
-    assertTrue(
+    assertTrue(returned.size() < operations.size(),
         "UnBoundedPartitionAwareCompactionStrategy should not include last "
-            + writeConfig.getTargetPartitionsPerDayBasedCompaction() + " partitions or later partitions from today",
-        returned.size() < operations.size());
-    Assert.assertEquals("BoundedPartitionAwareCompactionStrategy should have resulted in 1 compaction", returned.size(),
-        1);
+            + writeConfig.getTargetPartitionsPerDayBasedCompaction() + " partitions or later partitions from today");
+    assertEquals(1, returned.size(),
+        "BoundedPartitionAwareCompactionStrategy should have resulted in 1 compaction");
   }
 
   private List<HoodieCompactionOperation> createCompactionOperations(HoodieWriteConfig config,


### PR DESCRIPTION
Migrate the test cases in hudi-client to JUnit 5.

Follows #1553 

### Migration status (after merging)

| Package | JUnit 5 lib | API migration | Restructure packages |
| --- | --- | --- | --- |
| `hudi-cli` | ✅ | ✅ | - |
| `hudi-client` | ✅ | ✅ | - |
| `hudi-common` | ✅ | 🚧 | 🚧 |
| `hudi-hadoop-mr` | ✅ | ✅ | - |
| `hudi-hive-sync` | ✅ | ✅ | - |
| `hudi-integ-test` | ✅ | ✅  | N.A. |
| `hudi-spark` | ✅ | ✅ | - |
| `hudi-timeline-service` | ✅ | ✅ | - |
| `hudi-utilities` | ✅ | 🚧 | - |

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.