### PR TITLE
[HUDI-902] Avoid exception when getSchemaProvider

### DIFF
--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/InputBatch.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/InputBatch.java
@@ -18,9 +18,13 @@
 
 package org.apache.hudi.utilities.sources;
 
+import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.util.Option;
 import org.apache.hudi.exception.HoodieException;
 import org.apache.hudi.utilities.schema.SchemaProvider;
+
+import org.apache.avro.Schema;
+import org.apache.spark.api.java.JavaSparkContext;
 
 public class InputBatch<T> {
 
@@ -49,9 +53,25 @@ public class InputBatch<T> {
   }
 
   public SchemaProvider getSchemaProvider() {
-    if (schemaProvider == null) {
+    if (batch.isPresent() && schemaProvider == null) {
       throw new HoodieException("Please provide a valid schema provider class!");
     }
-    return schemaProvider;
+    return Option.ofNullable(schemaProvider).orElse(new NullSchemaProvider());
+  }
+
+  public static class NullSchemaProvider extends SchemaProvider {
+
+    public NullSchemaProvider() {
+      this(null, null);
+    }
+
+    public NullSchemaProvider(TypedProperties props, JavaSparkContext jssc) {
+      super(props, jssc);
+    }
+
+    @Override
+    public Schema getSourceSchema() {
+      return Schema.create(Schema.Type.NULL);
+    }
   }
 }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestInputBatch.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestInputBatch.java
@@ -1,0 +1,37 @@
+package org.apache.hudi.utilities.sources;
+
+import org.apache.hudi.common.util.Option;
+import org.apache.hudi.exception.HoodieException;
+import org.apache.hudi.utilities.schema.RowBasedSchemaProvider;
+import org.apache.hudi.utilities.schema.SchemaProvider;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestInputBatch {
+
+  @Test
+  public void getSchemaProviderShouldThrowException() {
+    final InputBatch<String> inputBatch = new InputBatch<>(Option.of("foo"), null, null);
+    Throwable t = assertThrows(HoodieException.class, inputBatch::getSchemaProvider);
+    assertEquals("Please provide a valid schema provider class!", t.getMessage());
+  }
+
+  @Test
+  public void getSchemaProviderShouldReturnNullSchemaProvider() {
+    final InputBatch<String> inputBatch = new InputBatch<>(Option.empty(), null, null);
+    SchemaProvider schemaProvider = inputBatch.getSchemaProvider();
+    assertTrue(schemaProvider instanceof InputBatch.NullSchemaProvider);
+  }
+
+  @Test
+  public void getSchemaProviderShouldReturnGivenSchemaProvider() {
+    SchemaProvider schemaProvider = new RowBasedSchemaProvider(null);
+    final InputBatch<String> inputBatch = new InputBatch<>(Option.of("foo"), null, schemaProvider);
+    assertSame(schemaProvider, inputBatch.getSchemaProvider());
+  }
+}


### PR DESCRIPTION
When no new data is fetched after reading from row source (like parquet), schema provider cannot be inferred and calling `getSchemaProvider()` results in HoodieException and requires schema provider to be set. This is not an ideal case for reading from schema-inferable source. Return `null` schema provider in case of no new data should be allowed.

## Committer checklist

 - [ ] Has a corresponding JIRA in PR title & commit
 
 - [ ] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.