### PR TITLE
[HUDI-813] Migrate hudi-utilities tests to JUnit 5

### DIFF
--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestAWSDatabaseMigrationServiceSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestAWSDatabaseMigrationServiceSource.java
@@ -28,29 +28,29 @@ import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Arrays;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestAWSDatabaseMigrationServiceSource {
 
   private static JavaSparkContext jsc;
   private static SparkSession spark;
 
-  @BeforeClass
+  @BeforeAll
   public static void setupTest() {
     jsc = UtilHelpers.buildSparkContext("aws-dms-test", "local[2]");
     spark = SparkSession.builder().config(jsc.getConf()).getOrCreate();
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownTest() {
     if (jsc != null) {
       jsc.stop();
@@ -99,7 +99,7 @@ public class TestAWSDatabaseMigrationServiceSource {
         new Record("2", 3433L)), Record.class);
 
     Dataset<Row> outputFrame = transformer.apply(jsc, spark, inputFrame, null);
-    assertTrue(Arrays.asList(outputFrame.schema().fields()).stream()
+    assertTrue(Arrays.stream(outputFrame.schema().fields())
         .map(f -> f.name()).anyMatch(n -> n.equals(AWSDmsAvroPayload.OP_FIELD)));
     assertTrue(outputFrame.select(AWSDmsAvroPayload.OP_FIELD).collectAsList().stream()
         .allMatch(r -> r.getString(0).equals("")));

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHDFSParquetImporter.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHDFSParquetImporter.java
@@ -41,12 +41,11 @@ import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SQLContext;
-
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -61,8 +60,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestHDFSParquetImporter implements Serializable {
 
@@ -71,7 +70,7 @@ public class TestHDFSParquetImporter implements Serializable {
   private static MiniDFSCluster dfsCluster;
   private static DistributedFileSystem dfs;
 
-  @BeforeClass
+  @BeforeAll
   public static void initClass() throws Exception {
     hdfsTestService = new HdfsTestService();
     dfsCluster = hdfsTestService.start(true);
@@ -82,7 +81,7 @@ public class TestHDFSParquetImporter implements Serializable {
     dfs.mkdirs(new Path(dfsBasePath));
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanupClass() {
     if (hdfsTestService != null) {
       hdfsTestService.stop();
@@ -94,7 +93,7 @@ public class TestHDFSParquetImporter implements Serializable {
   private transient Path srcFolder;
   private transient List<GenericRecord> insertData;
 
-  @Before
+  @BeforeEach
   public void init() throws IOException, ParseException {
     basePath = (new Path(dfsBasePath, Thread.currentThread().getStackTrace()[1].getMethodName())).toString();
 
@@ -106,7 +105,7 @@ public class TestHDFSParquetImporter implements Serializable {
     insertData = createInsertRecords(srcFolder);
   }
 
-  @After
+  @AfterEach
   public void clean() throws IOException {
     dfs.delete(new Path(basePath), true);
   }
@@ -138,8 +137,8 @@ public class TestHDFSParquetImporter implements Serializable {
       };
       // Schema file is not created so this operation should fail.
       assertEquals(0, dataImporter.dataImport(jsc, retry.get()));
-      assertEquals(retry.get(), -1);
-      assertEquals(fileCreated.get(), 1);
+      assertEquals(-1, retry.get());
+      assertEquals(1, fileCreated.get());
 
       // Check if
       // 1. .commit file is present
@@ -162,10 +161,10 @@ public class TestHDFSParquetImporter implements Serializable {
           recordCounts.put(partitionPath, recordCounts.get(partitionPath) + count);
         }
       }
-      assertTrue("commit file is missing", isCommitFilePresent);
-      assertEquals("partition is missing", 4, recordCounts.size());
+      assertTrue(isCommitFilePresent, "commit file is missing");
+      assertEquals(4, recordCounts.size(), "partition is missing");
       for (Entry<String, Long> e : recordCounts.entrySet()) {
-        assertEquals("missing records", 24, e.getValue().longValue());
+        assertEquals(24, e.getValue().longValue(), "missing records");
       }
     }
   }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHiveIncrementalPuller.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHiveIncrementalPuller.java
@@ -18,15 +18,16 @@
 
 package org.apache.hudi.utilities;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 public class TestHiveIncrementalPuller {
 
   private HiveIncrementalPuller.Config config;
 
-  @Before
+  @BeforeEach
   public void setup() {
     config = new HiveIncrementalPuller.Config();
   }
@@ -34,11 +35,9 @@ public class TestHiveIncrementalPuller {
   @Test
   public void testInitHiveIncrementalPuller() {
 
-    try {
+    assertDoesNotThrow(() -> {
       new HiveIncrementalPuller(config);
-    } catch (Exception e) {
-      Assert.fail("Unexpected exception while initing HiveIncrementalPuller, msg: " + e.getMessage());
-    }
+    }, "Unexpected exception while initing HiveIncrementalPuller.");
 
   }
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieMultiTableDeltaStreamer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestHoodieMultiTableDeltaStreamer.java
@@ -30,15 +30,15 @@ import org.apache.hudi.utilities.sources.TestDataSource;
 
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestHoodieMultiTableDeltaStreamer extends TestHoodieDeltaStreamer {
 
@@ -63,65 +63,57 @@ public class TestHoodieMultiTableDeltaStreamer extends TestHoodieDeltaStreamer {
 
   @Test
   public void testInvalidHiveSyncProps() throws IOException {
-    HoodieMultiTableDeltaStreamer.Config cfg = TestHelpers.getConfig(PROPS_INVALID_HIVE_SYNC_TEST_SOURCE1,dfsBasePath + "/config", TestDataSource.class.getName(), true);
-    try {
+    HoodieMultiTableDeltaStreamer.Config cfg = TestHelpers.getConfig(PROPS_INVALID_HIVE_SYNC_TEST_SOURCE1, dfsBasePath + "/config", TestDataSource.class.getName(), true);
+    Exception e = assertThrows(HoodieException.class, () -> {
       new HoodieMultiTableDeltaStreamer(cfg, jsc);
-      fail("Should fail when hive sync table not provided with enableHiveSync flag");
-    } catch (HoodieException he) {
-      log.error("Expected error when creating table execution objects", he);
-      assertTrue(he.getMessage().contains("Hive sync table field not provided!"));
-    }
+    }, "Should fail when hive sync table not provided with enableHiveSync flag");
+    log.debug("Expected error when creating table execution objects", e);
+    assertTrue(e.getMessage().contains("Hive sync table field not provided!"));
   }
 
   @Test
   public void testInvalidPropsFilePath() throws IOException {
-    HoodieMultiTableDeltaStreamer.Config cfg = TestHelpers.getConfig(PROPS_INVALID_FILE,dfsBasePath + "/config", TestDataSource.class.getName(), true);
-    try {
+    HoodieMultiTableDeltaStreamer.Config cfg = TestHelpers.getConfig(PROPS_INVALID_FILE, dfsBasePath + "/config", TestDataSource.class.getName(), true);
+    Exception e = assertThrows(IllegalArgumentException.class, () -> {
       new HoodieMultiTableDeltaStreamer(cfg, jsc);
-      fail("Should fail when invalid props file is provided");
-    } catch (IllegalArgumentException iae) {
-      log.error("Expected error when creating table execution objects", iae);
-      assertTrue(iae.getMessage().contains("Please provide valid common config file path!"));
-    }
+    }, "Should fail when invalid props file is provided");
+    log.debug("Expected error when creating table execution objects", e);
+    assertTrue(e.getMessage().contains("Please provide valid common config file path!"));
   }
 
   @Test
   public void testInvalidTableConfigFilePath() throws IOException {
-    HoodieMultiTableDeltaStreamer.Config cfg = TestHelpers.getConfig(PROPS_INVALID_TABLE_CONFIG_FILE,dfsBasePath + "/config", TestDataSource.class.getName(), true);
-    try {
+    HoodieMultiTableDeltaStreamer.Config cfg = TestHelpers.getConfig(PROPS_INVALID_TABLE_CONFIG_FILE, dfsBasePath + "/config", TestDataSource.class.getName(), true);
+    Exception e = assertThrows(IllegalArgumentException.class, () -> {
       new HoodieMultiTableDeltaStreamer(cfg, jsc);
-      fail("Should fail when invalid table config props file path is provided");
-    } catch (IllegalArgumentException iae) {
-      log.error("Expected error when creating table execution objects", iae);
-      assertTrue(iae.getMessage().contains("Please provide valid table config file path!"));
-    }
+    }, "Should fail when invalid table config props file path is provided");
+    log.debug("Expected error when creating table execution objects", e);
+    assertTrue(e.getMessage().contains("Please provide valid table config file path!"));
   }
 
   @Test
   public void testCustomConfigProps() throws IOException {
-    HoodieMultiTableDeltaStreamer.Config cfg = TestHelpers.getConfig(PROPS_FILENAME_TEST_SOURCE1,dfsBasePath + "/config", TestDataSource.class.getName(), false);
+    HoodieMultiTableDeltaStreamer.Config cfg = TestHelpers.getConfig(PROPS_FILENAME_TEST_SOURCE1, dfsBasePath + "/config", TestDataSource.class.getName(), false);
     HoodieMultiTableDeltaStreamer streamer = new HoodieMultiTableDeltaStreamer(cfg, jsc);
     TableExecutionContext executionContext = streamer.getTableExecutionContexts().get(1);
-    assertEquals(streamer.getTableExecutionContexts().size(), 2);
-    assertEquals(executionContext.getConfig().targetBasePath, dfsBasePath + "/multi_table_dataset/uber_db/dummy_table_uber");
-    assertEquals(executionContext.getConfig().targetTableName, "uber_db.dummy_table_uber");
-    assertEquals(executionContext.getProperties().getString(HoodieMultiTableDeltaStreamer.Constants.KAFKA_TOPIC_PROP), "topic1");
-    assertEquals(executionContext.getProperties().getString(DataSourceWriteOptions.RECORDKEY_FIELD_OPT_KEY()), "_row_key");
-    assertEquals(executionContext.getProperties().getString(DataSourceWriteOptions.KEYGENERATOR_CLASS_OPT_KEY()), TestHoodieDeltaStreamer.TestGenerator.class.getName());
-    assertEquals(executionContext.getProperties().getString(HoodieMultiTableDeltaStreamer.Constants.HIVE_SYNC_TABLE_PROP), "uber_hive_dummy_table");
+    assertEquals(2, streamer.getTableExecutionContexts().size());
+    assertEquals(dfsBasePath + "/multi_table_dataset/uber_db/dummy_table_uber", executionContext.getConfig().targetBasePath);
+    assertEquals("uber_db.dummy_table_uber", executionContext.getConfig().targetTableName);
+    assertEquals("topic1", executionContext.getProperties().getString(HoodieMultiTableDeltaStreamer.Constants.KAFKA_TOPIC_PROP));
+    assertEquals("_row_key", executionContext.getProperties().getString(DataSourceWriteOptions.RECORDKEY_FIELD_OPT_KEY()));
+    assertEquals(TestHoodieDeltaStreamer.TestGenerator.class.getName(), executionContext.getProperties().getString(DataSourceWriteOptions.KEYGENERATOR_CLASS_OPT_KEY()));
+    assertEquals("uber_hive_dummy_table", executionContext.getProperties().getString(HoodieMultiTableDeltaStreamer.Constants.HIVE_SYNC_TABLE_PROP));
   }
 
   @Test
-  @Ignore
+  @Disabled
   public void testInvalidIngestionProps() {
-    try {
-      HoodieMultiTableDeltaStreamer.Config cfg = TestHelpers.getConfig(PROPS_FILENAME_TEST_SOURCE1,dfsBasePath + "/config", TestDataSource.class.getName(), true);
+    Exception e = assertThrows(Exception.class, () -> {
+      HoodieMultiTableDeltaStreamer.Config cfg = TestHelpers.getConfig(PROPS_FILENAME_TEST_SOURCE1, dfsBasePath + "/config", TestDataSource.class.getName(), true);
       new HoodieMultiTableDeltaStreamer(cfg, jsc);
-      fail("Creation of execution object should fail without kafka topic");
-    } catch (Exception e) {
-      log.error("Creation of execution object failed with error: " + e.getMessage(), e);
-      assertTrue(e.getMessage().contains("Please provide valid table config arguments!"));
-    }
+    }, "Creation of execution object should fail without kafka topic");
+    log.debug("Creation of execution object failed with error: " + e.getMessage(), e);
+    assertTrue(e.getMessage().contains("Please provide valid table config arguments!"));
   }
 
   @Test //0 corresponds to fg
@@ -156,7 +148,7 @@ public class TestHoodieMultiTableDeltaStreamer extends TestHoodieDeltaStreamer {
     testUtils.sendMessages("topic1", Helpers.jsonifyRecords(dataGenerator.generateUpdatesAsPerSchema("001", 5, HoodieTestDataGenerator.TRIP_SCHEMA)));
     testUtils.sendMessages("topic2", Helpers.jsonifyRecords(dataGenerator.generateUpdatesAsPerSchema("001", 10, HoodieTestDataGenerator.SHORT_TRIP_SCHEMA)));
     streamer.sync();
-    assertEquals(streamer.getSuccessTables().size(), 2);
+    assertEquals(2, streamer.getSuccessTables().size());
     assertTrue(streamer.getFailedTables().isEmpty());
 
     //assert the record count matches now

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestJdbcbasedSchemaProvider.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestJdbcbasedSchemaProvider.java
@@ -26,9 +26,9 @@ import org.apache.avro.Schema;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.apache.spark.api.java.JavaSparkContext;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.sql.Connection;
@@ -36,7 +36,7 @@ import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestJdbcbasedSchemaProvider {
 
@@ -44,7 +44,7 @@ public class TestJdbcbasedSchemaProvider {
   private static final TypedProperties PROPS = new TypedProperties();
   protected transient JavaSparkContext jsc = null;
 
-  @Before
+  @BeforeEach
   public void init() {
     jsc = UtilHelpers.buildSparkContext(this.getClass().getName() + "-hoodie", "local[2]");
     PROPS.setProperty("hoodie.deltastreamer.schemaprovider.source.schema.jdbc.connection.url", "jdbc:h2:mem:test_mem");
@@ -56,7 +56,7 @@ public class TestJdbcbasedSchemaProvider {
     PROPS.setProperty("hoodie.deltastreamer.schemaprovider.source.schema.jdbc.nullable", "false");
   }
 
-  @After
+  @AfterEach
   public void teardown() throws Exception {
     if (jsc != null) {
       jsc.stop();

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestSchedulerConfGenerator.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestSchedulerConfGenerator.java
@@ -22,12 +22,12 @@ import org.apache.hudi.common.model.HoodieTableType;
 import org.apache.hudi.utilities.deltastreamer.HoodieDeltaStreamer;
 import org.apache.hudi.utilities.deltastreamer.SchedulerConfGenerator;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class TestSchedulerConfGenerator {
 
@@ -35,21 +35,21 @@ public class TestSchedulerConfGenerator {
   public void testGenerateSparkSchedulingConf() throws Exception {
     HoodieDeltaStreamer.Config cfg = new HoodieDeltaStreamer.Config();
     Map<String, String> configs = SchedulerConfGenerator.getSparkSchedulingConfigs(cfg);
-    assertNull("spark.scheduler.mode not set", configs.get(SchedulerConfGenerator.SPARK_SCHEDULER_ALLOCATION_FILE_KEY));
+    assertNull(configs.get(SchedulerConfGenerator.SPARK_SCHEDULER_ALLOCATION_FILE_KEY), "spark.scheduler.mode not set");
 
     System.setProperty(SchedulerConfGenerator.SPARK_SCHEDULER_MODE_KEY, "FAIR");
     cfg.continuousMode = false;
     configs = SchedulerConfGenerator.getSparkSchedulingConfigs(cfg);
-    assertNull("continuousMode is false", configs.get(SchedulerConfGenerator.SPARK_SCHEDULER_ALLOCATION_FILE_KEY));
+    assertNull(configs.get(SchedulerConfGenerator.SPARK_SCHEDULER_ALLOCATION_FILE_KEY), "continuousMode is false");
 
     cfg.continuousMode = true;
     cfg.tableType = HoodieTableType.COPY_ON_WRITE.name();
     configs = SchedulerConfGenerator.getSparkSchedulingConfigs(cfg);
-    assertNull("table type is not MERGE_ON_READ",
-        configs.get(SchedulerConfGenerator.SPARK_SCHEDULER_ALLOCATION_FILE_KEY));
+    assertNull(configs.get(SchedulerConfGenerator.SPARK_SCHEDULER_ALLOCATION_FILE_KEY),
+        "table type is not MERGE_ON_READ");
 
     cfg.tableType = HoodieTableType.MERGE_ON_READ.name();
     configs = SchedulerConfGenerator.getSparkSchedulingConfigs(cfg);
-    assertNotNull("all satisfies", configs.get(SchedulerConfGenerator.SPARK_SCHEDULER_ALLOCATION_FILE_KEY));
+    assertNotNull(configs.get(SchedulerConfGenerator.SPARK_SCHEDULER_ALLOCATION_FILE_KEY), "all satisfies");
   }
 }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestTimestampBasedKeyGenerator.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestTimestampBasedKeyGenerator.java
@@ -26,18 +26,18 @@ import org.apache.hudi.utilities.keygen.TimestampBasedKeyGenerator;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestTimestampBasedKeyGenerator {
   private GenericRecord baseRecord;
   private TypedProperties properties = new TypedProperties();
 
-  @Before
+  @BeforeEach
   public void initialize() throws IOException {
     Schema schema = SchemaTestUtil.getTimestampEvolvedSchema();
     baseRecord = SchemaTestUtil
@@ -61,23 +61,23 @@ public class TestTimestampBasedKeyGenerator {
     baseRecord.put("createTime", 1578283932000L);
     properties = getBaseKeyConfig("EPOCHMILLISECONDS", "yyyy-MM-dd hh", "GMT+8:00");
     HoodieKey hk1 = new TimestampBasedKeyGenerator(properties).getKey(baseRecord);
-    assertEquals(hk1.getPartitionPath(), "2020-01-06 12");
+    assertEquals("2020-01-06 12", hk1.getPartitionPath());
 
     // timezone is GMT
     properties = getBaseKeyConfig("EPOCHMILLISECONDS", "yyyy-MM-dd hh", "GMT");
     HoodieKey hk2 = new TimestampBasedKeyGenerator(properties).getKey(baseRecord);
-    assertEquals(hk2.getPartitionPath(), "2020-01-06 04");
+    assertEquals("2020-01-06 04", hk2.getPartitionPath());
 
     // timestamp is DATE_STRING, timezone is GMT+8:00
     baseRecord.put("createTime", "2020-01-06 12:12:12");
     properties = getBaseKeyConfig("DATE_STRING", "yyyy-MM-dd hh", "GMT+8:00");
     properties.setProperty("hoodie.deltastreamer.keygen.timebased.input.dateformat", "yyyy-MM-dd hh:mm:ss");
     HoodieKey hk3 = new TimestampBasedKeyGenerator(properties).getKey(baseRecord);
-    assertEquals(hk3.getPartitionPath(), "2020-01-06 12");
+    assertEquals("2020-01-06 12", hk3.getPartitionPath());
 
     // timezone is GMT
     properties = getBaseKeyConfig("DATE_STRING", "yyyy-MM-dd hh", "GMT");
     HoodieKey hk4 = new TimestampBasedKeyGenerator(properties).getKey(baseRecord);
-    assertEquals(hk4.getPartitionPath(), "2020-01-06 12");
+    assertEquals("2020-01-06 12", hk4.getPartitionPath());
   }
 }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestUtilHelpers.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/TestUtilHelpers.java
@@ -27,44 +27,39 @@ import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.experimental.runners.Enclosed;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@RunWith(Enclosed.class)
 public class TestUtilHelpers {
 
-  public static class TestCreateTransformer {
+  public static class TransformerFoo implements Transformer {
 
-    public static class TransformerFoo implements Transformer {
-
-      @Override
-      public Dataset apply(JavaSparkContext jsc, SparkSession sparkSession, Dataset<Row> rowDataset, TypedProperties properties) {
-        return null;
-      }
+    @Override
+    public Dataset apply(JavaSparkContext jsc, SparkSession sparkSession, Dataset<Row> rowDataset, TypedProperties properties) {
+      return null;
     }
+  }
 
-    public static class TransformerBar implements Transformer {
+  public static class TransformerBar implements Transformer {
 
-      @Override
-      public Dataset apply(JavaSparkContext jsc, SparkSession sparkSession, Dataset<Row> rowDataset, TypedProperties properties) {
-        return null;
-      }
+    @Override
+    public Dataset apply(JavaSparkContext jsc, SparkSession sparkSession, Dataset<Row> rowDataset, TypedProperties properties) {
+      return null;
     }
+  }
 
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
+  @Nested
+  public class TestCreateTransformer {
 
     @Test
     public void testCreateTransformerNotPresent() throws IOException {
@@ -93,9 +88,10 @@ public class TestUtilHelpers {
 
     @Test
     public void testCreateTransformerThrowsException() throws IOException {
-      exceptionRule.expect(IOException.class);
-      exceptionRule.expectMessage("Could not load transformer class(es) [foo, bar]");
-      UtilHelpers.createTransformer(Arrays.asList("foo", "bar"));
+      Exception e = assertThrows(IOException.class, () -> {
+        UtilHelpers.createTransformer(Arrays.asList("foo", "bar"));
+      });
+      assertEquals("Could not load transformer class(es) [foo, bar]", e.getMessage());
     }
   }
 }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/UtilitiesTestBase.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/UtilitiesTestBase.java
@@ -56,10 +56,10 @@ import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.sql.SQLContext;
 import org.apache.spark.sql.SparkSession;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -86,7 +86,7 @@ public class UtilitiesTestBase {
   protected static HiveTestService hiveTestService;
   private static ObjectMapper mapper = new ObjectMapper();
 
-  @BeforeClass
+  @BeforeAll
   public static void initClass() throws Exception {
     initClass(false);
   }
@@ -104,7 +104,7 @@ public class UtilitiesTestBase {
     }
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanupClass() {
     if (hdfsTestService != null) {
       hdfsTestService.stop();
@@ -117,7 +117,7 @@ public class UtilitiesTestBase {
     }
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     TestDataSource.initDataGen();
     jsc = UtilHelpers.buildSparkContext(this.getClass().getName() + "-hoodie", "local[2]");
@@ -125,7 +125,7 @@ public class UtilitiesTestBase {
     sparkSession = SparkSession.builder().config(jsc.getConf()).getOrCreate();
   }
 
-  @After
+  @AfterEach
   public void teardown() throws Exception {
     TestDataSource.resetDataGen();
     if (jsc != null) {

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/inline/fs/TestParquetInLining.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/inline/fs/TestParquetInLining.java
@@ -33,9 +33,8 @@ import org.apache.parquet.avro.AvroParquetWriter;
 import org.apache.parquet.hadoop.ParquetReader;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -46,6 +45,7 @@ import java.util.UUID;
 import static org.apache.hudi.common.fs.inline.FileSystemTestUtils.FILE_SCHEME;
 import static org.apache.hudi.common.fs.inline.FileSystemTestUtils.getPhantomFile;
 import static org.apache.hudi.common.fs.inline.FileSystemTestUtils.getRandomOuterInMemPath;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 /**
  * Tests {@link InLineFileSystem} with Parquet writer and reader. hudi-common can't access HoodieTestDataGenerator.
@@ -64,7 +64,7 @@ public class TestParquetInLining {
     inlineConf.set("fs." + InLineFileSystem.SCHEME + ".impl", InLineFileSystem.class.getName());
   }
 
-  @After
+  @AfterEach
   public void teardown() throws IOException {
     if (generatedPath != null) {
       File filePath = new File(generatedPath.toString().substring(generatedPath.toString().indexOf(':') + 1));
@@ -98,7 +98,7 @@ public class TestParquetInLining {
     // instantiate Parquet reader
     ParquetReader inLineReader = AvroParquetReader.builder(inlinePath).withConf(inlineConf).build();
     List<GenericRecord> records = readParquetGenericRecords(inLineReader);
-    Assert.assertArrayEquals(recordsToWrite.toArray(), records.toArray());
+    assertArrayEquals(recordsToWrite.toArray(), records.toArray());
     inLineReader.close();
   }
 

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/AbstractDFSSourceTestBase.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/AbstractDFSSourceTestBase.java
@@ -35,17 +35,17 @@ import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * An abstract test base for {@link Source} using DFS as the file system.
@@ -58,23 +58,23 @@ public abstract class AbstractDFSSourceTestBase extends UtilitiesTestBase {
   HoodieTestDataGenerator dataGenerator = new HoodieTestDataGenerator();
   boolean useFlattenedSchema = false;
 
-  @BeforeClass
+  @BeforeAll
   public static void initClass() throws Exception {
     UtilitiesTestBase.initClass();
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanupClass() {
     UtilitiesTestBase.cleanupClass();
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     super.setup();
     schemaProvider = new FilebasedSchemaProvider(Helpers.setupSchemaOnDFS(), jsc);
   }
 
-  @After
+  @AfterEach
   public void teardown() throws Exception {
     super.teardown();
   }

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestCsvDFSSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestCsvDFSSource.java
@@ -24,7 +24,7 @@ import org.apache.hudi.utilities.UtilitiesTestBase;
 import org.apache.hudi.utilities.schema.FilebasedSchemaProvider;
 
 import org.apache.hadoop.fs.Path;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.io.IOException;
 import java.util.List;
@@ -34,7 +34,7 @@ import java.util.List;
  */
 public class TestCsvDFSSource extends AbstractDFSSourceTestBase {
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     super.setup();
     this.dfsRoot = dfsBasePath + "/jsonFiles";

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestJsonDFSSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestJsonDFSSource.java
@@ -23,7 +23,7 @@ import org.apache.hudi.common.model.HoodieRecord;
 import org.apache.hudi.utilities.UtilitiesTestBase;
 
 import org.apache.hadoop.fs.Path;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.io.IOException;
 import java.util.List;
@@ -33,7 +33,7 @@ import java.util.List;
  */
 public class TestJsonDFSSource extends AbstractDFSSourceTestBase {
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     super.setup();
     this.dfsRoot = dfsBasePath + "/jsonFiles";

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestKafkaSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestKafkaSource.java
@@ -36,16 +36,16 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.streaming.kafka010.KafkaTestUtils;
 import org.apache.spark.streaming.kafka010.OffsetRange;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.UUID;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests against {@link AvroKafkaSource}.
@@ -57,17 +57,17 @@ public class TestKafkaSource extends UtilitiesTestBase {
   private FilebasedSchemaProvider schemaProvider;
   private KafkaTestUtils testUtils;
 
-  @BeforeClass
+  @BeforeAll
   public static void initClass() throws Exception {
     UtilitiesTestBase.initClass();
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanupClass() {
     UtilitiesTestBase.cleanupClass();
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     super.setup();
     schemaProvider = new FilebasedSchemaProvider(Helpers.setupSchemaOnDFS(), jsc);
@@ -75,7 +75,7 @@ public class TestKafkaSource extends UtilitiesTestBase {
     testUtils.setup();
   }
 
-  @After
+  @AfterEach
   public void teardown() throws Exception {
     super.teardown();
     testUtils.teardown();

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestParquetDFSSource.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/sources/TestParquetDFSSource.java
@@ -22,7 +22,7 @@ import org.apache.hudi.common.config.TypedProperties;
 import org.apache.hudi.common.model.HoodieRecord;
 
 import org.apache.hadoop.fs.Path;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.io.IOException;
 import java.util.List;
@@ -32,7 +32,7 @@ import java.util.List;
  */
 public class TestParquetDFSSource extends AbstractDFSSourceTestBase {
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     super.setup();
     this.dfsRoot = dfsBasePath + "/parquetFiles";

--- a/hudi-utilities/src/test/java/org/apache/hudi/utilities/transform/TestFlatteningTransformer.java
+++ b/hudi-utilities/src/test/java/org/apache/hudi/utilities/transform/TestFlatteningTransformer.java
@@ -22,9 +22,9 @@ import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestFlatteningTransformer {
 


### PR DESCRIPTION
Migrate the test cases in hudi-utilities to JUnit 5.

Follows #1570 

### Migration status (after merging)

| Package | JUnit 5 lib | API migration | Restructure packages |
| --- | --- | --- | --- |
| `hudi-cli` | ✅ | ✅ | - |
| `hudi-client` | ✅ | ✅ | - |
| `hudi-common` | ✅ | 🚧 | 🚧 |
| `hudi-hadoop-mr` | ✅ | ✅ | - |
| `hudi-hive-sync` | ✅ | ✅ | - |
| `hudi-integ-test` | ✅ | ✅  | N.A. |
| `hudi-spark` | ✅ | ✅ | - |
| `hudi-timeline-service` | ✅ | ✅ | - |
| `hudi-utilities` | ✅ | ✅ | - |

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.