### PR TITLE
[MINOR] Fix resource cleanup in TestTableSchemaEvolution

### DIFF
--- a/hudi-client/src/test/java/org/apache/hudi/client/TestTableSchemaEvolution.java
+++ b/hudi-client/src/test/java/org/apache/hudi/client/TestTableSchemaEvolution.java
@@ -75,13 +75,13 @@ public class TestTableSchemaEvolution extends TestHoodieClientBase {
       + TRIP_SCHEMA_SUFFIX;
 
   @BeforeEach
-  public void setUp() throws Exception {
+  public void setUp() throws IOException {
     initResources();
   }
 
   @AfterEach
-  public void tearDown() {
-    cleanupSparkContexts();
+  public void tearDown() throws IOException {
+    cleanupResources();
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -245,7 +245,8 @@
         <version>${maven-surefire-plugin.version}</version>
         <configuration>
           <skip>${skipUTs}</skip>
-          <argLine>-Xms256m -Xmx2g</argLine>
+          <argLine>-Xmx2g</argLine>
+          <forkedProcessExitTimeoutInSeconds>120</forkedProcessExitTimeoutInSeconds>
           <systemPropertyVariables>
             <log4j.configuration>
               ${surefire-log4j.file}


### PR DESCRIPTION
* initResources() should correspond to cleanupResources()
* set longer process exit timeout post testing (default 30 sec) before force exit fork