### PR TITLE
[HUDI-884] Shade avro and parquet-avro in hudi-hive-sync-bundle

### DIFF
--- a/hudi-integ-test/src/test/java/org/apache/hudi/integ/ITTestHoodieDemo.java
+++ b/hudi-integ-test/src/test/java/org/apache/hudi/integ/ITTestHoodieDemo.java
@@ -125,8 +125,15 @@ public class ITTestHoodieDemo extends ITTestBase {
             + " --source-class org.apache.hudi.utilities.sources.JsonDFSSource --source-ordering-field ts "
             + " --target-base-path " + COW_BASE_PATH + " --target-table " + COW_TABLE_NAME
             + " --props /var/demo/config/dfs-source.properties"
-            + " --schemaprovider-class org.apache.hudi.utilities.schema.FilebasedSchemaProvider "
-            + String.format(HIVE_SYNC_CMD_FMT, "dt", COW_TABLE_NAME),
+            + " --schemaprovider-class org.apache.hudi.utilities.schema.FilebasedSchemaProvider ",
+        "spark-submit --class org.apache.hudi.hive.HiveSyncTool " + HUDI_HIVE_SYNC_BUNDLE
+            + " --database default"
+            + " --table " + COW_TABLE_NAME
+            + " --base-path " + COW_BASE_PATH
+            + " --user hive"
+            + " --pass hive"
+            + " --jdbc-url jdbc:hive2://hiveserver:10000"
+            + " --partitioned-by dt",
         ("spark-submit --class org.apache.hudi.utilities.deltastreamer.HoodieDeltaStreamer " + HUDI_UTILITIES_BUNDLE
             + " --table-type MERGE_ON_READ "
             + " --source-class org.apache.hudi.utilities.sources.JsonDFSSource --source-ordering-field ts "

--- a/packaging/hudi-hive-sync-bundle/pom.xml
+++ b/packaging/hudi-hive-sync-bundle/pom.xml
@@ -69,12 +69,19 @@
                   <include>org.apache.hudi:hudi-hive-sync</include>
 
                   <include>com.beust:jcommander</include>
+                  <include>org.apache.avro:avro</include>
                   <include>org.apache.parquet:parquet-avro</include>
                   <include>com.esotericsoftware:kryo-shaded</include>
                   <include>org.objenesis:objenesis</include>
                   <include>com.esotericsoftware:minlog</include>
                 </includes>
               </artifactSet>
+              <relocations>
+                <relocation>
+                  <pattern>org.apache.avro.</pattern>
+                  <shadedPattern>org.apache.hudi.org.apache.avro.</shadedPattern>
+                </relocation>
+              </relocations>
               <createDependencyReducedPom>false</createDependencyReducedPom>
               <filters>
                 <filter>
@@ -119,6 +126,18 @@
       <groupId>org.apache.hudi</groupId>
       <artifactId>hudi-hive-sync</artifactId>
       <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.parquet</groupId>
+      <artifactId>parquet-avro</artifactId>
+      <scope>compile</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.avro</groupId>
+      <artifactId>avro</artifactId>
+      <scope>compile</scope>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
## *Tips*
- *Thank you very much for contributing to Apache Hudi.*
- *Please review https://hudi.apache.org/contributing.html before opening a pull request.*

## What is the purpose of the pull request

This pull request fixes the issue with running hive standalone tool mentioned here https://github.com/apache/incubator-hudi/issues/1610 . The error surfaced after the merging of https://github.com/apache/incubator-hudi/pull/1559 . It brought to forefront a couple of misses in hudi-hive-sync-bundle packaging:
- Avro was not shaded and relocated in the bundle. It is required to be shaded here similar to hadoop-mr-bundle because hive otherwise uses an older version of avro causing runtime issues.
- Parquet avro even though it was added to shade plugin, was not actually getting shaded because the dependency is labelled as **provided** in the parent POM. It had to be explicitly made a compile time dependency to be shaded.

## Brief change log

 - Shading of avro and parquet-avro in hudi-hive-sync-bundle pom

## Verify this pull request

- Manually tested standalone hive-sync-tool on emr cluster
- Added integration test for hive-sync-tool

## Committer checklist

 - [x] Has a corresponding JIRA in PR title & commit
 
 - [x] Commit message is descriptive of the change
 
 - [ ] CI is green

 - [ ] Necessary doc changes done or have another open PR
       
 - [ ] For large changes, please consider breaking it into sub-tasks under an umbrella JIRA.